### PR TITLE
[build] Disable profiling

### DIFF
--- a/Xamarin.PropertyEditing.Mac.Standalone/Xamarin.PropertyEditing.Mac.Standalone.csproj
+++ b/Xamarin.PropertyEditing.Mac.Standalone/Xamarin.PropertyEditing.Mac.Standalone.csproj
@@ -26,7 +26,7 @@
     <IncludeMonoRuntime>false</IncludeMonoRuntime>
     <UseSGen>true</UseSGen>
     <UseRefCounting>true</UseRefCounting>
-    <Profiling>true</Profiling>
+    <Profiling>false</Profiling>
     <HttpClientHandler></HttpClientHandler>
     <LinkMode></LinkMode>
     <XamMacArch></XamMacArch>


### PR DESCRIPTION
Mono has broken API with Xamarin.Mac again:

    Undefined symbols for architecture x86_64:
      "_mono_profiler_startup_log", referenced from:

Disabling this as we don't use it anyway. Now we can
compile with newer deps.