### PR TITLE
Fix null ref when getting ValueSource if value is null

### DIFF
--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -158,6 +158,27 @@ namespace Xamarin.PropertyEditing.Tests
 			Assume.That (vm.Value, Is.EqualTo (default (TValue)));
 			Assume.That (vm.MultipleValues, Is.True);
 			Assert.That (changed, Is.True, "PropertyChanged was not raised for Value when values began to disagree");
+		}
+
+		[Test]
+		public void ValueSourceDefaultWhenValuesDisagree ()
+		{
+			TValue value = GetNonDefaultRandomTestValue ();
+			TValue otherValue = GetRandomTestValue ();
+			while (Equals (otherValue, value))
+				otherValue = GetRandomTestValue ();
+
+			var vm = GetBasicTestModel (value);
+			Assume.That (vm.Value, Is.EqualTo (value));
+
+			var editor = GetBasicEditor (otherValue);
+
+			vm.Editors.Add (editor);
+
+			Assume.That (vm.Value, Is.EqualTo (default (TValue)));
+			Assume.That (vm.MultipleValues, Is.True);
+
+			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Default));
 		}
 
 		[Test]

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -23,7 +23,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			UpdateCurrentValue ();
 		}
 
-		public ValueSource ValueSource => this.value.Source;
+		public ValueSource ValueSource => this.value != null ? this.value.Source : ValueSource.Default;
 
 		public TValue Value
 		{
@@ -98,7 +98,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				MultipleValues = disagree;
 
 				// The public setter for Value is a local set for binding
-				SetCurrentValue ((currentValue != null) ? currentValue : null);
+				SetCurrentValue (currentValue);
 			}
 		}
 


### PR DESCRIPTION
This was happening specifically when switching fast enough from one inspected mock editable object to another in the Windows standalone app.