### PR TITLE
[Core] Fix AsyncWorkQueue

### DIFF
--- a/Xamarin.PropertyEditing.Tests/AsyncWorkQueueTests.cs
+++ b/Xamarin.PropertyEditing.Tests/AsyncWorkQueueTests.cs
@@ -47,6 +47,25 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test, Timeout (1000)]
+		[Description ("Worker siblings added while their requester isn't active should ALL unlock when their requester becomes active")]
+		public async Task SameRequesterAfterNonSameIsFreed ()
+		{
+			object requester1 = new object();
+			object requester2 = new object();
+
+			IDisposable work = await this.queue.RequestAsyncWork (requester1);
+			
+			var inWorkTask = this.queue.RequestAsyncWork (requester2);
+			Assume.That (inWorkTask.IsCompleted, Is.False);
+			var inWork2Task = this.queue.RequestAsyncWork (requester2);
+			Assume.That (inWork2Task.IsCompleted, Is.False);
+
+			work.Dispose();
+			(await inWorkTask).Dispose();
+			(await inWork2Task).Dispose();
+		}
+
+		[Test, Timeout (1000)]
 		public async Task WorkContinuesOnDisposeOfParentAndChild ()
 		{
 			string requester1 = "r1";


### PR DESCRIPTION
This fixes an issue (demonstrated in included test) where a
child/sibling to another requester is added when that requester is not
the active. The logic that was present in the reqest to set related
requester workers to active was not present when the queue was advanced.

This also significantly reduces the work the request work method does by
simply tracking the active requester. The original comment about small
queues turned out to be false and it is likely to see queues as long as
2x the number of properties.