### PR TITLE
Fixes to ensure Unfocusable Labels display correctly when Layering is turned on. 

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -11,13 +11,13 @@ namespace Xamarin.PropertyEditing.Mac
 	internal abstract class BaseRectangleEditorControl<T> : PropertyEditorControl
 		where T : struct
 	{
-		protected UnfocusableTextView XLabel { get; set; }
+		protected UnfocusableTextField XLabel { get; set; }
 		protected NSTextField XEditor { get; set; }
-		protected UnfocusableTextView YLabel { get; set; }
+		protected UnfocusableTextField YLabel { get; set; }
 		protected NSTextField YEditor { get; set; }
-		protected UnfocusableTextView WidthLabel { get; set; }
+		protected UnfocusableTextField WidthLabel { get; set; }
 		protected NSTextField WidthEditor { get; set; }
-		protected UnfocusableTextView HeightLabel { get; set; }
+		protected UnfocusableTextField HeightLabel { get; set; }
 		protected NSTextField HeightEditor { get; set; }
 
 		public override NSView FirstKeyView => XEditor;
@@ -30,28 +30,28 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public BaseRectangleEditorControl ()
 		{
-			XLabel = new UnfocusableTextView ();
+			XLabel = new UnfocusableTextField ();
 			XEditor = new NSTextField ();
 			XEditor.BackgroundColor = NSColor.Clear;
 			XEditor.StringValue = string.Empty;
 			XEditor.Activated += OnInputUpdated;
 			XEditor.EditingEnded += OnInputUpdated;
 
-			YLabel =  new UnfocusableTextView ();
+			YLabel =  new UnfocusableTextField ();
 			YEditor = new NSTextField ();
 			YEditor.BackgroundColor = NSColor.Clear;
 			YEditor.StringValue = string.Empty;
 			YEditor.Activated += OnInputUpdated;
 			YEditor.EditingEnded += OnInputUpdated;
 
-			WidthLabel = new UnfocusableTextView ();
+			WidthLabel = new UnfocusableTextField ();
 			WidthEditor = new NSTextField ();
 			WidthEditor.BackgroundColor = NSColor.Clear;
 			WidthEditor.StringValue = string.Empty;
 			WidthEditor.Activated += OnInputUpdated;
 			WidthEditor.EditingEnded += OnInputUpdated;
 
-			HeightLabel =  new UnfocusableTextView ();
+			HeightLabel =  new UnfocusableTextField ();
 			HeightEditor = new NSTextField ();
 			HeightEditor.BackgroundColor = NSColor.Clear;
 			HeightEditor.StringValue = string.Empty;

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -25,6 +25,11 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 
 			AddSubview (BooleanEditor);
+
+            this.DoConstraints (new[] {
+				BooleanEditor.ConstraintTo (this, (cb, c) => cb.Width == c.Width),
+				BooleanEditor.ConstraintTo (this, (cb, c) => cb.Left == c.Left)
+			});
 		}
 
 		internal NSButton BooleanEditor { get; set; }

--- a/Xamarin.PropertyEditing.Mac/Controls/CGRectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CGRectEditorControl.cs
@@ -10,22 +10,22 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			// TODO localize
 			XLabel.Frame = new CGRect (0, -5, 25, 20);
-			XLabel.Value = "X:";
+			XLabel.StringValue = "X:";
 
 			XEditor.Frame = new CGRect (25, 0, 50, 20);
 
 			YLabel.Frame = new CGRect (85, -5, 25, 20);
-			YLabel.Value = "Y:";
+			YLabel.StringValue = "Y:";
 
 			YEditor.Frame = new CGRect (105, 0, 50, 20);
 
 			WidthLabel.Frame = new CGRect (160, -5, 45, 20);
-			WidthLabel.Value = "Width:";
+			WidthLabel.StringValue = "Width:";
 
 			WidthEditor.Frame = new CGRect (205, 0, 50, 20);
 
 			HeightLabel.Frame = new CGRect (260, -5, 45, 20);
-			HeightLabel.Value = "Height:";
+			HeightLabel.StringValue = "Height:";
 
 			HeightEditor.Frame = new CGRect (305, 0, 50, 20);
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/CGRectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CGRectEditorControl.cs
@@ -9,22 +9,22 @@ namespace Xamarin.PropertyEditing.Mac
 		public CGRectEditorControl ()
 		{
 			// TODO localize
-			XLabel.Frame = new CGRect (0, -5, 25, 20);
+			XLabel.Frame = new CGRect (0, 0, 25, 24);
 			XLabel.StringValue = "X:";
 
 			XEditor.Frame = new CGRect (25, 0, 50, 20);
 
-			YLabel.Frame = new CGRect (85, -5, 25, 20);
+			YLabel.Frame = new CGRect (85, 0, 25, 24);
 			YLabel.StringValue = "Y:";
 
 			YEditor.Frame = new CGRect (105, 0, 50, 20);
 
-			WidthLabel.Frame = new CGRect (160, -5, 45, 20);
+			WidthLabel.Frame = new CGRect (160, 0, 45, 24);
 			WidthLabel.StringValue = "Width:";
 
 			WidthEditor.Frame = new CGRect (205, 0, 50, 20);
 
-			HeightLabel.Frame = new CGRect (260, -5, 45, 20);
+			HeightLabel.Frame = new CGRect (260, 0, 45, 24);
 			HeightLabel.StringValue = "Height:";
 
 			HeightEditor.Frame = new CGRect (305, 0, 50, 20);

--- a/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
@@ -24,7 +24,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public PointEditorControl ()
 		{
-			var xLabel = new UnfocusableTextView (new CGRect (0, -5, 25, 20), "X:");
+			var xLabel = new UnfocusableTextField (new CGRect (0, -5, 25, 20), "X:");
 
 			XEditor = new NSTextField (new CGRect (25, 0, 50, 20));
 			XEditor.BackgroundColor = NSColor.Clear;
@@ -33,7 +33,7 @@ namespace Xamarin.PropertyEditing.Mac
 				ViewModel.Value = new CGPoint (XEditor.IntValue, YEditor.IntValue);
 			};
 
-			var yLabel = new UnfocusableTextView (new CGRect (85, -5, 25, 20), "Y:");
+			var yLabel = new UnfocusableTextField (new CGRect (85, -5, 25, 20), "Y:");
 
 			YEditor = new NSTextField (new CGRect (110, 0, 50, 20));
 			YEditor.BackgroundColor = NSColor.Clear;

--- a/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
@@ -24,7 +24,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public PointEditorControl ()
 		{
-			var xLabel = new UnfocusableTextField (new CGRect (0, -5, 25, 20), "X:");
+			var xLabel = new UnfocusableTextField (new CGRect (0, 4, 25, 20), "X:");
 
 			XEditor = new NSTextField (new CGRect (25, 0, 50, 20));
 			XEditor.BackgroundColor = NSColor.Clear;
@@ -33,7 +33,7 @@ namespace Xamarin.PropertyEditing.Mac
 				ViewModel.Value = new CGPoint (XEditor.IntValue, YEditor.IntValue);
 			};
 
-			var yLabel = new UnfocusableTextField (new CGRect (85, -5, 25, 20), "Y:");
+			var yLabel = new UnfocusableTextField (new CGRect (85, 4, 25, 20), "Y:");
 
 			YEditor = new NSTextField (new CGRect (110, 0, 50, 20));
 			YEditor.BackgroundColor = NSColor.Clear;

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -18,7 +18,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
-			this.comboBox = new NSComboBox (new CGRect (0, 0, 150, 20)) {
+			this.comboBox = new NSComboBox () {
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				BackgroundColor = NSColor.Clear,
 				StringValue = String.Empty,
@@ -35,6 +35,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			this.DoConstraints (new[] {
 				comboBox.ConstraintTo (this, (cb, c) => cb.Width == c.Width),
+				comboBox.ConstraintTo (this, (cb, c) => cb.Left == c.Left),
 			});
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -11,10 +11,11 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public StringEditorControl ()
 		{
-			StringEditor = new NSTextField (new CGRect (0, 0, 240, 20));
-			StringEditor.TranslatesAutoresizingMaskIntoConstraints = false;
-			StringEditor.BackgroundColor = NSColor.Clear;
-			StringEditor.StringValue = string.Empty;
+			StringEditor = new NSTextField {
+				TranslatesAutoresizingMaskIntoConstraints = false,
+				BackgroundColor = NSColor.Clear,
+				StringValue = string.Empty,
+			};
 
 			// update the value on keypress
 			StringEditor.Changed += (sender, e) => {

--- a/Xamarin.PropertyEditing.Mac/Controls/UnfocusableTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/UnfocusableTextField.cs
@@ -4,21 +4,22 @@ using CoreGraphics;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	class UnfocusableTextView : NSTextView
+	class UnfocusableTextField : NSTextField
 	{
-		public UnfocusableTextView () : base ()
+		public UnfocusableTextField () : base ()
 		{
 			SetDefaultProperties ();
 		}
 
-		public UnfocusableTextView (CGRect frameRect, string text) : base (frameRect)
+		public UnfocusableTextField (CGRect frameRect, string text) : base (frameRect)
 		{
-			Value = text;
+			StringValue = text;
 			SetDefaultProperties ();
 		}
 
 		void SetDefaultProperties ()
 		{
+			Bordered = false;
 			Editable = false;
 			Selectable = false;
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/UnfocusableTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/UnfocusableTextField.cs
@@ -23,5 +23,13 @@ namespace Xamarin.PropertyEditing.Mac
 			Editable = false;
 			Selectable = false;
 		}
+
+		public override void DrawRect (CGRect dirtyRect)
+		{
+			CGPoint origin = new CGPoint (0.0f, 7.0f);
+			CGRect rect = new CGRect (origin, new CGSize (this.Bounds.Width, this.Bounds.Height));
+
+			this.AttributedStringValue.DrawInRect (rect);
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -88,6 +88,9 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
 
+			PropertiesViewModel.ViewModelMap.Add (typeof (CGPoint), (p, e) => new PropertyViewModel<CGPoint> (p, e));
+			PropertiesViewModel.ViewModelMap.Add (typeof (CGRect), (p, e) => new PropertyViewModel<CGRect> (p, e));
+
 			propertyFilter = new NSSearchField (new CGRect (10, Frame.Height - 25, 170, 24)) {
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				PlaceholderString = "Property Filter", // TODO Localize

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -140,9 +140,9 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 
 			// TODO: localize
-			NSTableColumn propertiesList = new NSTableColumn (PropertyListColId) { Title = "Properties" };
+			NSTableColumn propertiesList = new NSTableColumn (PropertyListColId) { Title = "Property" };
 			NSTableColumn propertyEditors = new NSTableColumn (PropertyEditorColId) { Title = "Value" };
-			propertiesList.Width = 150;
+			propertiesList.Width = 200;
 			propertyEditors.Width = 250;
 			propertyTable.AddColumn (propertiesList);
 			propertyTable.AddColumn (propertyEditors);

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -47,17 +47,15 @@ namespace Xamarin.PropertyEditing.Mac
 			// Setup view based on the column
 			switch (tableColumn.Identifier) {
 				case PropertyEditorPanel.PropertyListColId:
-					var view = (UnfocusableTextView)outlineView.MakeView (cellIdentifier + "props", this);
+					var view = (UnfocusableTextField)outlineView.MakeView (cellIdentifier + "props", this);
 					if (view == null) {
-						view = new UnfocusableTextView {
-							Frame = new CoreGraphics.CGRect (0, -5, 75, 20),
-							TextContainerInset = new CoreGraphics.CGSize (0, 9),
+						view = new UnfocusableTextField {
 							Identifier = cellIdentifier + "props",
 							Alignment = NSTextAlignment.Right,
 						};
 					}
 
-					view.Value = cellIdentifier;
+					view.StringValue = cellIdentifier;
 					return view;
 
 				case PropertyEditorPanel.PropertyEditorColId:

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -67,7 +67,7 @@
     <Compile Include="Controls\BaseRectangleEditorControl.cs" />
     <Compile Include="Controls\CGRectEditorControl.cs" />
     <Compile Include="Controls\PointEditorControl.cs" />
-    <Compile Include="Controls\UnfocusableTextView.cs" />
+    <Compile Include="Controls\UnfocusableTextField.cs" />
     <Compile Include="NSObjectFacade.cs" />
     <Compile Include="Controls\PredefinedValuesEditor.cs" />
   </ItemGroup>


### PR DESCRIPTION
Larry and Sandy pointed out that when CALayer backing is turned on the Property Label stop rendering, until a column resize occurs. My switching to using a NSTextField, instead of NSTextView, under the hood, we have  solution that works when CALayer is on, without requiring a column resize to see things properly.