### PR TITLE
[Core] Add MultiAvailabilityConstraint

### DIFF
--- a/Xamarin.PropertyEditing.Tests/MultiAvailabilityConstraintTests.cs
+++ b/Xamarin.PropertyEditing.Tests/MultiAvailabilityConstraintTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+
+namespace Xamarin.PropertyEditing.Tests
+{
+	[TestFixture]
+	internal class MultiAvailabilityConstraintTests
+	{
+		[TestCase (true, false, false, true, true)]
+		[TestCase (true, true, false, true, true)]
+		[TestCase (true, true, true, true, false)]
+		[TestCase (false, false, false, false, false)]
+		[TestCase (false, true, false, false, true)]
+		public async Task Constraint (bool expectedResult, bool g1ar, bool g1br, bool g2ar, bool g2br)
+		{
+			var g1a = new Mock<IAvailabilityConstraint> ();
+			g1a.Setup (a => a.GetIsAvailableAsync (null)).ReturnsAsync (g1ar);
+			var g1b = new Mock<IAvailabilityConstraint> ();
+			g1b.Setup (a => a.GetIsAvailableAsync (null)).ReturnsAsync (g1br);
+			var g2a = new Mock<IAvailabilityConstraint> ();
+			g2a.Setup (a => a.GetIsAvailableAsync (null)).ReturnsAsync (g2ar);
+			var g2b = new Mock<IAvailabilityConstraint> ();
+			g2b.Setup (a => a.GetIsAvailableAsync (null)).ReturnsAsync (g2br);
+
+			var multi = new MultiAvailabilityConstraint (new[] { new[] { g1a.Object, g1b.Object }, new[] { g2a.Object, g2b.Object } });
+			bool result = await multi.GetIsAvailableAsync (null);
+
+			Assert.That (result, Is.EqualTo (expectedResult));
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="MockPropertyInfo\MockPropertyInfo.cs" />
     <Compile Include="MockPropertyInfo\MockEnumPropertyInfo.cs" />
     <Compile Include="MockPropertyProviderTests.cs" />
+    <Compile Include="MultiAvailabilityConstraintTests.cs" />
     <Compile Include="PointViewModelTests.cs" />
     <Compile Include="RadialGradientBrushPropertyViewModelTests.cs" />
     <Compile Include="LinearGradientBrushPropertyViewModelTests.cs" />

--- a/Xamarin.PropertyEditing/MultiAvailabilityConstraint.cs
+++ b/Xamarin.PropertyEditing/MultiAvailabilityConstraint.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Xamarin.PropertyEditing
+{
+	/// <summary>
+	/// Represents groups of availability constraints that are ORed together.
+	/// </summary>
+	/// <remarks>
+	/// The individual availability constraints are ANDed together within the group to produce the groups' result.
+	/// The groups are ORed together, so only one needs to have its constituents all true.
+	/// </remarks>
+	public class MultiAvailabilityConstraint
+		: IAvailabilityConstraint
+	{
+		public MultiAvailabilityConstraint (IEnumerable<IEnumerable<IAvailabilityConstraint>> constraintGroups)
+		{
+			if (constraintGroups == null)
+				throw new ArgumentNullException (nameof(constraintGroups));
+
+			List<IPropertyInfo> properties = new List<IPropertyInfo> ();
+			this.constraints = new List<List<IAvailabilityConstraint>> ();
+			foreach (var g in constraintGroups) {
+				var group = new List<IAvailabilityConstraint> ();
+				foreach (var c in g) {
+					if (c.ConstrainingProperties != null) {
+						foreach (var p in c.ConstrainingProperties) {
+							if (!properties.Contains (p))
+								properties.Add (p);
+						}
+					}
+
+					group.Add (c);
+				}
+
+				this.constraints.Add (group);
+			}
+
+			ConstrainingProperties = properties;
+		}
+
+		public IReadOnlyList<IPropertyInfo> ConstrainingProperties {
+			get;
+		}
+
+		public async Task<bool> GetIsAvailableAsync (IObjectEditor editor)
+		{			
+			HashSet<Task<bool>> tasks = new HashSet<Task<bool>> ();
+			for (int i = 0; i < this.constraints.Count; i++) {
+				tasks.Add (Task.WhenAll (this.constraints[i].Select (c => c.GetIsAvailableAsync (editor)).ToArray ())
+					.ContinueWith (t => {
+						if (t.IsFaulted)
+							return false;
+
+						return Array.TrueForAll (t.Result, b => b);
+					}, TaskScheduler.Default));
+			}
+
+			// The groups of constraints are ||ed, each group's constraints are &&ed
+
+			while (tasks.Count > 0) {
+				var task = await Task.WhenAny (tasks).ConfigureAwait (false);
+				if (task.IsFaulted)
+					return false;
+				if (task.Result)
+					return true;
+
+				tasks.Remove (task);
+			}
+
+			return false;
+		}
+
+		private readonly List<List<IAvailabilityConstraint>> constraints;
+	}
+}

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -73,6 +73,7 @@
     <Compile Include="IPropertyInfo.cs" />
     <Compile Include="IResourceProvider.cs" />
     <Compile Include="ISelfConstrainedPropertyInfo.cs" />
+    <Compile Include="MultiAvailabilityConstraint.cs" />
     <Compile Include="NotifyingObject.cs" />
     <Compile Include="ObservableCollectionEx.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Implementation of IAvailabilityConstraint that ors together groups of
anded availability constraints. Written for a target platform, but
generic enough to be included here with tests.