### PR TITLE
[Core] Availability constraints

### DIFF
--- a/Xamarin.PropertyEditing/IAvailabilityConstraint.cs
+++ b/Xamarin.PropertyEditing/IAvailabilityConstraint.cs
@@ -1,7 +1,22 @@
-﻿namespace Xamarin.PropertyEditing
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Xamarin.PropertyEditing
 {
 	public interface IAvailabilityConstraint
 	{
-		bool GetIsAvailable (IObjectEditor editor);
+		/// <summary>
+		/// Gets a list of properties associated with the constraint.
+		/// </summary>
+		/// <remarks>
+		/// This list can be empty (or <c>null</c>) if the constraint is not based on regular properties. Properties listed here will
+		/// be monitored for changes and the availability re-queried when they do change. The list of properties will not be monitored
+		/// for changes.
+		/// </remarks>
+		IReadOnlyList<IPropertyInfo> ConstrainingProperties { get; }
+
+		/// <exception cref="ArgumentNullException"><paramref name="editor"/> is <c>null</c>.</exception>
+		Task<bool> GetIsAvailableAsync (IObjectEditor editor);
 	}
 }


### PR DESCRIPTION
This expands `IAvailabilityConstraint` to indicate `IPropertyInfo`s that would trigger a change and implements the logic for querying it into the VM.