### PR TITLE
Initial Accessibility support for our editors.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BaseNumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseNumericEditorControl.cs
@@ -87,5 +87,14 @@ namespace Xamarin.PropertyEditing.Mac
 			NumericEditor.Editable = ViewModel.Property.CanWrite;
 			Stepper.Enabled = ViewModel.Property.CanWrite;
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			NumericEditor.AccessibilityEnabled = NumericEditor.Enabled;
+			NumericEditor.AccessibilityTitle = ViewModel.Property.Name + " Numeric Editor"; // TODO Localization
+
+			Stepper.AccessibilityEnabled = Stepper.Enabled;
+			Stepper.AccessibilityTitle = ViewModel.Property.Name + " Numeric Stepper"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -106,5 +106,20 @@ namespace Xamarin.PropertyEditing.Mac
 			WidthEditor.Editable = ViewModel.Property.CanWrite;
 			HeightEditor.Editable = ViewModel.Property.CanWrite;
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			XEditor.AccessibilityEnabled = XEditor.Enabled;
+			XEditor.AccessibilityTitle = ViewModel.Property.Name + " X Editor"; // TODO Localization
+
+			YEditor.AccessibilityEnabled = YEditor.Enabled;
+			YEditor.AccessibilityTitle = ViewModel.Property.Name + " Y Editor"; // TODO Localization
+
+			WidthEditor.AccessibilityEnabled = WidthEditor.Enabled;
+			WidthEditor.AccessibilityTitle = ViewModel.Property.Name + " Width Editor"; // TODO Localization
+
+			HeightEditor.AccessibilityEnabled = XEditor.Enabled;
+			HeightEditor.AccessibilityTitle = ViewModel.Property.Name + " Height Editor"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -81,5 +81,11 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			BooleanEditor.Enabled = ViewModel.Property.CanWrite;
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			BooleanEditor.AccessibilityEnabled = BooleanEditor.Enabled;
+			BooleanEditor.AccessibilityTitle = ViewModel.Property.Name + " Boolean Editor"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CGPointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CGPointEditorControl.cs
@@ -34,5 +34,14 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			ViewModel.Value = new CGPoint (XEditor.FloatValue, YEditor.FloatValue);
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			XEditor.AccessibilityEnabled = XEditor.Enabled;
+			XEditor.AccessibilityTitle = ViewModel.Property.Name + " X Editor"; // TODO Localization
+
+			YEditor.AccessibilityEnabled = YEditor.Enabled;
+			YEditor.AccessibilityTitle = ViewModel.Property.Name + " Y Editor"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CGSizeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CGSizeEditorControl.cs
@@ -34,5 +34,14 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			ViewModel.Value = new CGSize (XEditor.FloatValue, YEditor.FloatValue);
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			XEditor.AccessibilityEnabled = XEditor.Enabled;
+			XEditor.AccessibilityTitle = ViewModel.Property.Name + " Width Editor"; // TODO Localization
+
+			YEditor.AccessibilityEnabled = YEditor.Enabled;
+			YEditor.AccessibilityTitle = ViewModel.Property.Name + " Height Editor"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/IntegerNumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/IntegerNumericEditorControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AppKit;
 using Foundation;
 using Xamarin.PropertyEditing.ViewModels;
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
@@ -29,5 +29,14 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			ViewModel.Value = new Point (XEditor.IntValue, YEditor.IntValue);
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			XEditor.AccessibilityEnabled = XEditor.Enabled;
+			XEditor.AccessibilityTitle = ViewModel.Property.Name + " X Editor"; // TODO Localization
+
+			YEditor.AccessibilityEnabled = YEditor.Enabled;
+			YEditor.AccessibilityTitle = ViewModel.Property.Name + " Y Editor"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -84,5 +84,11 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 
 		private readonly NSComboBox comboBox;
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			comboBox.AccessibilityEnabled = comboBox.Enabled;
+			comboBox.AccessibilityTitle = ViewModel.Property.Name + " Enumeration Combo Box"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -74,6 +74,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			SetEnabled ();
 			UpdateValue ();
+			UpdateAccessibilityValues ();
 		}
 
 		protected virtual void OnPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -92,5 +93,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected abstract void HandleErrorsChanged (object sender, System.ComponentModel.DataErrorsChangedEventArgs e);
 
 		protected abstract void SetEnabled ();
+
+		protected abstract void UpdateAccessibilityValues ();
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
@@ -29,5 +29,11 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			ViewModel.Value = new Size (XEditor.IntValue, YEditor.IntValue);
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			XEditor.AccessibilityTitle = ViewModel.Property.Name + " Width Editor"; // TODO Localization
+			YEditor.AccessibilityTitle = ViewModel.Property.Name + " Height Editor"; // TODO Localization
+		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -66,5 +66,10 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			StringEditor.Editable = ViewModel.Property.CanWrite;
 		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			StringEditor.AccessibilityTitle = ViewModel.Property.Name + " String Editor"; // TODO Localization
+		}
 	}
 }


### PR DESCRIPTION
Only setting the Accessibility.Title seems to be enough to give users enough information for each Property.