### PR TITLE
Mac search and arrange

### DIFF
--- a/Xamarin.PropertyEditing.Mac.Standalone/Xamarin.PropertyEditing.Mac.Standalone.csproj
+++ b/Xamarin.PropertyEditing.Mac.Standalone/Xamarin.PropertyEditing.Mac.Standalone.csproj
@@ -8,8 +8,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.PropertyEditing.Mac.Standalone</RootNamespace>
     <AssemblyName>Xamarin.PropertyEditing.Mac.Standalone</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -14,7 +14,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public abstract NSView FirstKeyView { get; }
 		public abstract NSView LastKeyView { get; }
 
-		public nint TableRow { get; set; }
+		public nint TableRow { get; set; } = -1;
 		public NSTableView TableView { get; set; }
 
 		PropertyViewModel viewModel;
@@ -53,6 +53,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public void UpdateKeyViews (bool backward = true, bool forward = true)
 		{
+			if (TableRow < 0)
+				return;
+
 			PropertyEditorControl ctrl = null;
 
 			//FIXME: don't hardcode column

--- a/Xamarin.PropertyEditing.Mac/NSObjectFacade.cs
+++ b/Xamarin.PropertyEditing.Mac/NSObjectFacade.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Foundation;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class NSObjectFacade
+		: NSObject
+	{
+		public NSObjectFacade (object obj)
+		{
+			Target = obj;
+		}
+
+		public object Target
+		{
+			get;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CoreGraphics;
 using Foundation;
 using AppKit;
 using Xamarin.PropertyEditing;
@@ -16,6 +17,9 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	public partial class PropertyEditorPanel : AppKit.NSView
 	{
+		NSSearchField propertyFilter;
+		NSComboBox propertyFilterMode;
+
 		public PropertyEditorPanel ()
 		{
 			Initialize ();
@@ -73,8 +77,41 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
 
+			propertyFilter = new NSSearchField (new CGRect (10, Frame.Height - 25, 170, 24));
+			propertyFilter.PlaceholderString = "Property Filter";
+			propertyFilter.ControlSize = NSControlSize.Regular;
+			AddSubview (propertyFilter);
+
+			var label = new NSTextField (new CGRect (195, Frame.Height - 28, 150, 24)) {
+				BackgroundColor = NSColor.Clear,
+				TextColor = NSColor.Black,
+				Editable = false,
+				Bezeled = false,
+				ControlSize = NSControlSize.Regular,
+				StringValue = "Property Filter Mode"
+			};
+			AddSubview (label);
+
+			propertyFilterMode = new NSComboBox (new CGRect (320, Frame.Height - 25, 100, 24));
+			propertyFilterMode.ControlSize = NSControlSize.Regular;
+            AddSubview (propertyFilter);
+
+
+			var enumValues = Enum.GetValues (typeof (PropertyArrangeMode));
+
+			foreach (var item in enumValues) {
+				propertyFilterMode.Add (new NSString (item.ToString ()));
+			}
+			propertyFilterMode.SelectItem (0);
+
+			AddSubview (propertyFilterMode);
+
+			// If either the Filter Mode or PropertySearchFilter Change Filter the Data
+			propertyFilterMode.Changed += PropertyFilterMode_Changed;
+			propertyFilter.Changed += PropertyFilterMode_Changed;
+
 			// create a table view and a scroll view
-			NSScrollView tableContainer = new NSScrollView (Frame) {
+			var tableContainer = new NSScrollView (new CGRect (10, Frame.Height - 240, Frame.Width - 20, Frame.Height - 30)) {
 				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable
 			};
 			propertyTable = new NSTableView {
@@ -99,6 +136,27 @@ namespace Xamarin.PropertyEditing.Mac
 			// add the panel to the window
 			tableContainer.DocumentView = propertyTable;
 			AddSubview (tableContainer);
+		}
+
+		void PropertyFilterMode_Changed (object sender, EventArgs e)
+		{
+			PropertyArrangeMode filterMode;
+			Enum.TryParse<PropertyArrangeMode> (propertyFilterMode.GetItemObject (0).ToString (), out filterMode);
+			FilterData (propertyFilter.Cell.Title, filterMode);
+		}
+
+		public void FilterData (string title, PropertyArrangeMode filterMode)
+		{
+			viewModel.FilterData (title, filterMode);
+		}
+
+		class FirstResponderTableView : NSTableView
+		{
+			[Export ("validateProposedFirstResponder:forEvent:")]
+			public bool validateProposedFirstResponder (NSResponder responder, NSEvent ev)
+			{
+				return true;
+			}
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -18,7 +18,7 @@ namespace Xamarin.PropertyEditing.Mac
 	public partial class PropertyEditorPanel : AppKit.NSView
 	{
 		NSSearchField propertyFilter;
-		NSComboBox propertyFilterMode;
+		NSComboBox propertyArrangeMode;
 
 		public PropertyEditorPanel ()
 		{
@@ -40,10 +40,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		// when this property changes, need to create new datasource
 		IEditorProvider editorProvider;
-		NSTableView propertyTable;
+		NSOutlineView propertyTable;
 		PropertyTableDataSource dataSource;
 		PanelViewModel viewModel;
 		INotifyCollectionChanged PropertiesChanged => viewModel?.Properties as INotifyCollectionChanged;
+
 		public IEditorProvider EditorProvider {
 			get { return editorProvider; }
 			set {
@@ -55,8 +56,8 @@ namespace Xamarin.PropertyEditing.Mac
 				editorProvider = value;
 				viewModel = new PanelViewModel (editorProvider);
 				dataSource = new PropertyTableDataSource (viewModel);
-				propertyTable.DataSource = dataSource;
 				propertyTable.Delegate = new PropertyTableDelegate (dataSource);
+				propertyTable.DataSource = dataSource;
 
 				// if propertiesChanged exists
 				if (PropertiesChanged != null)
@@ -82,39 +83,42 @@ namespace Xamarin.PropertyEditing.Mac
 			propertyFilter.ControlSize = NSControlSize.Regular;
 			AddSubview (propertyFilter);
 
-			var label = new NSTextField (new CGRect (195, Frame.Height - 28, 150, 24)) {
+			var label = new NSTextField (new CGRect (250, Frame.Height - 28, 150, 24)) {
 				BackgroundColor = NSColor.Clear,
 				TextColor = NSColor.Black,
 				Editable = false,
 				Bezeled = false,
 				ControlSize = NSControlSize.Regular,
-				StringValue = "Property Filter Mode"
+				StringValue = "Arrange By:"
 			};
 			AddSubview (label);
 
-			propertyFilterMode = new NSComboBox (new CGRect (320, Frame.Height - 25, 100, 24));
-			propertyFilterMode.ControlSize = NSControlSize.Regular;
-            AddSubview (propertyFilter);
+			propertyArrangeMode = new NSComboBox (new CGRect (320, Frame.Height - 25, 100, 24)) {
+				Editable = false,
+				ControlSize = NSControlSize.Regular,
+			};
+			AddSubview (propertyFilter);
 
 
 			var enumValues = Enum.GetValues (typeof (PropertyArrangeMode));
 
 			foreach (var item in enumValues) {
-				propertyFilterMode.Add (new NSString (item.ToString ()));
+				propertyArrangeMode.Add (new NSString (item.ToString ()));
 			}
-			propertyFilterMode.SelectItem (0);
+			propertyArrangeMode.SelectItem (0);
 
-			AddSubview (propertyFilterMode);
+			AddSubview (propertyArrangeMode);
 
 			// If either the Filter Mode or PropertySearchFilter Change Filter the Data
-			propertyFilterMode.Changed += PropertyFilterMode_Changed;
+			propertyArrangeMode.SelectionChanged += PropertyFilterMode_Changed;
 			propertyFilter.Changed += PropertyFilterMode_Changed;
 
 			// create a table view and a scroll view
 			var tableContainer = new NSScrollView (new CGRect (10, Frame.Height - 240, Frame.Width - 20, Frame.Height - 30)) {
 				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable
 			};
-			propertyTable = new NSTableView {
+
+			propertyTable = new FirstResponderOutlineView () {
 				RefusesFirstResponder = true,
 				AutoresizingMask = NSViewResizingMask.WidthSizable,
 				SelectionHighlightStyle = NSTableViewSelectionHighlightStyle.None,
@@ -133,6 +137,9 @@ namespace Xamarin.PropertyEditing.Mac
 			propertyTable.AddColumn (propertiesList);
 			propertyTable.AddColumn (propertyEditors);
 
+			// Set OutlineTableColumn or the arrows showing children/expansion will not be drawn
+			propertyTable.OutlineTableColumn = propertiesList;
+
 			// add the panel to the window
 			tableContainer.DocumentView = propertyTable;
 			AddSubview (tableContainer);
@@ -141,16 +148,16 @@ namespace Xamarin.PropertyEditing.Mac
 		void PropertyFilterMode_Changed (object sender, EventArgs e)
 		{
 			PropertyArrangeMode filterMode;
-			Enum.TryParse<PropertyArrangeMode> (propertyFilterMode.GetItemObject (0).ToString (), out filterMode);
+			Enum.TryParse<PropertyArrangeMode> (propertyArrangeMode.GetItemObject (propertyArrangeMode.SelectedIndex).ToString (), out filterMode);
 			FilterData (propertyFilter.Cell.Title, filterMode);
 		}
 
-		public void FilterData (string title, PropertyArrangeMode filterMode)
+		public void FilterData (string title, PropertyArrangeMode arrangeMode)
 		{
-			viewModel.FilterData (title, filterMode);
+			viewModel.FilterData (title, arrangeMode);
 		}
 
-		class FirstResponderTableView : NSTableView
+		class FirstResponderOutlineView : NSOutlineView
 		{
 			[Export ("validateProposedFirstResponder:forEvent:")]
 			public bool validateProposedFirstResponder (NSResponder responder, NSEvent ev)

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -21,6 +21,9 @@ namespace Xamarin.PropertyEditing.Mac
 		NSSearchField propertyFilter;
 		NSComboBox propertyArrangeMode;
 
+		public const string PropertyListTitle = "Property"; // TODO Localise
+		public const string PropertyEditorTitle = "Value";  // TODO Localise
+
 		public PropertyEditorPanel ()
 		{
 			Initialize ();
@@ -79,22 +82,25 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
 
-			propertyFilter = new NSSearchField (new CGRect (10, Frame.Height - 25, 170, 24));
-			propertyFilter.PlaceholderString = "Property Filter"; // TODO Localize
-			propertyFilter.ControlSize = NSControlSize.Regular;
+			propertyFilter = new NSSearchField (new CGRect (10, Frame.Height - 25, 170, 24)) {
+				TranslatesAutoresizingMaskIntoConstraints = false,
+				PlaceholderString = "Property Filter", // TODO Localize
+				ControlSize = NSControlSize.Regular,
+			};
 			AddSubview (propertyFilter);
 
-			var label = new NSTextField (new CGRect (250, Frame.Height - 28, 150, 24)) {
+			var propertyArrangeModeLabel = new NSTextField (new CGRect (245, Frame.Height - 28, 150, 24)) {
+				TranslatesAutoresizingMaskIntoConstraints = false,
 				BackgroundColor = NSColor.Clear,
 				TextColor = NSColor.Black,
 				Editable = false,
 				Bezeled = false,
-				ControlSize = NSControlSize.Regular,
 				StringValue = "Arrange By:"
 			};
-			AddSubview (label);
+			AddSubview (propertyArrangeModeLabel);
 
-			propertyArrangeMode = new NSComboBox (new CGRect (320, Frame.Height - 25, 100, 24)) {
+			propertyArrangeMode = new NSComboBox (new CGRect (320, Frame.Height - 25, 153, 24)) {
+				TranslatesAutoresizingMaskIntoConstraints = false,
 				Editable = false,
 				ControlSize = NSControlSize.Regular,
 			};
@@ -115,8 +121,8 @@ namespace Xamarin.PropertyEditing.Mac
 			propertyFilter.Changed += PropertyFilterText_Changed;
 
 			// create a table view and a scroll view
-			var tableContainer = new NSScrollView (new CGRect (10, Frame.Height - 240, Frame.Width - 20, Frame.Height - 30)) {
-				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable
+			var tableContainer = new NSScrollView (new CGRect (10, Frame.Height - 210, Frame.Width - 20, Frame.Height - 55)) {
+				TranslatesAutoresizingMaskIntoConstraints = false,
 			};
 
 			propertyTable = new FirstResponderOutlineView () {
@@ -126,15 +132,10 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 
 			// create columns for the panel
-			NSTableColumn propertiesList = new NSTableColumn ("PropertiesList") {
-				Title = "Properties",
-				Width = 200,
-			};
-
-			NSTableColumn propertyEditors = new NSTableColumn ("PropertyEditors") {
-				Title = "Editors",
-				Width = 255,
-			};
+			NSTableColumn propertiesList = new NSTableColumn ("PropertiesList") { Title = PropertyListTitle };
+			NSTableColumn propertyEditors = new NSTableColumn ("PropertyEditors") { Title = PropertyEditorTitle };
+			propertiesList.Width = 150;
+			propertyEditors.Width = 250;
 			propertyTable.AddColumn (propertiesList);
 			propertyTable.AddColumn (propertyEditors);
 
@@ -144,6 +145,22 @@ namespace Xamarin.PropertyEditing.Mac
 			// add the panel to the window
 			tableContainer.DocumentView = propertyTable;
 			AddSubview (tableContainer);
+
+			this.DoConstraints (new NSLayoutConstraint[] { 
+				propertyFilter.ConstraintTo(this, (pf, c) => pf.Top == c.Top + 3),
+				propertyFilter.ConstraintTo(this, (pf, c) => pf.Left == c.Left + 12),
+
+				propertyArrangeModeLabel.ConstraintTo(this, (pl, c) => pl.Top == c.Top + 5),
+				propertyArrangeModeLabel.ConstraintTo(propertyArrangeMode, (pl, pa) => pl.Left == pa.Left - 73),
+
+				propertyArrangeMode.ConstraintTo(this, (pa, c) => pa.Top == c.Top + 3),
+				propertyArrangeMode.ConstraintTo(this, (pa, c) => pa.Left == c.Left + 312),
+				propertyArrangeMode.ConstraintTo(this, (pa, c) => pa.Width == 154),
+
+				tableContainer.ConstraintTo(this, (t, c) => t.Top == c.Top + 30),
+				tableContainer.ConstraintTo(this, (t, c) => t.Width == c.Width - 20),
+				tableContainer.ConstraintTo(this, (t, c) => t.Height == c.Height - 40),
+			});
 		}
 
 		void PropertyFilterArrangeMode_Changed (object sender, EventArgs e)

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -110,8 +110,8 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (propertyArrangeMode);
 
 			// If either the Filter Mode or PropertySearchFilter Change Filter the Data
-			propertyArrangeMode.SelectionChanged += PropertyFilterMode_Changed;
-			propertyFilter.Changed += PropertyFilterMode_Changed;
+			propertyArrangeMode.SelectionChanged += PropertyFilterArrangeMode_Changed;
+			propertyFilter.Changed += PropertyFilterText_Changed;
 
 			// create a table view and a scroll view
 			var tableContainer = new NSScrollView (new CGRect (10, Frame.Height - 240, Frame.Width - 20, Frame.Height - 30)) {
@@ -145,16 +145,16 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (tableContainer);
 		}
 
-		void PropertyFilterMode_Changed (object sender, EventArgs e)
+		void PropertyFilterArrangeMode_Changed (object sender, EventArgs e)
 		{
 			PropertyArrangeMode filterMode;
 			Enum.TryParse<PropertyArrangeMode> (propertyArrangeMode.GetItemObject (propertyArrangeMode.SelectedIndex).ToString (), out filterMode);
-			FilterData (propertyFilter.Cell.Title, filterMode);
+			viewModel.ArrangeMode = filterMode;
 		}
 
-		public void FilterData (string title, PropertyArrangeMode arrangeMode)
+		void PropertyFilterText_Changed (object sender, EventArgs e)
 		{
-			viewModel.FilterData (title, arrangeMode);
+			viewModel.FilterText = propertyFilter.Cell.Title;
 		}
 
 		class FirstResponderOutlineView : NSOutlineView

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -79,7 +79,7 @@ namespace Xamarin.PropertyEditing.Mac
 			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
 
 			propertyFilter = new NSSearchField (new CGRect (10, Frame.Height - 25, 170, 24));
-			propertyFilter.PlaceholderString = "Property Filter";
+			propertyFilter.PlaceholderString = "Property Filter"; // TODO Localize
 			propertyFilter.ControlSize = NSControlSize.Regular;
 			AddSubview (propertyFilter);
 

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -182,6 +182,17 @@ namespace Xamarin.PropertyEditing.Mac
 			{
 				return true;
 			}
+
+			public override CGRect FrameOfOutlineCellAtRow (nint row)
+			{
+				var obj = (this.ItemAtRow (row) as NSObjectFacade);
+				if (!string.IsNullOrEmpty(obj.CategoryName)) {
+					return new CGRect (8, 11, 10, 10);
+				}
+				else {
+					return base.FrameOfOutlineCellAtRow (row);
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -103,7 +103,7 @@ namespace Xamarin.PropertyEditing.Mac
 			var enumValues = Enum.GetValues (typeof (PropertyArrangeMode));
 
 			foreach (var item in enumValues) {
-				propertyArrangeMode.Add (new NSString (item.ToString ()));
+				propertyArrangeMode.Add (new NSString (item.ToString ())); // TODO May need translating
 			}
 			propertyArrangeMode.SelectItem (0);
 

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -12,6 +12,7 @@ using Xamarin.PropertyEditing.Reflection;
 using System.Collections.Specialized;
 using System.Threading;
 using System.Threading.Tasks;
+using Xamarin.PropertyEditing.Mac.ViewModels;
 
 namespace Xamarin.PropertyEditing.Mac
 {
@@ -42,7 +43,7 @@ namespace Xamarin.PropertyEditing.Mac
 		IEditorProvider editorProvider;
 		NSOutlineView propertyTable;
 		PropertyTableDataSource dataSource;
-		PanelViewModel viewModel;
+		MacPanelViewModel viewModel;
 		INotifyCollectionChanged PropertiesChanged => viewModel?.Properties as INotifyCollectionChanged;
 
 		public IEditorProvider EditorProvider {
@@ -54,7 +55,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 				// Populate the Properety Table
 				editorProvider = value;
-				viewModel = new PanelViewModel (editorProvider);
+				viewModel = new MacPanelViewModel (editorProvider);
 				dataSource = new PropertyTableDataSource (viewModel);
 				propertyTable.Delegate = new PropertyTableDelegate (dataSource);
 				propertyTable.DataSource = dataSource;

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -52,7 +52,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
 		{
 			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return ViewModel.Properties.ToList ().Count;
+				return ViewModel.Properties.Count;
 			}
 			else {
 				if (item == null) {

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -19,6 +19,8 @@ namespace Xamarin.PropertyEditing.Mac
 		internal PanelViewModel ViewModel { get; private set; }
 		public ICollection<object> SelectedItems => this.ViewModel.SelectedObjects;
 		List<PropertyViewModel> properties => this.ViewModel.Properties.ToList ();
+		IEnumerable<IGrouping<string, PropertyViewModel>> propertiesGroupBy => this.properties.GroupBy (arg => arg.Category);
+		List<IGrouping<string, PropertyViewModel>> propertiesGroupByList => this.propertiesGroupBy.ToList ();
 
 		public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
 		{
@@ -26,14 +28,13 @@ namespace Xamarin.PropertyEditing.Mac
 				return this.properties.Count;
 			}
 			else {
-				var grouped = this.ViewModel.Properties.GroupBy (arg => arg.Category);
 				if (item == null) {
-					var count = grouped.Count ();
+					var count = propertiesGroupBy.Count ();
 					return count;
 				}
 				else {
 					var facade = (item as NSObjectFacade);
-					var where = grouped.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
+					var where = propertiesGroupBy.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
 					var count = where.ToList ()[0].Count ();
 					return count;
 				}
@@ -46,16 +47,14 @@ namespace Xamarin.PropertyEditing.Mac
 				return NSObjectFacade.WrapIt (this.properties[(int)childIndex]);
 			}
 			else {
-				var grouped = this.properties.GroupBy (arg => arg.Category);
-				var groupedList = grouped.ToList ();
 				if (item == null) {
-					var listItem = groupedList[(int)childIndex];
+					var listItem = propertiesGroupByList[(int)childIndex];
 					return NSObjectFacade.WrapIt (null, listItem.Key);
 				}
 				else {
 					var facade = (item as NSObjectFacade);
 					if (!string.IsNullOrEmpty (facade.CategoryName)) {
-						var where = grouped.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
+						var where = propertiesGroupBy.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
 						var wherelist = where.ToList ();
 						return NSObjectFacade.WrapIt (wherelist[0].ElementAt ((int)childIndex));
 					}

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -3,34 +3,80 @@ using System.Collections.Generic;
 using System.Linq;
 using AppKit;
 using Foundation;
-using Xamarin.PropertyEditing.Mac.ViewModels;
 using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	public class PropertyTableDataSource : NSOutlineViewDataSource
+	internal class PropertyTableDataSource
+		: NSOutlineViewDataSource
 	{
-		internal MacPanelViewModel ViewModel { get; private set; }
-		public ICollection<object> SelectedItems => ViewModel.SelectedObjects;
-
-		internal PropertyTableDataSource (MacPanelViewModel viewModel)
+		internal PropertyTableDataSource (PanelViewModel panelVm)
 		{
-			ViewModel = viewModel;
+			if (panelVm == null)
+				throw new ArgumentNullException (nameof (panelVm));
+
+			this.vm = panelVm;
 		}
+
+		public PanelViewModel DataContext => this.vm;
 
 		public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
 		{
-			return ViewModel.GetChildrenCount (item);
+			if (this.vm.ArrangedProperties.Count == 0)
+				return 0;
+
+			if (this.vm.ArrangeMode == PropertyArrangeMode.Name)
+				return this.vm.ArrangedProperties[0].Count;
+
+			if (item == null)
+				return this.vm.ArrangedProperties.Count;
+			else
+				return ((IGroupingList<string, PropertyViewModel>)((NSObjectFacade)item).Target).Count;
 		}
 
 		public override NSObject GetChild (NSOutlineView outlineView, nint childIndex, NSObject item)
 		{
-			return ViewModel.GetChildObject ((int)childIndex, item);
+			object element;
+			if (this.vm.ArrangeMode == PropertyArrangeMode.Name) {
+				element = (this.vm.ArrangedProperties[0][(int)childIndex]);
+			} else {
+				if (item == null)
+					element = this.vm.ArrangedProperties[(int)childIndex];
+				else {
+					element = ((IGroupingList<string, PropertyViewModel>)((NSObjectFacade)item).Target)[(int)childIndex];
+				}
+			}
+
+			return GetFacade (element);
 		}
 
 		public override bool ItemExpandable (NSOutlineView outlineView, NSObject item)
 		{
-			return ViewModel.ItemExpandable (item);
+			if (this.vm.ArrangeMode == PropertyArrangeMode.Name)
+				return false;
+
+			return ((NSObjectFacade)item).Target is IGroupingList<string, PropertyViewModel>;
 		}
+
+		public NSObject GetFacade (object element)
+		{
+			NSObject facade;
+			if (element is IGrouping<string, PropertyViewModel>) {
+				if (!this.groupFacades.TryGetValue (element, out facade)) {
+					this.groupFacades[element] = facade = new NSObjectFacade (element);
+				}
+			} else
+				facade = new NSObjectFacade (element);
+
+			return facade;
+		}
+
+		public bool TryGetFacade (object element, out NSObject facade)
+		{
+			return this.groupFacades.TryGetValue (element, out facade);
+		}
+
+		private readonly PanelViewModel vm;
+		private readonly Dictionary<object, NSObject> groupFacades = new Dictionary<object, NSObject> ();
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -34,7 +34,7 @@ namespace Xamarin.PropertyEditing.Mac
 				else {
 					var facade = (item as NSObjectFacade);
 					var where = grouped.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
-					var count = where.ToList()[0].Count ();
+					var count = where.ToList ()[0].Count ();
 					return count;
 				}
 			}

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -9,6 +9,39 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	public class PropertyTableDataSource : NSOutlineViewDataSource
 	{
+		internal PanelViewModel ViewModel { get; private set; }
+		public ICollection<object> SelectedItems => ViewModel.SelectedObjects;
+
+		List<PropertyViewModel> properties;
+		List<PropertyViewModel> Properties {
+			get {
+				if (properties == null) {
+					properties = ViewModel.Properties.ToList ();
+				}
+				return properties;
+			}
+		}
+
+		IEnumerable<IGrouping<string, PropertyViewModel>> propertiesGroupBy;
+		IEnumerable<IGrouping<string, PropertyViewModel>> PropertiesGroupBy {
+			get {
+				if (propertiesGroupBy == null) {
+					propertiesGroupBy = ViewModel.Properties.GroupBy (arg => arg.Category);
+				}
+				return propertiesGroupBy;
+			}
+		}
+
+		List<IGrouping<string, PropertyViewModel>> propertiesGroupByList;
+		List<IGrouping<string, PropertyViewModel>> PropertiesGroupByList {
+			get {
+				if (propertiesGroupByList == null) {
+					propertiesGroupByList = PropertiesGroupBy.ToList ();
+				}
+				return propertiesGroupByList;
+			}
+		}
+
 		internal PropertyTableDataSource (PanelViewModel viewModel)
 		{
 			ViewModel = viewModel;
@@ -16,46 +49,45 @@ namespace Xamarin.PropertyEditing.Mac
 			PanelViewModel.ViewModelMap.Add (typeof (CoreGraphics.CGRect), (p, e) => new PropertyViewModel<CoreGraphics.CGRect> (p, e));
 		}
 
-		internal PanelViewModel ViewModel { get; private set; }
-		public ICollection<object> SelectedItems => this.ViewModel.SelectedObjects;
-		List<PropertyViewModel> properties => this.ViewModel.Properties.ToList ();
-		IEnumerable<IGrouping<string, PropertyViewModel>> propertiesGroupBy => this.properties.GroupBy (arg => arg.Category);
-		List<IGrouping<string, PropertyViewModel>> propertiesGroupByList => this.propertiesGroupBy.ToList ();
-
 		public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
 		{
-			if (this.ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return this.properties.Count;
+			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
+				return ViewModel.Properties.ToList ().Count;
 			}
 			else {
 				if (item == null) {
-					var count = propertiesGroupBy.Count ();
+					var count = PropertiesGroupBy.Count ();
 					return count;
 				}
 				else {
-					var facade = (item as NSObjectFacade);
-					var where = propertiesGroupBy.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
-					var count = where.ToList ()[0].Count ();
+					var count = GetPropertyGroupByWhere (item).ToList ()[0].Count ();
 					return count;
 				}
 			}
 		}
 
+		IEnumerable<IGrouping<string, PropertyViewModel>> GetPropertyGroupByWhere (NSObject item)
+		{
+			var facade = (item as NSObjectFacade);
+			var where = PropertiesGroupBy.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
+			return where;
+		}
+
 		public override NSObject GetChild (NSOutlineView outlineView, nint childIndex, NSObject item)
 		{
-			if (this.ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return NSObjectFacade.WrapIt (this.properties[(int)childIndex]);
+			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
+				return NSObjectFacade.WrapIt (Properties[(int)childIndex]);
 			}
 			else {
+				// It item null it's a top level node
 				if (item == null) {
-					var listItem = propertiesGroupByList[(int)childIndex];
+					var listItem = PropertiesGroupByList[(int)childIndex];
 					return NSObjectFacade.WrapIt (null, listItem.Key);
 				}
 				else {
 					var facade = (item as NSObjectFacade);
 					if (!string.IsNullOrEmpty (facade.CategoryName)) {
-						var where = propertiesGroupBy.Where ((arg1, arg2) => arg1.Key == facade.CategoryName);
-						var wherelist = where.ToList ();
+						var wherelist = GetPropertyGroupByWhere (item).ToList ();
 						return NSObjectFacade.WrapIt (wherelist[0].ElementAt ((int)childIndex));
 					}
 					else {
@@ -67,7 +99,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override bool ItemExpandable (NSOutlineView outlineView, NSObject item)
 		{
-			if (this.ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
+			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
 				return false;
 			}
 			else {

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -3,104 +3,34 @@ using System.Collections.Generic;
 using System.Linq;
 using AppKit;
 using Foundation;
+using Xamarin.PropertyEditing.Mac.ViewModels;
 using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Mac
 {
 	public class PropertyTableDataSource : NSOutlineViewDataSource
 	{
-		internal PanelViewModel ViewModel { get; private set; }
+		internal MacPanelViewModel ViewModel { get; private set; }
 		public ICollection<object> SelectedItems => ViewModel.SelectedObjects;
 
-		internal PropertyTableDataSource (PanelViewModel viewModel)
+		internal PropertyTableDataSource (MacPanelViewModel viewModel)
 		{
 			ViewModel = viewModel;
 		}
 
 		public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
 		{
-			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return ViewModel.Properties.Count;
-			}
-			else {
-				if (item == null) {
-					var count = ViewModel.CachedPropertiesGroupBy.Count ();
-					return count;
-				}
-				else {
-					var count = GetRootNodeByCategory (item).Count ();
-					return count;
-				}
-			}
-		}
-
-		IGrouping<string, PropertyViewModel> GetRootNodeByCategory (NSObject item)
-		{
-			var facade = (item as NSObjectFacade);
-			var root = ViewModel.CachedPropertiesGroupBy.First ((arg1) => arg1.Key == facade.CategoryName);
-			return root;
+			return ViewModel.GetChildrenCount (item);
 		}
 
 		public override NSObject GetChild (NSOutlineView outlineView, nint childIndex, NSObject item)
 		{
-			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return NSObjectFacade.WrapIt (ViewModel.CachedProperties[(int)childIndex]);
-			}
-			else {
-				// It item null it's a top level node
-				if (item == null) {
-					var listItem = ViewModel.CachedPropertiesGroupBy.ToList ()[(int)childIndex];
-					return NSObjectFacade.WrapIt (null, listItem.Key);
-				}
-				else {
-					var facade = (item as NSObjectFacade);
-					if (!string.IsNullOrEmpty (facade.CategoryName)) {
-						var rootNode = GetRootNodeByCategory (item);
-						return NSObjectFacade.WrapIt (rootNode.ElementAt ((int)childIndex));
-					}
-					else {
-						return null;
-					}
-				}
-			}
+			return ViewModel.GetChildObject ((int)childIndex, item);
 		}
 
 		public override bool ItemExpandable (NSOutlineView outlineView, NSObject item)
 		{
-			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return false;
-			}
-			else {
-				return string.IsNullOrEmpty ((item as NSObjectFacade).CategoryName) ? false : true;
-			}
-		}
-
-		public override NSObject GetObjectValue (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
-		{
-			// I don't believe this is correct
-			if (string.IsNullOrEmpty ((item as NSObjectFacade).CategoryName)) {
-				return (NSString)((item as NSObjectFacade).WrappedObject as PropertyViewModel).Property.Name;
-			}
-			else {
-				return (NSString)(item as NSObjectFacade).CategoryName;
-			}
-		}
-	}
-
-	class NSObjectFacade : NSObject
-	{
-		public object WrappedObject;
-		public string CategoryName;
-
-		public NSObjectFacade (object obj, string categoryName = null) : base ()
-		{
-			this.WrappedObject = obj;
-			this.CategoryName = categoryName;
-		}
-
-		public static NSObjectFacade WrapIt (object obj, string categoryName = null)
-		{
-			return new NSObjectFacade (obj, categoryName);
+			return ViewModel.ItemExpandable (item);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -12,35 +12,9 @@ namespace Xamarin.PropertyEditing.Mac
 		internal PanelViewModel ViewModel { get; private set; }
 		public ICollection<object> SelectedItems => ViewModel.SelectedObjects;
 
-		List<PropertyViewModel> properties;
-		List<PropertyViewModel> Properties {
-			get {
-				if (properties == null) {
-					properties = ViewModel.Properties.ToList ();
-				}
-				return properties;
-			}
-		}
-
-		IEnumerable<IGrouping<string, PropertyViewModel>> propertiesGroupBy;
-		IEnumerable<IGrouping<string, PropertyViewModel>> PropertiesGroupBy {
-			get {
-				if (propertiesGroupBy == null) {
-					propertiesGroupBy = ViewModel.Properties.GroupBy (arg => arg.Category);
-				}
-				return propertiesGroupBy;
-			}
-		}
-
 		internal PropertyTableDataSource (PanelViewModel viewModel)
 		{
 			ViewModel = viewModel;
-			PanelViewModel.ViewModelMap.Add (typeof (CoreGraphics.CGPoint), (p, e) => new PropertyViewModel<CoreGraphics.CGPoint> (p, e));
-			PanelViewModel.ViewModelMap.Add (typeof (CoreGraphics.CGRect), (p, e) => new PropertyViewModel<CoreGraphics.CGRect> (p, e));
-
-			ViewModel.PropertyChanged += (sender, e) => {
-				properties = null;
-			};
 		}
 
 		public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
@@ -50,7 +24,7 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 			else {
 				if (item == null) {
-					var count = PropertiesGroupBy.Count ();
+					var count = ViewModel.CachedPropertiesGroupBy.Count ();
 					return count;
 				}
 				else {
@@ -63,19 +37,19 @@ namespace Xamarin.PropertyEditing.Mac
 		IGrouping<string, PropertyViewModel> GetRootNodeByCategory (NSObject item)
 		{
 			var facade = (item as NSObjectFacade);
-			var root = PropertiesGroupBy.First ((arg1) => arg1.Key == facade.CategoryName);
+			var root = ViewModel.CachedPropertiesGroupBy.First ((arg1) => arg1.Key == facade.CategoryName);
 			return root;
 		}
 
 		public override NSObject GetChild (NSOutlineView outlineView, nint childIndex, NSObject item)
 		{
 			if (ViewModel.ArrangeMode == PropertyArrangeMode.Name) {
-				return NSObjectFacade.WrapIt (Properties[(int)childIndex]);
+				return NSObjectFacade.WrapIt (ViewModel.CachedProperties[(int)childIndex]);
 			}
 			else {
 				// It item null it's a top level node
 				if (item == null) {
-					var listItem = PropertiesGroupBy.ToList ()[(int)childIndex];
+					var listItem = ViewModel.CachedPropertiesGroupBy.ToList ()[(int)childIndex];
 					return NSObjectFacade.WrapIt (null, listItem.Key);
 				}
 				else {

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -44,7 +44,7 @@ namespace Xamarin.PropertyEditing.Mac
 					view = outlineView.MakeView (cellIdentifier + "props", this);
 					if (view == null) {
 						view = new UnfocusableTextView (new CoreGraphics.CGRect (0, -5, 75, 20), property.Property.Name) {
-							TextContainerInset = new CoreGraphics.CGSize (0, 7),
+							TextContainerInset = new CoreGraphics.CGSize (0, 9),
 							Identifier = cellIdentifier + "props",
 							Alignment = NSTextAlignment.Right,
 						};

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -86,22 +86,6 @@ namespace Xamarin.PropertyEditing.Mac
 			return (string.IsNullOrEmpty (facade.CategoryName));
 		}
 
-		public override void ItemDidCollapse (NSNotification notification)
-		{
-			var facade = notification.UserInfo.ObjectForKey (new NSString ("NSObject")) as NSObjectFacade;
-			if (!string.IsNullOrEmpty (facade.CategoryName)) {
-				DataSource.ViewModel.ExpandedNode[facade.CategoryName] = false;
-			}
-		}
-
-		public override void ItemDidExpand (NSNotification notification)
-		{
-			var facade = notification.UserInfo.ObjectForKey (new NSString ("NSObject")) as NSObjectFacade;
-			if (!string.IsNullOrEmpty (facade.CategoryName)) {
-				DataSource.ViewModel.ExpandedNode[facade.CategoryName] = true;
-			}
-		}
-
 		// set up the editor based on the type of view model
 		PropertyEditorControl SetUpEditor (Type controlType, PropertyViewModel property, NSTableView table)
 		{

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -91,7 +91,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 					// we must reset these every time, as the view may have been reused
 					editor.ViewModel = vm;
-					//editor.TableRow = row;
+					editor.TableRow = outlineView.RowForItem (item);
 					return editor;
 			}
 

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using AppKit;
 using Foundation;
 using Xamarin.PropertyEditing.ViewModels;
+using Xamarin.PropertyEditing.Mac.ViewModels;
 
 namespace Xamarin.PropertyEditing.Mac
 {

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -1,16 +1,15 @@
 ﻿﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using AppKit;
 using Foundation;
 using Xamarin.PropertyEditing.ViewModels;
-using Xamarin.PropertyEditing.Mac.ViewModels;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	public class PropertyTableDelegate : NSOutlineViewDelegate
+	internal class PropertyTableDelegate
+		: NSOutlineViewDelegate
 	{
-		PropertyTableDataSource DataSource;
-
 		Dictionary<Type, Type> viewModelTypes = new Dictionary<Type, Type> {
 			{typeof (StringPropertyViewModel), typeof (StringEditorControl)},
 			{typeof (IntegerPropertyViewModel), typeof (IntegerNumericEditorControl)},
@@ -22,59 +21,78 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public PropertyTableDelegate (PropertyTableDataSource datasource)
 		{
-			this.DataSource = datasource;
+			this.dataSource = datasource;
+		}
+
+		public void UpdateExpansions (NSOutlineView outlineView)
+		{
+			this.isExpanding = true;
+
+			if (!String.IsNullOrWhiteSpace (this.dataSource.DataContext.FilterText)) {
+				outlineView.ExpandItem (null, true);
+			} else {
+				foreach (IGrouping<string, PropertyViewModel> g in this.dataSource.DataContext.ArrangedProperties) {
+					NSObject item;
+					if (!this.dataSource.TryGetFacade (g, out item))
+						continue;
+
+					if (this.dataSource.DataContext.GetIsExpanded (g.Key))
+						outlineView.ExpandItem (item);
+					else
+						outlineView.CollapseItem (item);
+				}
+			}
+			this.isExpanding = false;
 		}
 
 		// the table is looking for this method, picks it up automagically
 		public override NSView GetView (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
 		{
-			var facade = (item as NSObjectFacade);
-			PropertyViewModel property = (PropertyViewModel)facade.WrappedObject; ;
-
-			string cellIdentifier;
-			if (string.IsNullOrEmpty (facade.CategoryName)) {
-				cellIdentifier = property.Property.Name;
-			} else {
-				cellIdentifier = facade.CategoryName;
-			}
+			var facade = (NSObjectFacade)item;
+			var vm = facade.Target as PropertyViewModel;
+			var group = facade.Target as IGroupingList<string, PropertyViewModel>;
+			string cellIdentifier = (group == null) ? vm.Property.Name : group.Key;
 
 			// Setup view based on the column
 			switch (tableColumn.Identifier) {
-				case PropertyEditorPanel.PropertyListTitle:
-					view = outlineView.MakeView (cellIdentifier + "props", this);
+				case PropertyEditorPanel.PropertyListColId:
+					var view = (UnfocusableTextView)outlineView.MakeView (cellIdentifier + "props", this);
 					if (view == null) {
-						view = new UnfocusableTextView (new CoreGraphics.CGRect (0, -5, 75, 20), property.Property.Name) {
+						view = new UnfocusableTextView {
+							Frame = new CoreGraphics.CGRect (0, -5, 75, 20),
 							TextContainerInset = new CoreGraphics.CGSize (0, 9),
 							Identifier = cellIdentifier + "props",
 							Alignment = NSTextAlignment.Right,
 						};
 					}
+
+					view.Value = cellIdentifier;
 					return view;
 
-				case PropertyEditorPanel.PropertyEditorTitle:
-					if (!String.IsNullOrEmpty (facade.CategoryName)) {
-						var editor = (PropertyEditorControl)outlineView.MakeView (cellIdentifier + "edits", this);
-						if (editor == null) {
-							Type controlType;
-							Type propertyType = property.GetType ();
-							if (viewModelTypes.TryGetValue (propertyType, out controlType)) {
-								editor = SetUpEditor (controlType, property, outlineView);
-							} else {
-								if (propertyType.IsGenericType) {
-									Type genericType = propertyType.GetGenericTypeDefinition ();
-									if (genericType == typeof (EnumPropertyViewModel<>))
-										controlType = typeof (EnumEditorControl<>).MakeGenericType (property.Property.Type);
-									editor = SetUpEditor (controlType, property, outlineView);
-								}
+				case PropertyEditorPanel.PropertyEditorColId:
+					if (vm == null)
+						return null;
+
+					var editor = (PropertyEditorControl)outlineView.MakeView (cellIdentifier + "edits", this);
+					if (editor == null) {
+						Type controlType;
+						Type propertyType = vm.GetType ();
+						if (viewModelTypes.TryGetValue (propertyType, out controlType)) {
+							editor = SetUpEditor (controlType, vm, outlineView);
+						} else {
+							if (propertyType.IsGenericType) {
+								Type genericType = propertyType.GetGenericTypeDefinition ();
+								if (genericType == typeof (EnumPropertyViewModel<>))
+									controlType = typeof (EnumEditorControl<>).MakeGenericType (vm.Property.Type);
+								editor = SetUpEditor (controlType, vm, outlineView);
 							}
 						}
-
-						// we must reset these every time, as the view may have been reused
-						editor.ViewModel = property;
-						//editor.TableRow = row;
-						return editor;
 					}
-					break;
+
+					// we must reset these every time, as the view may have been reused
+					editor.ViewModel = vm;
+					//editor.TableRow = row;
+					return editor;
 			}
 
 			throw new Exception ("Unknown column identifier: " + tableColumn.Identifier);
@@ -82,17 +100,40 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override bool ShouldSelectItem (NSOutlineView outlineView, NSObject item)
 		{
-			var facade = (item as NSObjectFacade);
-			// Don't allow selecttion if CategoryName is populated
-			return (string.IsNullOrEmpty (facade.CategoryName));
+			return (!(item is NSObjectFacade) || !(((NSObjectFacade)item).Target is IGroupingList<string, PropertyViewModel>));
 		}
 
+		public override void ItemDidExpand (NSNotification notification)
+		{
+			if (this.isExpanding)
+				return;
+
+			NSObjectFacade facade = notification.UserInfo.Values[0] as NSObjectFacade;
+			var group = facade.Target as IGroupingList<string, PropertyViewModel>;
+			if (group != null)
+				this.dataSource.DataContext.SetIsExpanded (group.Key, isExpanded: true);
+		}
+
+		public override void ItemDidCollapse (NSNotification notification)
+		{
+			if (this.isExpanding)
+				return;
+
+			NSObjectFacade facade = notification.UserInfo.Values[0] as NSObjectFacade;
+			var group = facade.Target as IGroupingList<string, PropertyViewModel>;
+			if (group != null)
+				this.dataSource.DataContext.SetIsExpanded (group.Key, isExpanded: false);
+		}
+
+		private PropertyTableDataSource dataSource;
+		private bool isExpanding;
+
 		// set up the editor based on the type of view model
-		PropertyEditorControl SetUpEditor (Type controlType, PropertyViewModel property, NSTableView table)
+		private PropertyEditorControl SetUpEditor (Type controlType, PropertyViewModel property, NSOutlineView outline)
 		{
 			var view = (PropertyEditorControl)Activator.CreateInstance (controlType);
 			view.Identifier = property.GetType ().Name;
-			view.TableView = table;
+			view.TableView = outline;
 
 			return view;
 		}

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -40,8 +40,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 			// Setup view based on the column
 			switch (tableColumn.Identifier) {
-				case "PropertiesList":
-					var view = outlineView.MakeView (cellIdentifier + "props", this);
+				case PropertyEditorPanel.PropertyListTitle:
+					view = outlineView.MakeView (cellIdentifier + "props", this);
 					if (view == null) {
 						view = new UnfocusableTextView (new CoreGraphics.CGRect (0, -5, 75, 20), property.Property.Name) {
 							TextContainerInset = new CoreGraphics.CGSize (0, 7),
@@ -51,7 +51,7 @@ namespace Xamarin.PropertyEditing.Mac
 					}
 					return view;
 
-				case "PropertyEditors":
+				case PropertyEditorPanel.PropertyEditorTitle:
 					if (!String.IsNullOrEmpty (facade.CategoryName)) {
 						var editor = (PropertyEditorControl)outlineView.MakeView (cellIdentifier + "edits", this);
 						if (editor == null) {

--- a/Xamarin.PropertyEditing.Mac/ViewModels/MacPanelViewModel.cs
+++ b/Xamarin.PropertyEditing.Mac/ViewModels/MacPanelViewModel.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using Foundation;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Mac.ViewModels
+{
+	internal class MacPanelViewModel : PanelViewModel
+	{
+		public MacPanelViewModel (IEditorProvider provider)
+					: base (provider)
+		{
+			ViewModelMap.Add (typeof (CoreGraphics.CGPoint), (p, e) => new PropertyViewModel<CoreGraphics.CGPoint> (p, e));
+		}
+
+		public int GetChildrenCount (NSObject item)
+		{
+			if (ArrangeMode == PropertyArrangeMode.Name) {
+				return Properties.Count;
+			}
+			else {
+				if (item == null) {
+					var count = Properties.GroupBy (arg => arg.Category).Count ();
+					return count;
+				}
+				else {
+					var count = GetRootNodeByCategory (item).Count ();
+					return count;
+				}
+			}
+		}
+
+		public NSObjectFacade GetChildObject (int childIndex, NSObject item)
+		{
+			if (ArrangeMode == PropertyArrangeMode.Name) {
+				return NSObjectFacade.WrapIt (Properties[childIndex]);
+			}
+			else {
+				// It item null it's a top level node
+				if (item == null) {
+					var listItem = Properties.GroupBy (arg => arg.Category).ToList ()[childIndex];
+					return NSObjectFacade.WrapIt (null, listItem.Key);
+				}
+				else {
+					var facade = (item as NSObjectFacade);
+					if (!string.IsNullOrEmpty (facade.CategoryName)) {
+						var rootNode = GetRootNodeByCategory (item);
+						return NSObjectFacade.WrapIt (rootNode.ElementAt (childIndex));
+					}
+					else {
+						return null;
+					}
+				}
+			}
+		}
+
+		public IGrouping<string, PropertyViewModel> GetRootNodeByCategory (NSObject item)
+		{
+			var facade = (item as NSObjectFacade);
+			var root = Properties.GroupBy (arg => arg.Category).First ((arg1) => arg1.Key == facade.CategoryName);
+			return root;
+		}
+
+		public bool ItemExpandable (NSObject item)
+		{
+			if (ArrangeMode == PropertyArrangeMode.Name) {
+				return false;
+			}
+			else {
+				return string.IsNullOrEmpty ((item as NSObjectFacade).CategoryName) ? false : true;
+			}
+		}
+	}
+
+	class NSObjectFacade : NSObject
+	{
+		public object WrappedObject;
+		public string CategoryName;
+
+		public NSObjectFacade (object obj, string categoryName = null)
+		{
+			this.WrappedObject = obj;
+			this.CategoryName = categoryName;
+		}
+
+		public static NSObjectFacade WrapIt (object obj, string categoryName = null)
+		{
+			return new NSObjectFacade (obj, categoryName);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/ViewModels/MacPanelViewModel.cs
+++ b/Xamarin.PropertyEditing.Mac/ViewModels/MacPanelViewModel.cs
@@ -71,21 +71,4 @@ namespace Xamarin.PropertyEditing.Mac.ViewModels
 			}
 		}
 	}
-
-	class NSObjectFacade : NSObject
-	{
-		public object WrappedObject;
-		public string CategoryName;
-
-		public NSObjectFacade (object obj, string categoryName = null)
-		{
-			this.WrappedObject = obj;
-			this.CategoryName = categoryName;
-		}
-
-		public static NSObjectFacade WrapIt (object obj, string categoryName = null)
-		{
-			return new NSObjectFacade (obj, categoryName);
-		}
-	}
 }

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -69,7 +69,7 @@
     <Compile Include="Controls\CGRectEditorControl.cs" />
     <Compile Include="Controls\PointEditorControl.cs" />
     <Compile Include="Controls\UnfocusableTextView.cs" />
-    <Compile Include="ViewModels\MacPanelViewModel.cs" />
+    <Compile Include="NSObjectFacade.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\" />

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Controls\CGRectEditorControl.cs" />
     <Compile Include="Controls\PointEditorControl.cs" />
     <Compile Include="Controls\UnfocusableTextView.cs" />
+    <Compile Include="ViewModels\MacPanelViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\" />

--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -26,6 +26,7 @@ namespace Xamarin.PropertyEditing.Tests
 		private class TestClassSub
 			: TestClass
 		{
+			[System.ComponentModel.Category ("Sub")]
 			public int SubProperty {
 				get;
 				set;
@@ -457,6 +458,42 @@ namespace Xamarin.PropertyEditing.Tests
 
 			vm.FilterText = String.Empty;
 			Assert.That (vm.ArrangedProperties[0].Count, Is.EqualTo (2));
+		}
+
+		[Test]
+		public async Task PropertyCategoryArrange ()
+		{
+			var provider = new ReflectionEditorProvider ();
+			var obj = new TestClassSub ();
+			var editor = await provider.GetObjectEditorAsync (obj);
+			Assume.That (editor.Properties.Count, Is.EqualTo (2));
+
+			var vm = new PanelViewModel (provider) { ArrangeMode = PropertyArrangeMode.Category };
+			vm.SelectedObjects.Add (obj);
+
+			Assume.That (vm.ArrangedProperties, Is.Not.Empty);
+			Assert.That (vm.ArrangedProperties.FirstOrDefault (g => g.Key == "Sub"), Is.Not.Null);
+		}
+
+		[Test]
+		public async Task PropertyListCategoryFiltered ()
+		{
+			var provider = new ReflectionEditorProvider ();
+			var obj = new TestClassSub ();
+			var editor = await provider.GetObjectEditorAsync (obj);
+			Assume.That (editor.Properties.Count, Is.EqualTo (2));
+
+			var vm = new PanelViewModel (provider) { ArrangeMode = PropertyArrangeMode.Category };
+			vm.SelectedObjects.Add (obj);
+
+			Assume.That (vm.ArrangedProperties, Is.Not.Empty);
+
+			vm.FilterText = "sub";
+			Assert.That (vm.ArrangedProperties.Count, Is.EqualTo (1));
+
+			var group = vm.ArrangedProperties.FirstOrDefault (g => g.Key == "Sub");
+			Assert.That (group, Is.Not.Null);
+			Assert.That (group.Count, Is.EqualTo (1));
 		}
 
 		private TestContext context;

--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -430,7 +430,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 			Assert.That (vm.Properties, Is.Not.Empty);
 			Assume.That (vm.Properties.Count, Is.EqualTo (2));
-			vm.FilterData ("sub", PropertyArrangeMode.Name);
+			vm.FilterText = "sub";
 			Assume.That (vm.Properties.Count, Is.EqualTo (1));
 		}
 
@@ -448,9 +448,9 @@ namespace Xamarin.PropertyEditing.Tests
 
 			Assert.That (vm.Properties, Is.Not.Empty);
 			Assume.That (vm.Properties.Count, Is.EqualTo (2));
-			vm.FilterData ("sub", PropertyArrangeMode.Name);
+			vm.FilterText = "sub";
 			Assume.That (vm.Properties.Count, Is.EqualTo (1));
-			vm.FilterData (string.Empty, PropertyArrangeMode.Name);
+			vm.FilterText = string.Empty;
 			Assume.That (vm.Properties.Count, Is.EqualTo (2));
 		}
 

--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -426,12 +426,14 @@ namespace Xamarin.PropertyEditing.Tests
 			Assume.That (editor.Properties.Count, Is.EqualTo (2));
 
 			var vm = new PanelViewModel (provider);
+			Assume.That (vm.ArrangeMode, Is.EqualTo (PropertyArrangeMode.Name));
 			vm.SelectedObjects.Add (obj);
 
-			Assert.That (vm.Properties, Is.Not.Empty);
-			Assume.That (vm.Properties.Count, Is.EqualTo (2));
+			Assume.That (vm.ArrangedProperties, Is.Not.Empty);
+			Assume.That (vm.ArrangedProperties[0].Count, Is.EqualTo (2));
+
 			vm.FilterText = "sub";
-			Assume.That (vm.Properties.Count, Is.EqualTo (1));
+			Assert.That (vm.ArrangedProperties[0].Count, Is.EqualTo (1));
 		}
 
 		[Test]
@@ -442,16 +444,19 @@ namespace Xamarin.PropertyEditing.Tests
 			var obj = new TestClassSub ();
 			var editor = await provider.GetObjectEditorAsync (obj);
 			Assume.That (editor.Properties.Count, Is.EqualTo (2));
-
+			
 			var vm = new PanelViewModel (provider);
+			Assume.That (vm.ArrangeMode, Is.EqualTo (PropertyArrangeMode.Name));
 			vm.SelectedObjects.Add (obj);
 
-			Assert.That (vm.Properties, Is.Not.Empty);
-			Assume.That (vm.Properties.Count, Is.EqualTo (2));
+			Assume.That (vm.ArrangedProperties, Is.Not.Empty);
+			Assume.That (vm.ArrangedProperties[0].Count, Is.EqualTo (2));
+
 			vm.FilterText = "sub";
-			Assume.That (vm.Properties.Count, Is.EqualTo (1));
-			vm.FilterText = string.Empty;
-			Assume.That (vm.Properties.Count, Is.EqualTo (2));
+			Assume.That (vm.ArrangedProperties[0].Count, Is.EqualTo (1));
+
+			vm.FilterText = String.Empty;
+			Assert.That (vm.ArrangedProperties[0].Count, Is.EqualTo (2));
 		}
 
 		private TestContext context;

--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -17,8 +17,7 @@ namespace Xamarin.PropertyEditing.Tests
 	{
 		private class TestClass
 		{
-			public string Property
-			{
+			public string Property {
 				get;
 				set;
 			}
@@ -27,8 +26,7 @@ namespace Xamarin.PropertyEditing.Tests
 		private class TestClassSub
 			: TestClass
 		{
-			public int SubProperty
-			{
+			public int SubProperty {
 				get;
 				set;
 			}
@@ -37,14 +35,14 @@ namespace Xamarin.PropertyEditing.Tests
 		[SetUp]
 		public void Setup ()
 		{
-			SynchronizationContext.SetSynchronizationContext (this.context = new TestContext());
+			SynchronizationContext.SetSynchronizationContext (this.context = new TestContext ());
 		}
 
 		[Test]
 		public async Task PropertiesAddedFromEditor ()
 		{
 			var provider = new ReflectionEditorProvider ();
-			var obj = new TestClass();
+			var obj = new TestClass ();
 			var editor = await provider.GetObjectEditorAsync (obj);
 			Assume.That (editor.Properties.Count, Is.EqualTo (1));
 
@@ -52,20 +50,20 @@ namespace Xamarin.PropertyEditing.Tests
 			vm.SelectedObjects.Add (obj);
 
 			Assert.That (vm.Properties, Is.Not.Empty);
-			Assert.That (vm.Properties[0].Property, Is.EqualTo (editor.Properties.Single()));
+			Assert.That (vm.Properties[0].Property, Is.EqualTo (editor.Properties.Single ()));
 		}
 
 		[Test]
 		[Description ("When editors of two different types are selected, the properties that are common should be listed")]
 		public void PropertiesFromCommonSubset ()
 		{
-			var obj1 = new TestClass();
-			var obj2 = new TestClassSub();
+			var obj1 = new TestClass ();
+			var obj2 = new TestClassSub ();
 
 			var sharedPropertyMock = new Mock<IPropertyInfo> ();
-			sharedPropertyMock.SetupGet (pi => pi.Type).Returns (typeof(string));
+			sharedPropertyMock.SetupGet (pi => pi.Type).Returns (typeof (string));
 			var subPropertyMock = new Mock<IPropertyInfo> ();
-			subPropertyMock.SetupGet (pi => pi.Type).Returns (typeof(int));
+			subPropertyMock.SetupGet (pi => pi.Type).Returns (typeof (int));
 
 			var editor1Mock = new Mock<IObjectEditor> ();
 			editor1Mock.SetupGet (oe => oe.Properties).Returns (new[] { sharedPropertyMock.Object });
@@ -126,10 +124,10 @@ namespace Xamarin.PropertyEditing.Tests
 		[Description ("Adding or removing editors shouldn't remake other editors or duplicate")]
 		public void EditorsShouldBeConsistent ()
 		{
-			var provider = new ReflectionEditorProvider();
+			var provider = new ReflectionEditorProvider ();
 
-			var obj1 = new TestClass();
-			var obj2 = new TestClass();
+			var obj1 = new TestClass ();
+			var obj2 = new TestClass ();
 
 			var vm = new PanelViewModel (provider);
 			vm.SelectedObjects.Add (obj1);
@@ -137,7 +135,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var property = vm.Properties[0];
 			Assume.That (property.Editors.Count, Is.EqualTo (1));
 
-			var editor = property.Editors.Single();
+			var editor = property.Editors.Single ();
 
 			vm.SelectedObjects.Add (obj2);
 
@@ -248,12 +246,12 @@ namespace Xamarin.PropertyEditing.Tests
 			provider.Setup (ep => ep.GetObjectEditorAsync (obj)).ReturnsAsync (editorMock.Object);
 
 			var vm = new PanelViewModel (provider.Object);
-			
+
 			// We need access to the custom reset method here to ensure compliance
 			// It's a bit hacky but this is unlikely to change. If it does, this test
 			// will ensure the new notifier works as it should when resetting.
-			Assume.That (vm.SelectedObjects, Is.TypeOf<ObservableCollectionEx<object>>());
-			((ObservableCollectionEx<object>) vm.SelectedObjects).Reset (new[] { obj });
+			Assume.That (vm.SelectedObjects, Is.TypeOf<ObservableCollectionEx<object>> ());
+			((ObservableCollectionEx<object>)vm.SelectedObjects).Reset (new[] { obj });
 
 			Assume.That (vm.Properties.Count, Is.EqualTo (1));
 			Assume.That (vm.Properties.Select (v => v.Property), Contains.Item (mockProperty1.Object));
@@ -332,7 +330,7 @@ namespace Xamarin.PropertyEditing.Tests
 			vm.SelectedObjects.Remove (derivedObj);
 			Assume.That (vm.Properties, Is.Not.Empty);
 
-			var changedField = typeof(ObservableCollection<IPropertyInfo>).GetField (nameof (INotifyCollectionChanged.CollectionChanged), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+			var changedField = typeof (ObservableCollection<IPropertyInfo>).GetField (nameof (INotifyCollectionChanged.CollectionChanged), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
 			MulticastDelegate d = (MulticastDelegate)changedField.GetValue (derivedProperties);
 			Assert.That (d, Is.Null);
 		}
@@ -367,8 +365,8 @@ namespace Xamarin.PropertyEditing.Tests
 			Assume.That (vm.Properties.Count, Is.EqualTo (1));
 			Assume.That (vm.Properties.Select (v => v.Property), Contains.Item (baseProperty.Object));
 
-			Assume.That (vm.SelectedObjects, Is.TypeOf<ObservableCollectionEx<object>>());
-			((ObservableCollectionEx<object>) vm.SelectedObjects).Reset (new[] { baseObj });
+			Assume.That (vm.SelectedObjects, Is.TypeOf<ObservableCollectionEx<object>> ());
+			((ObservableCollectionEx<object>)vm.SelectedObjects).Reset (new[] { baseObj });
 			Assume.That (vm.Properties, Is.Not.Empty);
 
 			var changedField = typeof (ObservableCollection<IPropertyInfo>).GetField (nameof (INotifyCollectionChanged.CollectionChanged), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
@@ -384,7 +382,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var obj2 = new object ();
 
 			var property = new Mock<IPropertyInfo> ();
-			property.SetupGet (pi => pi.Type).Returns (typeof(string));
+			property.SetupGet (pi => pi.Type).Returns (typeof (string));
 
 			var editor1 = new Mock<IObjectEditor> ();
 			editor1.SetupGet (oe => oe.Target).Returns (obj1);
@@ -415,7 +413,45 @@ namespace Xamarin.PropertyEditing.Tests
 			await Task.Yield ();
 
 			Assert.That (vm.Properties, Is.Empty);
-			this.context.ThrowPendingExceptions();
+			this.context.ThrowPendingExceptions ();
+		}
+
+		[Test]
+		[Description ("When filtered Text exists then list is reduced.")]
+		public async Task PropertyListFilteredTextReducesList ()
+		{
+			var provider = new ReflectionEditorProvider ();
+			var obj = new TestClassSub ();
+			var editor = await provider.GetObjectEditorAsync (obj);
+			Assume.That (editor.Properties.Count, Is.EqualTo (2));
+
+			var vm = new PanelViewModel (provider);
+			vm.SelectedObjects.Add (obj);
+
+			Assert.That (vm.Properties, Is.Not.Empty);
+			Assume.That (vm.Properties.Count, Is.EqualTo (2));
+			vm.FilterData ("sub", PropertyArrangeMode.Name);
+			Assume.That (vm.Properties.Count, Is.EqualTo (1));
+		}
+
+		[Test]
+		[Description ("When filtered Text is cleared then list is restored back to its original.")]
+		public async Task PropertyListFilteredTextClearedRestoresList ()
+		{
+			var provider = new ReflectionEditorProvider ();
+			var obj = new TestClassSub ();
+			var editor = await provider.GetObjectEditorAsync (obj);
+			Assume.That (editor.Properties.Count, Is.EqualTo (2));
+
+			var vm = new PanelViewModel (provider);
+			vm.SelectedObjects.Add (obj);
+
+			Assert.That (vm.Properties, Is.Not.Empty);
+			Assume.That (vm.Properties.Count, Is.EqualTo (2));
+			vm.FilterData ("sub", PropertyArrangeMode.Name);
+			Assume.That (vm.Properties.Count, Is.EqualTo (1));
+			vm.FilterData (string.Empty, PropertyArrangeMode.Name);
+			Assume.That (vm.Properties.Count, Is.EqualTo (2));
 		}
 
 		private TestContext context;

--- a/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
@@ -11,13 +11,6 @@ using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Windows
 {
-	public enum PropertyArrangeMode
-	{
-		Name = 0,
-		Category = 1,
-		ValueSource = 2
-	}
-
 	[TemplatePart (Name = "search", Type = typeof(TextBox))]
 	[TemplatePart (Name = "propertyItems", Type = typeof(ItemsControl))]
 	public class PropertyEditorPanel

--- a/Xamarin.PropertyEditing.sln
+++ b/Xamarin.PropertyEditing.sln
@@ -56,4 +56,24 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = PrefixedHierarchical
+		$0.TextStylePolicy = $2
+		$2.FileWidth = 80
+		$2.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $3
+		$3.NewLinesForBracesInAnonymousMethods = False
+		$3.NewLinesForBracesInControlBlocks = False
+		$3.NewLinesForBracesInAnonymousTypes = False
+		$3.NewLinesForBracesInObjectCollectionArrayInitializers = False
+		$3.NewLinesForBracesInLambdaExpressionBody = False
+		$3.NewLineForElse = False
+		$3.NewLineForCatch = False
+		$3.NewLineForFinally = False
+		$3.SpacingAfterMethodDeclarationName = True
+		$3.SpaceAfterMethodCallName = True
+		$3.scope = text/x-csharp
+	EndGlobalSection
 EndGlobal

--- a/Xamarin.PropertyEditing/Extensions.cs
+++ b/Xamarin.PropertyEditing/Extensions.cs
@@ -38,5 +38,13 @@ namespace Xamarin.PropertyEditing
 			self.Remove (key);
 			return true;
 		}
+
+		public static bool Contains (this string self, string value, StringComparison comparison)
+		{
+			if (self == null)
+				throw new ArgumentNullException (nameof(self));
+
+			return self.IndexOf (value, comparison) >= 0;
+		}
 	}
 }

--- a/Xamarin.PropertyEditing/Extensions.cs
+++ b/Xamarin.PropertyEditing/Extensions.cs
@@ -29,5 +29,14 @@ namespace Xamarin.PropertyEditing
 			foreach (T item in enumerable)
 				self.Add (item);
 		}
+
+		public static bool TryRemove<TKey, TElement> (this IDictionary<TKey, TElement> self, TKey key, out TElement element)
+		{
+			if (!self.TryGetValue (key, out element))
+				return false;
+
+			self.Remove (key);
+			return true;
+		}
 	}
 }

--- a/Xamarin.PropertyEditing/IGroupingList.cs
+++ b/Xamarin.PropertyEditing/IGroupingList.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Xamarin.PropertyEditing
+{
+	internal interface IGroupingList<TKey, TElement>
+		: IGrouping<TKey, TElement>, IReadOnlyList<TElement>
+	{
+	}
+
+	internal class ObservableGrouping<TKey, TElement>
+		: ObservableCollectionEx<TElement>, IGroupingList<TKey, TElement>
+	{
+		public ObservableGrouping (TKey key)
+		{
+			Key = key;
+		}
+
+		public ObservableGrouping (IGrouping<TKey, TElement> grouping)
+		{
+			Key = grouping.Key;
+			AddRange (grouping);
+		}
+
+		public TKey Key
+		{
+			get;
+		}
+
+		public void QuietClear()
+		{
+			Items.Clear ();
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/IMutableLookup.cs
+++ b/Xamarin.PropertyEditing/IMutableLookup.cs
@@ -1,0 +1,73 @@
+﻿//
+// IMutableLookup.cs
+//
+// Author:
+//   Eric Maupin  <me@ermau.com>
+//
+// Copyright (c) 2011 Eric Maupin (http://www.ermau.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cadenza.Collections
+{
+	internal interface IMutableLookup<TKey, TElement>
+		: ILookup<TKey, TElement>
+	{
+		/// <summary>
+		/// Adds <paramref name="element"/> under the specified <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key to add <paramref name="element"/> under.</param>
+		/// <param name="element">The element to add.</param>
+		void Add (TKey key, TElement element);
+
+		/// <summary>
+		/// Adds <paramref name="elements"/> under the specified <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">They key to add <paramref name="elements"/> under.</param>
+		/// <param name="elements">The elements to add.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="elements"/> is <c>null</c>.</exception>
+		void Add (TKey key, IEnumerable<TElement> elements);
+
+		/// <summary>
+		/// Removes <paramref name="element"/> from the <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key that <paramref name="element"/> is located under.</param>
+		/// <param name="element">The element to remove from <paramref name="key"/>. </param>
+		/// <returns><c>true</c> if <paramref name="key"/> and <paramref name="element"/> existed, <c>false</c> if not.</returns>
+		bool Remove (TKey key, TElement element);
+
+		/// <summary>
+		/// Removes <paramref name="key"/> from the lookup.
+		/// </summary>
+		/// <param name="key">They to remove.</param>
+		/// <returns><c>true</c> if <paramref name="key"/> existed.</returns>
+		bool Remove (TKey key);
+
+		/// <summary>
+		/// Clears the lookup.
+		/// </summary>
+		void Clear ();
+	}
+}

--- a/Xamarin.PropertyEditing/ObservableCollectionEx.cs
+++ b/Xamarin.PropertyEditing/ObservableCollectionEx.cs
@@ -19,6 +19,12 @@ namespace Xamarin.PropertyEditing
 			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, list, index));
 		}
 
+		public void RemoveRange (IEnumerable<T> range)
+		{
+			foreach (T element in range)
+				Remove (element);
+		}
+
 		/// <remarks>Only used for testing <see cref="INotifyCollectionChanged"/> compliance.</remarks>
 		internal void Reset (IEnumerable<T> newContents)
 		{

--- a/Xamarin.PropertyEditing/ObservableLookup.cs
+++ b/Xamarin.PropertyEditing/ObservableLookup.cs
@@ -1,0 +1,336 @@
+﻿//
+// MutableLookup.cs
+//
+// Author:
+//   Eric Maupin  <me@ermau.com>
+//
+// Copyright (c) 2011 Eric Maupin (http://www.ermau.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+using Cadenza.Collections;
+
+namespace Xamarin.PropertyEditing
+{
+	/// <summary>
+	/// A mutable lookup implementing <see cref="ILookup{TKey,TElement}"/>
+	/// </summary>
+	/// <typeparam name="TKey">The lookup key.</typeparam>
+	/// <typeparam name="TElement">The elements under each <typeparamref name="TKey"/>.</typeparam>
+	internal class ObservableLookup<TKey, TElement>
+		: IMutableLookup<TKey, TElement>, INotifyCollectionChanged, IReadOnlyList<IGroupingList<TKey, TElement>>
+	{
+		public ObservableLookup ()
+			: this (EqualityComparer<TKey>.Default)
+		{
+		}
+
+		public ObservableLookup (IEqualityComparer<TKey> comparer)
+		{
+			if (comparer == null)
+				throw new ArgumentNullException ("comparer");
+
+			this.groupings = new OrderedDictionary<TKey, ObservableGrouping<TKey, TElement>> (comparer);
+			if (!typeof (TKey).IsValueType)
+				this.nullGrouping = new ObservableGrouping<TKey, TElement> (default (TKey));
+		}
+
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+		public bool ReuseGroups
+		{
+			get { return this.reuseGroups; }
+			set
+			{
+				if (this.reuseGroups == value)
+					return;
+
+				this.reuseGroups = value;
+				if (value)
+					this.oldGroups = new Dictionary<TKey, ObservableGrouping<TKey, TElement>> ();
+				else
+					this.oldGroups = null;
+			}
+		}
+
+		/// <summary>
+		/// Adds <paramref name="element"/> under the specified <paramref name="key"/>. <paramref name="key"/> does not need to exist.
+		/// </summary>
+		/// <param name="key">The key to add <paramref name="element"/> under.</param>
+		/// <param name="element">The element to add.</param>
+		public void Add (TKey key, TElement element)
+		{
+			ObservableGrouping<TKey, TElement> grouping;
+			if (key == null) {
+				grouping = nullGrouping;
+				if (grouping.Count == 0)
+					OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, grouping, 0));
+			} else if (!this.groupings.TryGetValue (key, out grouping)) {
+				if (!ReuseGroups || !this.oldGroups.TryRemove (key, out grouping))
+					grouping = new ObservableGrouping<TKey, TElement> (key);
+				
+				this.groupings.Add (key, grouping);
+				OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, (object)grouping, (this.groupings.Count - 1 + ((this.nullGrouping.Count > 0) ? 1 : 0))));
+			}
+
+			grouping.Add (element);
+		}
+
+		public void Add (TKey key, IEnumerable<TElement> elements)
+		{
+			if (elements == null)
+				throw new ArgumentNullException ("elements");
+
+			ObservableGrouping<TKey, TElement> grouping;
+			if (key == null) {
+				grouping = nullGrouping;
+				grouping.AddRange (elements);
+				if (grouping.Count == 0)
+					OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, grouping, 0));
+			} else if (!this.groupings.TryGetValue (key, out grouping)) {
+				if (!ReuseGroups || !this.oldGroups.TryRemove (key, out grouping))
+					grouping = new ObservableGrouping<TKey, TElement> (key);
+
+				grouping.AddRange (elements);
+
+				this.groupings.Add (key, grouping);
+				OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, (object)grouping, (this.groupings.Count - 1 + ((this.nullGrouping.Count > 0) ? 1 : 0))));
+			}
+		}
+
+		public void Add (IGrouping<TKey, TElement> grouping)
+		{
+			ObservableGrouping<TKey, TElement> og;
+			if (!ReuseGroups || !this.oldGroups.TryRemove (grouping.Key, out og)) {
+				og = new ObservableGrouping<TKey, TElement> (grouping.Key);
+			}
+
+			og.AddRange (grouping);
+
+			this.groupings.Add (grouping.Key, og);
+			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, (object)og, this.groupings.Count - 1));
+		}
+
+		public void Insert (int index, IGrouping<TKey, TElement> grouping)
+		{
+			ObservableGrouping<TKey, TElement> og;
+			if (!ReuseGroups || !this.oldGroups.TryRemove (grouping.Key, out og)) {
+				og = new ObservableGrouping<TKey, TElement> (grouping.Key);
+			}
+
+			og.AddRange (grouping);
+			this.groupings.Insert (index, og.Key, og);
+			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, (object)og, index));
+		}
+
+		/// <summary>
+		/// Removes <paramref name="element"/> from the <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key that <paramref name="element"/> is located under.</param>
+		/// <param name="element">The element to remove from <paramref name="key"/>. </param>
+		/// <returns><c>true</c> if <paramref name="key"/> and <paramref name="element"/> existed, <c>false</c> if not.</returns>
+		public bool Remove (TKey key, TElement element)
+		{
+			ObservableGrouping<TKey, TElement> group;
+			if (key == null) {
+				group = this.nullGrouping;
+			} else {
+				if (!this.groupings.TryGetValue (key, out group))
+					return false;
+			}
+
+			if (group.Remove (element)) {
+				if (group.Count == 0) {
+					Remove (key);
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Removes <paramref name="key"/> from the lookup.
+		/// </summary>
+		/// <param name="key">They to remove.</param>
+		/// <returns><c>true</c> if <paramref name="key"/> existed.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		public bool Remove (TKey key)
+		{
+			if (key == null) {
+				bool removed = (this.nullGrouping.Count > 0);
+				this.nullGrouping.Clear ();
+				if (removed)
+					OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Remove, this.nullGrouping, 0));
+
+				return removed;
+			}
+
+			int index = this.groupings.IndexOf (key);
+			if (index >= 0) {
+				var g = this.groupings[index];
+				this.groupings.Remove (key);
+				if (ReuseGroups) {
+					g.QuietClear ();
+					this.groupings.Add (key, g);
+				}
+				
+				OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Remove, g, index));
+				return true;
+			}
+
+			return false;
+		}
+
+		public void Clear ()
+		{
+			if (this.nullGrouping != null)
+				this.nullGrouping.Clear ();
+
+			if (ReuseGroups) {
+				foreach (var g in this.groupings.Values) {
+					this.oldGroups.Add (g.Key, g);
+					g.QuietClear ();
+				}
+			}
+
+			this.groupings.Clear ();
+			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Reset));
+		}
+
+		public bool TryGetValues (TKey key, out IEnumerable<TElement> values)
+		{
+			values = null;
+
+			if (key == null) {
+				if (this.nullGrouping.Count != 0) {
+					values = nullGrouping;
+					return true;
+				} else
+					return false;
+			}
+
+			ObservableGrouping<TKey, TElement> grouping;
+			if (!this.groupings.TryGetValue (key, out grouping))
+				return false;
+
+			values = grouping;
+			return true;
+		}
+
+		#region ILookup Members
+		/// <summary>
+		/// Gets the number of groupings.
+		/// </summary>
+		public int Count
+		{
+			get { return this.groupings.Count + ((this.nullGrouping != null && this.nullGrouping.Count > 0) ? 1 : 0); }
+		}
+
+		IGroupingList<TKey, TElement> IReadOnlyList<IGroupingList<TKey, TElement>>.this[int index] => (IGroupingList<TKey, TElement>)this[index];
+
+		/// <summary>
+		/// Gets the elements for <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key to get the elements for.</param>
+		/// <returns>The elements under <paramref name="key"/>.</returns>
+		public IEnumerable<TElement> this[TKey key]
+		{
+			get
+			{
+				if (key == null)
+					return this.nullGrouping;
+
+				ObservableGrouping<TKey, TElement> grouping;
+				if (this.groupings.TryGetValue (key, out grouping))
+					return grouping;
+
+				return new TElement[0];
+			}
+		}
+
+		public IEnumerable<TElement> this[int index]
+		{
+			get
+			{
+				if (index == this.groupings.Count) {
+					return this.nullGrouping;
+				}
+
+				return this.groupings[index];
+			}
+		}
+
+		/// <summary>
+		/// Gets whether or not there's a grouping for <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key to check for.</param>
+		/// <returns><c>true</c> if <paramref name="key"/> is present.</returns>
+		public bool Contains (TKey key)
+		{
+			if (key == null)
+				return (this.nullGrouping.Count > 0);
+
+			return this.groupings.ContainsKey (key);
+		}
+
+		public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator ()
+		{
+			foreach (var g in this.groupings.Values)
+				yield return g;
+
+			if (this.nullGrouping != null && this.nullGrouping.Count > 0)
+				yield return this.nullGrouping;
+		}
+
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
+		{
+			return this.GetEnumerator ();
+		}
+		#endregion
+
+		private readonly OrderedDictionary<TKey, ObservableGrouping<TKey, TElement>> groupings;
+		private readonly ObservableGrouping<TKey, TElement> nullGrouping;
+
+		private bool reuseGroups;
+		private Dictionary<TKey, ObservableGrouping<TKey, TElement>> oldGroups;
+
+		private void OnCollectionChanged (NotifyCollectionChangedEventArgs e)
+		{
+			CollectionChanged?.Invoke (this, e);
+		}
+
+		IEnumerator<IGroupingList<TKey, TElement>> IEnumerable<IGroupingList<TKey, TElement>>.GetEnumerator ()
+		{
+			foreach (var g in this.groupings.Values)
+				yield return g;
+
+			if (this.nullGrouping != null && this.nullGrouping.Count > 0)
+				yield return this.nullGrouping;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/OrderedDictionary.cs
+++ b/Xamarin.PropertyEditing/OrderedDictionary.cs
@@ -1,0 +1,437 @@
+﻿//
+// OrderedDictionary.cs
+//
+// Author:
+//   Eric Maupin  <me@ermau.com>
+//
+// Copyright (c) 2009 Eric Maupin (http://www.ermau.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Cadenza.Collections
+{
+	internal class OrderedDictionary<TKey, TValue>
+		: IDictionary<TKey, TValue>, IList<KeyValuePair<TKey, TValue>>
+	{
+		public OrderedDictionary ()
+			: this (0)
+		{
+		}
+
+		public OrderedDictionary (int capacity)
+			: this (capacity, EqualityComparer<TKey>.Default)
+		{
+		}
+
+		public OrderedDictionary (IEqualityComparer<TKey> equalityComparer)
+			: this (0, equalityComparer)
+		{
+		}
+
+		public OrderedDictionary (int capacity, IEqualityComparer<TKey> equalityComparer)
+		{
+			this.dict = new Dictionary<TKey, TValue> (capacity, equalityComparer);
+			this.kvpCollection = this.dict;
+			this.keyOrder = new List<TKey> (capacity);
+			this.roKeys = new ReadOnlyCollection<TKey> (this.keyOrder);
+			this.roValues = new ReadOnlyValueCollection (this);
+		}
+
+		public OrderedDictionary (ICollection<KeyValuePair<TKey, TValue>> dictionary)
+			: this (dictionary, EqualityComparer<TKey>.Default)
+		{
+		}
+
+		public OrderedDictionary (ICollection<KeyValuePair<TKey, TValue>> dictionary, IEqualityComparer<TKey> equalityComparer)
+			: this ((dictionary != null) ? dictionary.Count : 0, equalityComparer)
+		{
+			if (dictionary == null)
+				throw new ArgumentNullException ("dictionary");
+
+			foreach (var kvp in dictionary)
+				Add (kvp.Key, kvp.Value);
+		}
+
+		bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
+		{
+			get { return false; }
+		}
+
+		/// <summary>
+		/// Gets the equality comparer being used for <typeparam name="TKey"/>.
+		/// </summary>
+		public IEqualityComparer<TKey> Comparer
+		{
+			get { return this.dict.Comparer; }
+		}
+
+		/// <summary>
+		/// Gets or sets the value associated with <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key to get or set the value for.</param>
+		/// <returns>The value associated with the key.</returns>
+		/// <exception cref="KeyNotFoundException"><paramref name="key"/> was not found attempting to get.</exception>
+		public TValue this[TKey key]
+		{
+			get { return this.dict[key]; }
+			set
+			{
+				if (!this.dict.ContainsKey (key))
+					this.keyOrder.Add (key);
+
+				this.dict[key] = value;
+			}
+		}
+
+		/// <summary>
+		/// Gets the value at the specified index.
+		/// </summary>
+		/// <param name="index">The index to get the value at.</param>
+		/// <returns>The value at the specified index.</returns>
+		/// <exception cref="IndexOutOfRangeException"><paramref name="index"/> is less than 0 or greater than <see cref="Count"/>.</exception>
+		public TValue this[int index]
+		{
+			get { return this.dict[this.keyOrder[index]]; }
+		}
+
+		KeyValuePair<TKey, TValue> IList<KeyValuePair<TKey, TValue>>.this[int index]
+		{
+			get { return new KeyValuePair<TKey, TValue> (this.keyOrder[index], this[index]); }
+			set
+			{
+				keyOrder[index] = value.Key;
+				this.dict[value.Key] = value.Value;
+			}
+		}
+
+		/// <summary>
+		/// Gets the number of items in the dictionary.
+		/// </summary>
+		public int Count
+		{
+			get { return this.dict.Count; }
+		}
+
+		/// <summary>
+		/// Gets a read only collection of keys in the dictionary.
+		/// </summary>
+		public ICollection<TKey> Keys
+		{
+			get { return this.roKeys; }
+		}
+
+		/// <summary>
+		/// Gets a read only collection of values in the dictionary.
+		/// </summary>
+		public ICollection<TValue> Values
+		{
+			get { return this.roValues; }
+		}
+
+		bool ICollection<KeyValuePair<TKey, TValue>>.Contains (KeyValuePair<TKey, TValue> item)
+		{
+			return kvpCollection.Contains (item);
+		}
+
+		/// <summary>
+		/// Gets whether or not <paramref name="key"/> is in the dictionary.
+		/// </summary>
+		/// <param name="key">The key to look for.</param>
+		/// <returns><c>true</c> if the key was found, <c>false</c> if not.</returns>
+		/// <exception cref="ArgumentNullException">If <paramref name="key"/> is <c>null</c>.</exception>
+		public bool ContainsKey (TKey key)
+		{
+			return this.dict.ContainsKey (key);
+		}
+
+		/// <summary>
+		/// Gets whether or not <paramref name="value"/> is in the dictionary.
+		/// </summary>
+		/// <param name="value">The value to look for.</param>
+		/// <returns><c>true</c> if the value was found, <c>false</c> if not.</returns>
+		public bool ContainsValue (TValue value)
+		{
+			return this.dict.ContainsValue (value);
+		}
+
+		/// <summary>
+		/// Gets the index of <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key to find the index of.</param>
+		/// <returns>-1 if the key was not found, the index otherwise.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		public int IndexOf (TKey key)
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			return this.keyOrder.IndexOf (key);
+		}
+
+		/// <summary>
+		/// Gets the index of <paramref name="key"/> starting with <paramref name="startIndex"/>.
+		/// </summary>
+		/// <param name="key">The key to find the index of.</param>
+		/// <param name="startIndex">The index to start the search at.</param>
+		/// <returns>-1 if the key was not found, the index otherwise.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="startIndex"/> is not within the valid range of indexes.</exception>
+		public int IndexOf (TKey key, int startIndex)
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			return this.keyOrder.IndexOf (key, startIndex);
+		}
+
+		/// <summary>
+		///	Gets the index of <paramref name="key"/> between the range given by <paramref name="startIndex"/> and <paramref name="count"/>.
+		/// </summary>
+		/// <param name="key">The key to find the index of.</param>
+		/// <param name="startIndex">The index to start the search at.</param>
+		/// <param name="count">How many items to search, including the <paramref name="startIndex"/>.</param>
+		/// <returns>-1 if the key was not found, the index otherwise.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="startIndex"/> is not within the valid range of indexes.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="startIndex"/> and <paramref name="count"/> are not a valid range.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 0.</exception>
+		public int IndexOf (TKey key, int startIndex, int count)
+		{
+			if (key == null)
+				throw new ArgumentNullException ("key");
+
+			return this.keyOrder.IndexOf (key, startIndex, count);
+		}
+
+		int IList<KeyValuePair<TKey, TValue>>.IndexOf (KeyValuePair<TKey, TValue> item)
+		{
+			return this.keyOrder.IndexOf (item.Key);
+		}
+
+		/// <summary>
+		/// Attempts to get the <paramref name="value"/> for the <paramref name="key"/>.
+		/// </summary>
+		/// <param name="key">The key to search for.</param>
+		/// <param name="value">The value, if found.</param>
+		/// <returns><c>true</c> if the key was found, <c>false</c> otherwise.</returns>
+		/// <exception cref="ArgumentNullException">If <paramref name="key"/> is <c>null</c>.</exception>
+		public bool TryGetValue (TKey key, out TValue value)
+		{
+			return this.dict.TryGetValue (key, out value);
+		}
+
+		/// <summary>
+		/// Adds the <paramref name="key"/> and <paramref name="value"/> to the dictionary.
+		/// </summary>
+		/// <param name="key">The key to associate with the <paramref name="value"/>.</param>
+		/// <param name="value">The value to add.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		/// <exception cref="ArgumentException"><paramref name="key"/> already exists in the dictionary.</exception>
+		public void Add (TKey key, TValue value)
+		{
+			this.dict.Add (key, value);
+			this.keyOrder.Add (key);
+		}
+
+		void ICollection<KeyValuePair<TKey, TValue>>.Add (KeyValuePair<TKey, TValue> item)
+		{
+			Add (item.Key, item.Value);
+		}
+
+		/// <summary>
+		/// Inserts the <paramref name="key"/> and <paramref name="value"/> at the specified index.
+		/// </summary>
+		/// <param name="index">The index to insert the key and value at.</param>
+		/// <param name="key">The key to assicate with the <paramref name="value"/>.</param>
+		/// <param name="value">The value to insert.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than 0 or greater than <see cref="Count"/></exception>
+		public void Insert (int index, TKey key, TValue value)
+		{
+			this.keyOrder.Insert (index, key);
+			this.dict.Add (key, value);
+		}
+
+		void IList<KeyValuePair<TKey, TValue>>.Insert (int index, KeyValuePair<TKey, TValue> item)
+		{
+			Insert (index, item.Key, item.Value);
+		}
+
+		/// <summary>
+		/// Removes the key and associated value from the dictionary if found.
+		/// </summary>
+		/// <param name="key">The key to remove.</param>
+		/// <returns><c>true</c> if the key was found, <c>false</c> if not.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+		public bool Remove (TKey key)
+		{
+			return (this.dict.Remove (key) && this.keyOrder.Remove (key));
+		}
+
+		bool ICollection<KeyValuePair<TKey, TValue>>.Remove (KeyValuePair<TKey, TValue> item)
+		{
+			return (kvpCollection.Remove (item) && this.keyOrder.Remove (item.Key));
+		}
+
+		/// <summary>
+		/// Removes they key and associated value from the dictionary located at <paramref name="index"/>.
+		/// </summary>
+		/// <param name="index">The index at which to remove an item.</param>
+		public void RemoveAt (int index)
+		{
+			TKey key = this.keyOrder[index];
+			Remove (key);
+		}
+
+		/// <summary>
+		/// Clears the dictionary.
+		/// </summary>
+		public void Clear ()
+		{
+			this.dict.Clear ();
+			this.keyOrder.Clear ();
+		}
+
+		void ICollection<KeyValuePair<TKey, TValue>>.CopyTo (KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+		{
+			if (array == null)
+				throw new ArgumentNullException ("array");
+			if (this.Count > array.Length - arrayIndex)
+				throw new ArgumentException ("Not enough space in array to copy");
+			if (arrayIndex < 0)
+				throw new ArgumentOutOfRangeException ("arrayIndex");
+
+			for (int i = 0; i < this.keyOrder.Count; ++i) {
+				TKey key = keyOrder[i];
+				array[arrayIndex++] = new KeyValuePair<TKey, TValue> (key, this.dict[key]);
+			}
+		}
+
+		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator ()
+		{
+			foreach (TKey key in this.keyOrder)
+				yield return new KeyValuePair<TKey, TValue> (key, this[key]);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return GetEnumerator ();
+		}
+
+		private readonly ReadOnlyValueCollection roValues;
+		private readonly ReadOnlyCollection<TKey> roKeys;
+		private readonly ICollection<KeyValuePair<TKey, TValue>> kvpCollection;
+		private readonly Dictionary<TKey, TValue> dict;
+		private readonly List<TKey> keyOrder;
+
+		private class ReadOnlyValueCollection
+			: IList<TValue>
+		{
+			public ReadOnlyValueCollection (OrderedDictionary<TKey, TValue> dict)
+			{
+				this.odict = dict;
+			}
+
+			public void Add (TValue item)
+			{
+				throw new NotSupportedException ();
+			}
+
+			public void Clear ()
+			{
+				throw new NotSupportedException ();
+			}
+
+			public bool Contains (TValue item)
+			{
+				return this.odict.ContainsValue (item);
+			}
+
+			public void CopyTo (TValue[] array, int arrayIndex)
+			{
+				if (array == null)
+					throw new ArgumentNullException ("array");
+				if (this.Count > array.Length - arrayIndex)
+					throw new ArgumentException ("Not enough space in array to copy");
+				if (arrayIndex < 0 || arrayIndex > array.Length)
+					throw new ArgumentOutOfRangeException ("arrayIndex");
+
+				for (int i = 0; i < this.odict.Count; ++i)
+					array[arrayIndex++] = this.odict[i];
+			}
+
+			public int Count
+			{
+				get { return odict.Count; }
+			}
+
+			public bool IsReadOnly
+			{
+				get { return true; }
+			}
+
+			public bool Remove (TValue item)
+			{
+				throw new NotSupportedException ();
+			}
+
+			public int IndexOf (TValue item)
+			{
+				throw new NotImplementedException ();
+				//return this.odict.dict.Values.IndexOf (item);
+			}
+
+			public void Insert (int index, TValue item)
+			{
+				throw new NotSupportedException ();
+			}
+
+			public void RemoveAt (int index)
+			{
+				throw new NotSupportedException ();
+			}
+
+			public TValue this[int index]
+			{
+				get { return odict[index]; }
+				set { throw new NotSupportedException (); }
+			}
+
+			public IEnumerator<TValue> GetEnumerator ()
+			{
+				for (int i = 0; i < odict.keyOrder.Count; ++i)
+					yield return odict[i];
+			}
+
+			IEnumerator IEnumerable.GetEnumerator ()
+			{
+				return GetEnumerator ();
+			}
+
+			private readonly OrderedDictionary<TKey, TValue> odict;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/PropertyArrangeMode.cs
+++ b/Xamarin.PropertyEditing/PropertyArrangeMode.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Xamarin.PropertyEditing
+{
+	public enum PropertyArrangeMode
+	{
+		Name = 0,
+		Category = 1,
+		ValueSource = 2
+	}
+}

--- a/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
@@ -131,9 +131,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 		private void Filter (string oldFilter)
 		{
 			FilterState state = FilterState.Unknown;
-			if (String.IsNullOrWhiteSpace (oldFilter) || FilterText.StartsWith (oldFilter))
+			if (String.IsNullOrWhiteSpace (oldFilter) || FilterText.StartsWith (oldFilter, StringComparison.OrdinalIgnoreCase))
 				state = FilterState.Longer;
-			else if (oldFilter.StartsWith (FilterText))
+			else if (oldFilter.StartsWith (FilterText, StringComparison.OrdinalIgnoreCase))
 				state = FilterState.Shorter;
 
 			if (state != FilterState.Shorter) {
@@ -158,30 +158,16 @@ namespace Xamarin.PropertyEditing.ViewModels
 			return (ArrangeMode == PropertyArrangeMode.Name) ? "0" : vm.Category;
 		}
 
-		private ObservableGrouping<string, PropertyViewModel> GetGroupList (PropertyViewModel propertyVm)
-		{
-			switch (ArrangeMode) {
-				case PropertyArrangeMode.Name:
-					return (arranged.Count > 0) ? arranged[0] as ObservableGrouping<string, PropertyViewModel> : null;
-				case PropertyArrangeMode.Category:
-					return arranged[propertyVm.Category] as ObservableGrouping<string, PropertyViewModel>;
-
-				default:
-					return null;
-			}
-		}
-
 		private bool MatchesFilter (PropertyViewModel vm)
 		{
 			if (String.IsNullOrWhiteSpace (FilterText))
 				return true;
 
-			string filter = FilterText.ToLower ();
-			if (ArrangeMode == PropertyArrangeMode.Category && vm.Category != null && vm.Category.ToLower().Contains (filter)) {
+			if (ArrangeMode == PropertyArrangeMode.Category && vm.Category != null && vm.Category.Contains (FilterText, StringComparison.OrdinalIgnoreCase)) {
 				return true;
 			}
 
-			return vm.Property.Name.ToLower ().Contains (filter);
+			return vm.Property.Name.Contains (FilterText, StringComparison.OrdinalIgnoreCase);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -98,11 +98,13 @@ namespace Xamarin.PropertyEditing.ViewModels
 			get {
 				return filterText;
 			}
-			private set {
+			set {
 				if (filterText == value)
 					return;
 
-				this.filterText = value;
+				filterText = value;
+
+				FilterData ();
 				OnPropertyChanged ();
 			}
 		}
@@ -112,11 +114,13 @@ namespace Xamarin.PropertyEditing.ViewModels
 			get {
 				return arrangeMode;
 			}
-			private set {
+			set {
 				if (arrangeMode == value)
 					return;
 
-				this.arrangeMode = value;
+				arrangeMode = value;
+
+				FilterData ();
 				OnPropertyChanged ();
 			}
 		}
@@ -200,10 +204,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 			return new StringPropertyViewModel (property, this.editors);
 		}
 
-		internal void FilterData (string filterText, PropertyArrangeMode filterMode)
+		void FilterData ()
 		{
-            this.FilterText = filterText;
-			this.ArrangeMode = filterMode;
 			this.properties.Clear ();
 
 			UpdateProperties ();

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -33,6 +33,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 			get;
 		}
 
+		public Dictionary<string, bool> ExpandedNode { get; internal set; }
+
 		// TODO: Consider having the property hooks at the top level and a map of IPropertyInfo -> PropertyViewModel
 		// the hash lookup would be likely faster than doing a property info compare in every property and would
 		// reduce the number event attach/detatches
@@ -93,8 +95,14 @@ namespace Xamarin.PropertyEditing.ViewModels
 		private ObservableCollection<PropertyViewModel> properties = new ObservableCollection<PropertyViewModel> ();
 		private readonly ObservableCollectionEx<object> selectedObjects = new ObservableCollectionEx<object> ();
 
-		string filterText;
-		PropertyArrangeMode filterMode;
+		public string FilterText {
+			get;
+			private set;
+		}
+		public PropertyArrangeMode ArrangeMode {
+			get;
+			private set;
+		}
 
 		private void UpdateProperties (IObjectEditor[] removedEditors = null, IObjectEditor[] newEditors = null)
 		{
@@ -127,23 +135,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 
 			foreach (IPropertyInfo property in newSet) {
-				if (string.IsNullOrEmpty (filterText)) {
+				if (string.IsNullOrEmpty (FilterText)) {
 					this.properties.Add (GetViewModel (property));
 				}
 				else {
-					switch (filterMode) {
-						case PropertyArrangeMode.Name:
-							if (property.Name.StartsWith (filterText, StringComparison.InvariantCultureIgnoreCase)) {
-								this.properties.Add (GetViewModel (property));
-							}
-							break;
-						case PropertyArrangeMode.Category:
-							if (property.Name.StartsWith (filterText, StringComparison.InvariantCultureIgnoreCase)) {
-								this.properties.Add (GetViewModel (property));
-							}
-							break;
-						case PropertyArrangeMode.ValueSource:
-							break;
+					if (property.Name.StartsWith (FilterText, StringComparison.InvariantCultureIgnoreCase)) {
+						this.properties.Add (GetViewModel (property));
 					}
 				}
 			}
@@ -188,8 +185,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		internal void FilterData (string filterText, PropertyArrangeMode filterMode)
 		{
-            this.filterText = filterText;
-			this.filterMode = filterMode;
+            this.FilterText = filterText;
+			this.ArrangeMode = filterMode;
 			this.properties.Clear ();
 
 			UpdateProperties ();

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -90,13 +90,16 @@ namespace Xamarin.PropertyEditing.ViewModels
 		}
 
 		private readonly List<IObjectEditor> editors = new List<IObjectEditor> ();
-		private readonly ObservableCollection<PropertyViewModel> properties = new ObservableCollection<PropertyViewModel> ();
+		private ObservableCollection<PropertyViewModel> properties = new ObservableCollection<PropertyViewModel> ();
 		private readonly ObservableCollectionEx<object> selectedObjects = new ObservableCollectionEx<object> ();
+
+		string filterText;
+		PropertyArrangeMode filterMode;
 
 		private void UpdateProperties (IObjectEditor[] removedEditors = null, IObjectEditor[] newEditors = null)
 		{
 			if (this.editors.Count == 0) {
-				this.properties.Clear();
+				this.properties.Clear ();
 				return;
 			}
 
@@ -124,7 +127,25 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 
 			foreach (IPropertyInfo property in newSet) {
-				this.properties.Add (GetViewModel (property));
+				if (string.IsNullOrEmpty (filterText)) {
+					this.properties.Add (GetViewModel (property));
+				}
+				else {
+					switch (filterMode) {
+						case PropertyArrangeMode.Name:
+							if (property.Name.StartsWith (filterText, StringComparison.InvariantCultureIgnoreCase)) {
+								this.properties.Add (GetViewModel (property));
+							}
+							break;
+						case PropertyArrangeMode.Category:
+							if (property.Name.StartsWith (filterText, StringComparison.InvariantCultureIgnoreCase)) {
+								this.properties.Add (GetViewModel (property));
+							}
+							break;
+						case PropertyArrangeMode.ValueSource:
+							break;
+					}
+				}
 			}
 		}
 
@@ -163,6 +184,15 @@ namespace Xamarin.PropertyEditing.ViewModels
 				return vmFactory (property, this.editors);
 			
 			return new StringPropertyViewModel (property, this.editors);
+		}
+
+		internal void FilterData (string filterText, PropertyArrangeMode filterMode)
+		{
+            this.filterText = filterText;
+			this.filterMode = filterMode;
+			this.properties.Clear ();
+
+			UpdateProperties ();
 		}
 
 		private Task busyTask;

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -33,8 +33,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 			get;
 		}
 
-		public Dictionary<string, bool> ExpandedNode { get; internal set; }
-
 		// TODO: Consider having the property hooks at the top level and a map of IPropertyInfo -> PropertyViewModel
 		// the hash lookup would be likely faster than doing a property info compare in every property and would
 		// reduce the number event attach/detatches
@@ -92,16 +90,35 @@ namespace Xamarin.PropertyEditing.ViewModels
 		}
 
 		private readonly List<IObjectEditor> editors = new List<IObjectEditor> ();
-		private ObservableCollection<PropertyViewModel> properties = new ObservableCollection<PropertyViewModel> ();
+		private readonly ObservableCollection<PropertyViewModel> properties = new ObservableCollection<PropertyViewModel> ();
 		private readonly ObservableCollectionEx<object> selectedObjects = new ObservableCollectionEx<object> ();
 
+		string filterText;
 		public string FilterText {
-			get;
-			private set;
+			get {
+				return filterText;
+			}
+			private set {
+				if (filterText == value)
+					return;
+
+				this.filterText = value;
+				OnPropertyChanged ();
+			}
 		}
+
+		PropertyArrangeMode arrangeMode;
 		public PropertyArrangeMode ArrangeMode {
-			get;
-			private set;
+			get {
+				return arrangeMode;
+			}
+			private set {
+				if (arrangeMode == value)
+					return;
+
+				this.arrangeMode = value;
+				OnPropertyChanged ();
+			}
 		}
 
 		private void UpdateProperties (IObjectEditor[] removedEditors = null, IObjectEditor[] newEditors = null)

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -21,7 +21,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 			EditorProvider = provider;
 
 			this.selectedObjects.CollectionChanged += OnSelectedObjectsChanged;
-			PropertyChanged += PropertiesViewModel_PropertyChanged;
 		}
 
 		/// <remarks>Consumers should check for <see cref="INotifyCollectionChanged"/> and hook appropriately.</remarks>
@@ -126,6 +125,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
+		bool IsFiltering {
+			get {
+				return !string.IsNullOrEmpty (filterText);
+			}
+		}
+
 		private void UpdateProperties (IObjectEditor[] removedEditors = null, IObjectEditor[] newEditors = null)
 		{
 			if (this.editors.Count == 0) {
@@ -157,7 +162,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 
 			foreach (IPropertyInfo property in newSet) {
-				if (string.IsNullOrEmpty (FilterText)) {
+				if (!IsFiltering) {
 					this.properties.Add (GetViewModel (property));
 				}
 				else {
@@ -210,31 +215,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 			this.properties.Clear ();
 
 			UpdateProperties ();
-		}
-
-		List<PropertyViewModel> cachedProperties;
-		public List<PropertyViewModel> CachedProperties {
-			get {
-				if (cachedProperties == null) {
-					cachedProperties = Properties.ToList ();
-				}
-				return cachedProperties;
-			}
-		}
-
-		IEnumerable<IGrouping<string, PropertyViewModel>> cachedPropertiesGroupBy;
-		public IEnumerable<IGrouping<string, PropertyViewModel>> CachedPropertiesGroupBy {
-			get {
-				if (cachedPropertiesGroupBy == null) {
-					cachedPropertiesGroupBy = CachedProperties.GroupBy (arg => arg.Category);
-				}
-				return cachedPropertiesGroupBy;
-			}
-		}
-
-		void PropertiesViewModel_PropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			cachedProperties = null;
 		}
 
 		private Task busyTask;

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -21,6 +21,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			EditorProvider = provider;
 
 			this.selectedObjects.CollectionChanged += OnSelectedObjectsChanged;
+			PropertyChanged += PropertiesViewModel_PropertyChanged;
 		}
 
 		/// <remarks>Consumers should check for <see cref="INotifyCollectionChanged"/> and hook appropriately.</remarks>
@@ -209,6 +210,31 @@ namespace Xamarin.PropertyEditing.ViewModels
 			this.properties.Clear ();
 
 			UpdateProperties ();
+		}
+
+		List<PropertyViewModel> cachedProperties;
+		public List<PropertyViewModel> CachedProperties {
+			get {
+				if (cachedProperties == null) {
+					cachedProperties = Properties.ToList ();
+				}
+				return cachedProperties;
+			}
+		}
+
+		IEnumerable<IGrouping<string, PropertyViewModel>> cachedPropertiesGroupBy;
+		public IEnumerable<IGrouping<string, PropertyViewModel>> CachedPropertiesGroupBy {
+			get {
+				if (cachedPropertiesGroupBy == null) {
+					cachedPropertiesGroupBy = CachedProperties.GroupBy (arg => arg.Category);
+				}
+				return cachedPropertiesGroupBy;
+			}
+		}
+
+		void PropertiesViewModel_PropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			cachedProperties = null;
 		}
 
 		private Task busyTask;

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -69,6 +69,10 @@
     <Compile Include="ViewModels\StringPropertyViewModel.cs" />
     <Compile Include="ViewModels\ViewModelBase.cs" />
     <Compile Include="PropertyArrangeMode.cs" />
+    <Compile Include="IGroupingList.cs" />
+    <Compile Include="ObservableLookup.cs" />
+    <Compile Include="IMutableLookup.cs" />
+    <Compile Include="OrderedDictionary.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ViewModels\RelayCommand.cs" />
     <Compile Include="ViewModels\StringPropertyViewModel.cs" />
     <Compile Include="ViewModels\ViewModelBase.cs" />
+    <Compile Include="PropertyArrangeMode.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This implements filter searching and arranging on Mac. It does temporarily break the tabbing fix introduced just before as that was based on a regular `NSTableView` and not an `NSOutlineView`. We'll fix that separately in the interest of getting this in.