### PR TITLE
Bleroy brush editor 2

### DIFF
--- a/Xamarin.PropertyEditing.Tests/Manual/BrushEditor.md
+++ b/Xamarin.PropertyEditing.Tests/Manual/BrushEditor.md
@@ -1,0 +1,237 @@
+# Brush Editor Manual Test Plan
+
+Those manual tests should be performed on the standalone app.
+
+## Brush properties are properly displayed in the property grid
+
+1. Select "Mocked Sample 1".
+	- The `ReadOnlySolidBrush` and `SolidBrush` properties are properly labeled and have a property menu button on the right.
+	- The `ReadOnlySolidBrush` should appear as a column-wide yellow solid color, with opacity that shows the checkerboard pattern underneath.
+	- The `SolidBrush` property should show as a column-wide blue solid color, with opacity that shows the checkerboard pattern underneath, but not as visible as for `ReadOnlySolidBrush`.
+
+## Read-only brush properties are not clickable
+
+1. Click on the `ReadOnlySolidBrush` colored rectangle.
+	- Nothing opens, nothing happens.
+
+## Writable brush properties show a popup on click
+
+1. Click on the `SolidBrush` colored rectangle.
+	- The brush editor appears in a popup.
+2. Click outside of the popup.
+	- The popup disappears.
+
+## Brush type can be changed
+
+1. Select "Mocked Sample 1". Click on the `SolidBrush` property preview box.
+	- The popup opens.
+2. Click on the no brush tab.
+	- The "nobrush" tab gets selected.
+	- The part of the popup below the brush type tabs disappears (the popup itself might move depending on available screen real estate).
+	- The preview box shows no color, just the text "No brush".
+9. Click on the solid brush tab.
+	- The solid brush tab gets selected.
+	- The solid brush editor appears back (the popup may move depending on available screen real estate) with the previously selected color.
+
+## Brush popup is keyboard accessible
+
+1. Tab from the previous property.
+	- The brush preview box is focused but does not immediately open the popup.
+2. Tab when focused on the brush preview box
+	- Focus goes to the next property.
+3. `Shift-tab` from the next property.
+	- Focus goes back to the brush preview box, still no popup.
+4. `Shift-tab` again.
+	- Focus goes to the previous property.
+5. Tab back to the brush preview box, then hit `space`.
+	- The popup opens, and sets the focus on the first brush type tab.
+6. Hit `Esc`.
+	- The popup disappears and the focus goes back to the brush preview box.
+7. Hit `space` again to re-open the popup. Inside the popup, `tab` / `shift-tab` between the tab bar, the color space drop-down if there's one, the color component text boxes, and the hex textbox.
+	- Focus travels accordingly inside the popup but doesn't escape it.
+8. Tab to the brush types tab bar, then press the 'n' key (shifted or not).
+	- The "nobrush" tab gets selected.
+	- The part of the popup below the brush type tabs disappears (the popup itself might move depending on available screen real estate).
+	- The preview box shows no color, just the text "No brush".
+9. Press the 's' key (shifted or not).
+	- The solid brush tab gets selected.
+	- The solid brush editor appears back (the popup may move depending on available screen real estate) with the previously selected color.
+
+## Brush editor popup shows the current brush
+
+1. Clicking on the blue preview for the `SolidBrush` property of a mocked sample button shows the correct data for the color:
+	- shade cursor is near the top-right corner.
+	- gradient for the shade picker shows shades of blue.
+	- hue cursor is a little below center.
+	- initial color, current color, last color all show the same color as the preview.
+	- `R = 20`, `G = 120`, `B = 220`, `A = 94%`, `Hex = #F01478DC`, `H = 210°`, `L = 47%`, `S = 91%`, `B = 86%`, `C = 91%`, `M = 45%`, `Y = 0%`, `K = 14%`, `Opacity = 100%`.
+2. Clicking on any brush property of the "Mocked WPF button" shows the popup with "no brush" selected.
+
+## Shade picker changes the shade, not the hue
+
+1. In a brush popup with solid brush active, click and hold inside the shade picker, then move around without letting go.
+	- Shade picker cursor follows the mouse but stays inside the gradient.
+	- Last color and initial color remain the same.
+	- Hue remains unchanged, both in components when HSL and HBS modes are active, and the hue picker's cursor doesn't move.
+	- Alpha channel remains unchanged (and its effects can be seen on the preview, initial color, last color, and current color).
+	- Preview, current color, hex value change while the cursor is dragged around
+	- Components (R, G, B, C, M, Y, K, S, B, L) change while the cursor is dragged around.
+
+2. Let go of the mouse button.
+	- Initial color remains unchanged.
+	- Last color takes the current color.
+	- If the cursor was let go of on the left or bottom edge of the shade picker (which correspond to gray or black, for which hue is undefined), the hue remains what it was before the cursor was dragged.
+
+## Hue picker changes the hue, not the shade
+
+1. In a brush popup with solid brush active, click and hold inside the hue picker, then move around without letting go.
+	- Hue picker cursor follows the mouse but stays inside the gradient.
+	- Last color and initial color remain the same.
+	- Shade remains unchanged: the shade cursor doesn't move.
+	- Alpha channel remains unchanged (and its effects can be seen on the preview, initial color, last color, and current color).
+	- Preview, current color, hex value change while the cursor is dragged around.
+	- Components R, G, B, C, M, Y, H change while the cursor is dragged around, while S, B, L, and K remain unchanged.
+
+2. Let go of the mouse button.
+	- Initial color remains unchanged.
+	- Last color takes the current color.
+
+## Initial color button resets the brush
+
+1. Open the brush editor for the "Mocked Sample 1" button, then change the shade and hue.
+2. Click the initial color button.
+	- Preview, current color, last color, shade picker, hue picker, hex, and all components are reset to `R = 20`, `G = 120`, `B = 220`, `A = 94%`, `Hex = #F01478DC`, `H = 210°`, `L = 47%`, `S = 91%`, `B = 86%`, `C = 91%`, `M = 45%`, `Y = 0%`, `K = 14%`, `Opacity = 100%`.
+
+## Switching back and forth between no brush and solid brush doesn't lose color selection
+
+1. Open the brush editor for the "Mocked Sample 1" button, change the shade and hue, switch to no brush, then back to solid brush.
+	- The color should be the same as before the switch to no brush.
+2. Repeat the above check with a brush property from "Mocked WPF button".
+
+## Color component entry mode can be changed
+
+1. Open the brush editor for the "Mocked Sample 1" button, then click the label of one of the component boxes.
+	- A menu opens, showing a choice of HLS, HSB, RGB, and CMYK.
+2. Choose each of the options in turn
+	- The correct component boxes are shown.
+	- Each box shows a value with a unit, rounded to the nearest integer.
+	- Each box shows a mini-gradient on the bottom (rainbow for H, preview of changing this component alone from minimum to maximum value, taking the alpha channel into account).
+3. For each entry mode, change each of the components.
+	- When focusing on a component, it switches from a number rounded to the nearest integer with a unit where applicable, to a unitless number rounded to the nearest tenth.
+	- When focusing, the value is selected.
+	- A click on the text while the whole value is selected removes the selection and sets the cursor to the place that was clicked.
+	- When focused, the mini-gradient temporarily disappears.
+	- The value gets committed when either `return` or `tab` is pressed, or when focusing out.
+	- The new value causes the rest of the brush editor to update accordingly and register the updated color as the new current selection.
+4. Try invalid values such as non-numerical, or out of range, then focus out.
+	- Validation should kick in and show the textbox with a red outline, and revert to the previous value.
+	- Focusing back shows the invalid value entered before.
+5. Fix the invalid value.
+	- Border should go back to normal
+	- New value should be committed.
+
+## Colors can be entered with the hex box
+
+1. Open the brush editor for the "Mocked Sample 1" button, focus on the hex textbox.
+	- The whole value should be selected.
+	- Clicking inside the box while the whole value is selected should deselect and position the cursor where the click happened.
+	- Hitting `return`, `tab`, or focusing out commits the new value.
+2. Change the value to "#e071a73c", hit return.
+	- The value is capitalized to "#E071A73C".
+	- The shade picker get a green gradient, and moves its cursor down and left.
+	- The hue picker moves its cursor up to a green hue.
+	- The preview, current color, and last color adopt the new color (including transparency that is a little more visible).
+	- The initial color doesn't change.
+	- Component values change to `R = 113`, `G = 167`, `B = 60`, `A = 88%`, `H = 90°`, `L = 45%`, `S = 64%`, `B = 65%`, `C = 32%`, `M = 0%`, `Y = 64%`, `K = 35%`, `Opacity = 100%`
+
+## Components can be entered sequentially
+
+1. Open the brush editor for the "Mocked Sample 1" , then switch to the HLS view.
+2. Enter a hue of 300.
+	- The shade picker should change its gradient to purple, but the cursor should not move.
+	- The hue picker shouldchange its cursor to purple.
+	- Other components, as well as thepreview, current color, and last color should update.
+3. Enter a lightness (L) of 0.
+	- The preview, current color, and last color switch to a translucent black.
+	- The shade picker gradient remains unchanged, but its cursor jumps down to the black edge on the bottom.
+	- The hue picker doesn't move.
+	- The hue still shows 300°.
+	- Other components update.
+4. Enter a lightness of 80.
+	- The preview, current color, and last color switch back to a purplish pink.
+	- The shade picker keeps its purple gradient unchanged, but its cursor jumps up towards the top.
+	- The hue picker doesn't change.
+	- The hue still shows 300°.
+	- Other components update.
+5. Enter a saturation (S) of 0.
+	- The preview, current color, and last color switch to a translucent white.
+	- The shade picker gradient remains unchanged, but its cursor jumps down to the white edge on the left.
+	- The hue picker doesn't move.
+	- The hue still shows 300°.
+	- Other components update.
+6. Enter a saturation of 80.
+	- The preview, current color, and last color switch back to a purplish pink.
+	- The shade picker keeps its purple gradient unchanged, but its cursor jumps up towards the top-right.
+	- The hue picker doesn't change.
+	- The hue still shows 300°.
+	- Other components update.
+7. Switch to CMYK and enter 100 in the black (K) component.
+	- The preview, current color, and last color switch to a translucent black.
+	- The shade picker gradient remains unchanged, but its cursor jumps down to the lower-left corner.
+	- The hue picker doesn't move.
+	- The hue still shows 300°.
+	- Other components update.
+8. Enter a blackness of 10.
+	- The preview, current color, and last color switch back to a purplish pink.
+	- The shade picker keeps its purple gradient unchanged, but its cursor jumps up towards the top and slightly to the right.
+	- The hue picker doesn't change.
+	- The hue still shows 300°.
+	- Other components update.
+9. All the other components are less tricky, and trying them one by one will yield expectable results. Be sure to check each time that:
+	- The preview, current color, and last color update.
+	- The shade picker keeps up in both gradient hue and cursor position.
+	- The hue picker updates its cursor position.
+	- Other components update as relevant.
+
+## The brush editor is properly themed
+
+1. Open the brush editor and check that all UI elements are properly styled.
+2. Switch the theme, and verify again.
+
+## Brush opacity can be edited
+
+1. Open the brush editor on a solid brush property, then deploy the advanced pane by clicking on the chevron on the bottom.
+	- The opacity editor deploys and shows the current percentage (including a '%' sign after the value), rounded to the nearest unit.
+2. Click the opacity textbox.
+	- The opacity value gets selected, and is without unit, and rounded to the nearest tenth.
+	- The opacity can be edited.
+
+## Color space appears as needed and can be edited
+
+1. Open a brush property on the "Mocked WPF button" and switch it to a solid brush.
+	- No color space drop-down should be visible.
+2. Open the `SolidBrush` property on "Mocked Sample 1".
+	- A color space drop-down can be found between the brush type tabs and the solid brush editor.
+	- The drop-down contains a "RGB" and a "sRGB" entry.
+	- The "sRGB" option is selected.
+3. Select the "RGB" option, then move to a different control and back.
+	- The "RGB" option is still selected.
+
+## Reset
+
+1. Open a brush property on the "Mocked WPF button".
+	- The property menu indicator is empty and the "Reset" option is disabled.
+2. Switch it to a solid brush and select a shade and hue.
+	- The property menu indicator is filled, and "Reset" is enabled.
+3. Close the popup, then select "Reset" in the property menu.
+	- The property is back to "No brush".
+	- The property menu indicator is empty, and the reset option is disabled.
+4. Re-open the popup.
+	- The property menu indicator is still empty.
+5. Switch to solid brush.
+	- The property menu indicator is filled.
+	- The selected color is black.
+
+## Setting a brush property to a resource
+
+TBD

--- a/Xamarin.PropertyEditing.Tests/SolidBrushPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/SolidBrushPropertyViewModelTests.cs
@@ -21,25 +21,290 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
-		public void ValueChangesTriggerSolidPropertyChanges()
+		public void ValueChangesTriggerSolidColorAndColorSpacePropertyChangesOnly ()
 		{
 			BrushPropertyViewModel vm = PrepareMockViewModel ();
 
 			var colorChanged = false;
 			var colorSpaceChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+
+			CommonColor initialColor = vm.Solid.InitialColor;
+			CommonColor lastColor = vm.Solid.LastColor;
+			CommonColor shade = vm.Solid.Shade;
+			CommonColor hueColor = vm.Solid.HueColor;
+
 			vm.Solid.PropertyChanged += (s, e) => {
 				switch (e.PropertyName) {
-				case nameof(SolidBrushViewModel.Color):
+				case nameof (SolidBrushViewModel.Color):
 					colorChanged = true;
 					break;
 				case nameof (SolidBrushViewModel.ColorSpace):
 					colorSpaceChanged = true;
 					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
 				}
 			};
-			vm.Value = new CommonSolidBrush (new CommonColor ());
+
+			CommonColor newColor = GetNewRandomColor (Random, vm.Solid.Color);
+			vm.Value = new CommonSolidBrush (newColor);
+
 			Assert.IsTrue (colorChanged);
+			Assert.AreEqual (newColor, vm.Solid.Color);
 			Assert.IsTrue (colorSpaceChanged);
+			Assert.IsFalse (hueColorChanged);
+			Assert.AreEqual (hueColor, vm.Solid.HueColor);
+			Assert.IsFalse (shadeChanged);
+			Assert.AreEqual (shade, vm.Solid.Shade);
+			Assert.AreEqual (initialColor, vm.Solid.InitialColor);
+			Assert.AreEqual (lastColor, vm.Solid.LastColor);
+		}
+
+		[Test]
+		public void UpdatingHueOnGreyDoesntCauseColorToChange ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			var grey = new CommonColor (20, 20, 20);
+			vm.Value = new CommonSolidBrush (grey);
+
+			var colorChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+
+			vm.Solid.PropertyChanged += (s, e) => {
+				switch (e.PropertyName) {
+				case nameof (SolidBrushViewModel.Color):
+					colorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
+				}
+			};
+
+			vm.Solid.HueColor = new CommonColor (0, 0, 255);
+
+			Assert.IsFalse (colorChanged);
+			Assert.AreEqual (grey, vm.Solid.Color);
+			Assert.IsTrue (hueColorChanged);
+			Assert.IsFalse (shadeChanged);
+		}
+
+		[Test]
+		public void UpdatingHueOnSaturatedColorsCausesColorToChange ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			var blue = new CommonColor (20, 20, 255);
+			vm.Value = new CommonSolidBrush (blue);
+
+			var colorChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+
+			vm.Solid.PropertyChanged += (s, e) => {
+				switch (e.PropertyName) {
+				case nameof (SolidBrushViewModel.Color):
+					colorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
+				}
+			};
+
+			vm.Solid.HueColor = new CommonColor (255, 0, 0);
+
+			Assert.IsTrue (colorChanged);
+			Assert.IsTrue (hueColorChanged);
+			Assert.IsFalse (shadeChanged);
+		}
+
+		[Test]
+		public void UpdatingShadeCausesColorToChange ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			vm.Value = GetRandomTestValue (Random);
+
+			var colorChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+			var alpha = vm.Solid.Color.A;
+
+			vm.Solid.PropertyChanged += (s, e) => {
+				switch (e.PropertyName) {
+				case nameof (SolidBrushViewModel.Color):
+					colorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
+				}
+			};
+
+			CommonColor newShade = GetNewRandomColor (Random, vm.Solid.Shade);
+			vm.Solid.Shade = newShade;
+
+			Assert.IsTrue (colorChanged);
+			Assert.IsFalse (hueColorChanged);
+			Assert.IsTrue (shadeChanged);
+			Assert.AreEqual (alpha, vm.Solid.Color.A);
+			Assert.AreEqual (newShade.R, vm.Solid.Color.R);
+			Assert.AreEqual (newShade.G, vm.Solid.Color.G);
+			Assert.AreEqual (newShade.B, vm.Solid.Color.B);
+		}
+
+		[Test]
+		public void UpdatingColorCausesParentValueToChangeAndInitialColorToBeSetOnTheFirstTime ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			vm.Value = GetRandomTestValue (Random);
+
+			var colorChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+			var parentChanged = false;
+			var alpha = vm.Solid.Color.A;
+
+			vm.Solid.PropertyChanged += (s, e) => {
+				switch (e.PropertyName) {
+				case nameof (SolidBrushViewModel.Color):
+					colorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
+				}
+			};
+			vm.PropertyChanged += (s, e) => {
+				parentChanged = true;
+			};
+
+			CommonColor newColor = GetNewRandomColor (Random, vm.Solid.Color);
+			vm.Solid.Color = newColor;
+
+			Assert.IsTrue (parentChanged);
+			Assert.IsTrue (colorChanged);
+			Assert.IsFalse (hueColorChanged);
+			Assert.IsFalse (shadeChanged);
+			Assert.AreEqual (newColor, vm.Solid.Color);
+			Assert.AreEqual (newColor, vm.Solid.InitialColor);
+		}
+
+		[Test]
+		public void InitialAndLastColorDontChangeOnceSet ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			vm.Value = GetRandomTestValue (Random);
+
+			CommonColor initialColor = vm.Solid.InitialColor;
+			CommonColor lastColor = vm.Solid.LastColor;
+
+			CommonColor newColor = GetNewRandomColor (Random, vm.Solid.Color);
+			vm.Solid.Color = newColor;
+
+			Assert.AreEqual (initialColor, vm.Solid.InitialColor);
+			Assert.AreEqual (lastColor, vm.Solid.InitialColor);
+		}
+
+		[Test]
+		public void CommitLastColorChangesLastColorAndShade ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			vm.Value = GetRandomTestValue (Random);
+
+			CommonColor lastColor = vm.Solid.LastColor;
+
+			CommonColor newColor = GetNewRandomColor (Random, vm.Solid.Color);
+			vm.Solid.Color = newColor;
+
+			var colorChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+			var lastColorChanged = false;
+
+			vm.Solid.PropertyChanged += (s, e) => {
+				switch (e.PropertyName) {
+				case nameof (SolidBrushViewModel.Color):
+					colorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.LastColor):
+					lastColorChanged = true;
+					break;
+				}
+			};
+
+			vm.Solid.CommitLastColor ();
+
+			Assert.IsTrue (lastColorChanged);
+			Assert.IsTrue (shadeChanged);
+			Assert.IsFalse (colorChanged);
+			Assert.IsFalse (hueColorChanged);
+			Assert.AreEqual (newColor, vm.Solid.LastColor);
+		}
+
+		[Test]
+		public void CommitHueChangesHueOnly ()
+		{
+			BrushPropertyViewModel vm = PrepareMockViewModel ();
+			vm.Value = GetRandomTestValue (Random);
+
+			CommonColor hueColor = vm.Solid.HueColor;
+
+			CommonColor newColor = GetNewRandomColor (Random, vm.Solid.Color);
+			vm.Solid.Color = newColor;
+
+			var colorChanged = false;
+			var hueColorChanged = false;
+			var shadeChanged = false;
+			var lastColorChanged = false;
+
+			vm.Solid.PropertyChanged += (s, e) => {
+				switch (e.PropertyName) {
+				case nameof (SolidBrushViewModel.Color):
+					colorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.HueColor):
+					hueColorChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.Shade):
+					shadeChanged = true;
+					break;
+				case nameof (SolidBrushViewModel.LastColor):
+					lastColorChanged = true;
+					break;
+				}
+			};
+
+			vm.Solid.CommitHue ();
+
+			Assert.IsTrue (hueColorChanged);
+			Assert.IsFalse (lastColorChanged);
+			Assert.IsFalse (shadeChanged);
+			Assert.IsFalse (colorChanged);
 		}
 
 		protected override CommonBrush GetRandomTestValue (Random rand)
@@ -49,6 +314,13 @@ namespace Xamarin.PropertyEditing.Tests
 			var opacity = rand.NextDouble ();
 
 			return new CommonSolidBrush (color, colorSpace, opacity);
+		}
+
+		private static CommonColor GetNewRandomColor (Random rand, CommonColor oldColor)
+		{
+			CommonColor newColor = rand.NextColor ();
+			while (newColor == oldColor) newColor = rand.NextColor ();
+			return newColor;
 		}
 
 		private static BrushPropertyViewModel PrepareMockViewModel ()

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="MockControls\MockNSButton.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Manual\BrushEditor.md" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
@@ -35,8 +35,8 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 				inspectedObject = mockedControl.MockedControl;
 				if (mockedControl is MockedSampleControlButton mockedButton) {
 					IObjectEditor editor = await this.panel.EditorProvider.GetObjectEditorAsync (inspectedObject);
-					await mockedButton.SetBrush (editor, new CommonSolidBrush (20, 120, 220, 240, "sRGB"));
-					await mockedButton.SetReadOnlyBrush (editor, new CommonSolidBrush (240, 220, 15, 190));
+					await mockedButton.SetBrushInitialValue (editor, new CommonSolidBrush (20, 120, 220, 240, "sRGB"));
+					await mockedButton.SetReadOnlyBrushInitialValue (editor, new CommonSolidBrush (240, 220, 15, 190));
 				}
 			}
 

--- a/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
@@ -35,8 +35,8 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 				inspectedObject = mockedControl.MockedControl;
 				if (mockedControl is MockedSampleControlButton mockedButton) {
 					IObjectEditor editor = await this.panel.EditorProvider.GetObjectEditorAsync (inspectedObject);
-					await mockedButton.SetBrushInitialValue (editor, new CommonSolidBrush (20, 120, 220, 240, "sRGB"));
-					await mockedButton.SetReadOnlyBrushInitialValue (editor, new CommonSolidBrush (240, 220, 15, 190));
+					await mockedButton.SetBrushInitialValueAsync (editor, new CommonSolidBrush (20, 120, 220, 240, "sRGB"));
+					await mockedButton.SetReadOnlyBrushInitialValueAsync (editor, new CommonSolidBrush (240, 220, 15, 190));
 				}
 			}
 

--- a/Xamarin.PropertyEditing.Windows.Standalone/MockedSampleControlButton.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MockedSampleControlButton.cs
@@ -23,17 +23,23 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 			MockedControl.AddProperty<CommonBrush> (this.readOnlyBrushPropertyInfo);
 		}
 
-		public async Task SetBrush (IObjectEditor editor, CommonBrush brush)
+		public async Task SetBrushInitialValue (IObjectEditor editor, CommonBrush brush)
 		{
+			if (this.brushSet) return;
 			await editor.SetValueAsync (this.brushPropertyInfo, new ValueInfo<CommonBrush> { Value = brush });
+			this.brushSet = true;
 		}
 
-		public async Task SetReadOnlyBrush (IObjectEditor editor, CommonBrush brush)
+		public async Task SetReadOnlyBrushInitialValue (IObjectEditor editor, CommonBrush brush)
 		{
+			if (this.readOnlyBrushSet) return;
 			await editor.SetValueAsync (this.readOnlyBrushPropertyInfo, new ValueInfo<CommonBrush> { Value = brush });
+			this.readOnlyBrushSet = true;
 		}
 
-		private IPropertyInfo brushPropertyInfo;
-		private IPropertyInfo readOnlyBrushPropertyInfo;
+		IPropertyInfo brushPropertyInfo;
+		IPropertyInfo readOnlyBrushPropertyInfo;
+		bool brushSet = false;
+		bool readOnlyBrushSet = false;
 	}
 }

--- a/Xamarin.PropertyEditing.Windows.Standalone/MockedSampleControlButton.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MockedSampleControlButton.cs
@@ -23,23 +23,23 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 			MockedControl.AddProperty<CommonBrush> (this.readOnlyBrushPropertyInfo);
 		}
 
-		public async Task SetBrushInitialValue (IObjectEditor editor, CommonBrush brush)
+		public async Task SetBrushInitialValueAsync (IObjectEditor editor, CommonBrush brush)
 		{
 			if (this.brushSet) return;
 			await editor.SetValueAsync (this.brushPropertyInfo, new ValueInfo<CommonBrush> { Value = brush });
 			this.brushSet = true;
 		}
 
-		public async Task SetReadOnlyBrushInitialValue (IObjectEditor editor, CommonBrush brush)
+		public async Task SetReadOnlyBrushInitialValueAsync (IObjectEditor editor, CommonBrush brush)
 		{
 			if (this.readOnlyBrushSet) return;
 			await editor.SetValueAsync (this.readOnlyBrushPropertyInfo, new ValueInfo<CommonBrush> { Value = brush });
 			this.readOnlyBrushSet = true;
 		}
 
-		IPropertyInfo brushPropertyInfo;
-		IPropertyInfo readOnlyBrushPropertyInfo;
-		bool brushSet = false;
-		bool readOnlyBrushSet = false;
+		private IPropertyInfo brushPropertyInfo;
+		private IPropertyInfo readOnlyBrushPropertyInfo;
+		private bool brushSet = false;
+		private bool readOnlyBrushSet = false;
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using System.Windows.Controls;
+using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using Xamarin.PropertyEditing.ViewModels;
@@ -22,7 +22,8 @@ namespace Xamarin.PropertyEditing.Windows
 			this.brushTabs = this.brushBoxPopup?.Child?.GetDescendants<BrushTabbedEditorControl>().FirstOrDefault();
 
 			if (IsEnabled && this.brushBoxButton != null && this.brushBoxPopup != null) {
-				this.brushBoxPopup.PlacementTarget = this.brushBoxButton;
+				this.brushBoxPopup.PlacementTarget = this.brushBoxButton.FindParent<PropertyPresenter>();
+				this.brushBoxPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(PlacePopup);
 				this.brushBoxPopup.Opened += (s, e) => {
 					this.brushTabs?.FocusFirstChild ();
 				};
@@ -35,6 +36,14 @@ namespace Xamarin.PropertyEditing.Windows
 					}
 				};
 			}
+		}
+
+		public static CustomPopupPlacement[] PlacePopup(Size popupSize, Size targetSize, Point offset) {
+			return new[] {
+				new CustomPopupPlacement (new Point(offset.X, offset.Y + targetSize.Height), PopupPrimaryAxis.Horizontal),
+				new CustomPopupPlacement (new Point(offset.X, offset.Y - popupSize.Height), PopupPrimaryAxis.Horizontal),
+				new CustomPopupPlacement (new Point(offset.X - popupSize.Width, offset.Y + targetSize.Height), PopupPrimaryAxis.Horizontal),
+			};
 		}
 
 		private ButtonBase brushBoxButton;

--- a/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
@@ -21,7 +21,7 @@ namespace Xamarin.PropertyEditing.Windows
 			this.brushBoxPopup = GetTemplateChild ("brushBoxPopup") as Popup;
 			this.brushTabs = this.brushBoxPopup?.Child?.GetDescendants<BrushTabbedEditorControl>().FirstOrDefault();
 
-			if (IsEnabled && this.brushBoxButton != null && this.brushBoxPopup != null) {
+			if (this.brushBoxButton != null && this.brushBoxPopup != null) {
 				this.brushBoxPopup.PlacementTarget = this.brushBoxButton.FindParent<PropertyPresenter>();
 				this.brushBoxPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(PlacePopup);
 				this.brushBoxPopup.Opened += (s, e) => {

--- a/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
@@ -26,6 +26,8 @@ namespace Xamarin.PropertyEditing.Windows
 				this.brushBoxPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(PlacePopup);
 				this.brushBoxPopup.Opened += (s, e) => {
 					this.brushTabs?.FocusFirstChild ();
+					// Need to refresh the tabs and their value manually
+					this.brushTabs?.SelectTabFromBrush ();
 				};
 				this.brushBoxPopup.Closed += (s, e) => {
 					this.brushBoxButton.Focus ();

--- a/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Primitives;
@@ -19,25 +20,29 @@ namespace Xamarin.PropertyEditing.Windows
 
 			this.brushBoxButton = GetTemplateChild ("brushBoxButton") as ButtonBase;
 			this.brushBoxPopup = GetTemplateChild ("brushBoxPopup") as Popup;
-			this.brushTabs = this.brushBoxPopup?.Child?.GetDescendants<BrushTabbedEditorControl>().FirstOrDefault();
 
-			if (this.brushBoxButton != null && this.brushBoxPopup != null) {
-				this.brushBoxPopup.PlacementTarget = this.brushBoxButton.FindParent<PropertyPresenter>();
-				this.brushBoxPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(PlacePopup);
-				this.brushBoxPopup.Opened += (s, e) => {
-					this.brushTabs?.FocusFirstChild ();
-					// Need to refresh the tabs and their value manually
-					this.brushTabs?.SelectTabFromBrush ();
-				};
-				this.brushBoxPopup.Closed += (s, e) => {
-					this.brushBoxButton.Focus ();
-				};
-				this.brushBoxPopup.KeyUp += (s, e) => {
-					if (e.Key == Key.Escape) {
-						this.brushBoxPopup.IsOpen = false;
-					}
-				};
-			}
+			if (this.brushBoxButton == null)
+				throw new InvalidOperationException ($"{nameof(BrushEditorControl)} is missing a child ButtonBase named \"brushBoxButton\"");
+			if (this.brushBoxPopup == null)
+				throw new InvalidOperationException ("BrushEditorControl is missing a child Popup named \"brushBoxPopup\"");
+
+			this.brushTabs = this.brushBoxPopup.Child?.GetDescendants<BrushTabbedEditorControl>().FirstOrDefault();
+
+			this.brushBoxPopup.PlacementTarget = this.brushBoxButton.FindParent<PropertyPresenter>();
+			this.brushBoxPopup.CustomPopupPlacementCallback = new CustomPopupPlacementCallback(PlacePopup);
+			this.brushBoxPopup.Opened += (s, e) => {
+				this.brushTabs?.FocusFirstChild ();
+				// Need to refresh the tabs and their value manually
+				this.brushTabs?.SelectTabFromBrush ();
+			};
+			this.brushBoxPopup.Closed += (s, e) => {
+				this.brushBoxButton.Focus ();
+			};
+			this.brushBoxPopup.KeyUp += (s, e) => {
+				if (e.Key == Key.Escape) {
+					this.brushBoxPopup.IsOpen = false;
+				}
+			};
 		}
 
 		public static CustomPopupPlacement[] PlacePopup(Size popupSize, Size targetSize, Point offset) {

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -1,4 +1,5 @@
 using System.Windows.Controls;
+using System.Windows.Input;
 using Xamarin.PropertyEditing.Drawing;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -16,22 +17,38 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			brushChoice = GetTemplateChild ("brushChoice") as ChoiceControl;
+			this.brushChoice = GetTemplateChild ("brushChoice") as ChoiceControl;
 
-			if (brushChoice != null) {
+			if (this.brushChoice != null) {
 				StorePreviousBrush ();
 				SelectTabFromBrush ();
 
-				brushChoice.SelectedItemChanged += (s, e) => {
+				this.brushChoice.SelectedItemChanged += (s, e) => {
 					if (ViewModel == null) return;
 					StorePreviousBrush ();
-					switch ((string)brushChoice.SelectedValue) {
+					switch ((string)((ChoiceItem)(this.brushChoice.SelectedItem)).Value) {
 					case none:
 						ViewModel.Value = null;
 						break;
 					case solid:
 						ViewModel.Value = ViewModel.Solid.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));
 						break;
+					}
+				};
+
+				this.brushChoice.KeyUp += (s, e) => {
+					if (ViewModel == null) return;
+					StorePreviousBrush ();
+					switch (e.Key) {
+					case Key.N:
+						e.Handled = true;
+						this.brushChoice.SelectedValue = none;
+						break;
+					case Key.S:
+						e.Handled = true;
+						this.brushChoice.SelectedValue = solid;
+						break;
+					// TODO: add G, T, R for the other brush types when they are available.
 					}
 				};
 			}
@@ -42,7 +59,7 @@ namespace Xamarin.PropertyEditing.Windows
 
 		internal void FocusFirstChild()
 		{
-			brushChoice?.FocusSelectedItem();
+			this.brushChoice?.FocusSelectedItem();
 		}
 
 		private const string none = nameof (none);
@@ -62,13 +79,13 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void SelectTabFromBrush ()
 		{
-			if (brushChoice == null) return;
+			if (this.brushChoice == null) return;
 			switch (ViewModel?.Value) {
 			case null:
-				brushChoice.SelectedValue = none;
+				this.brushChoice.SelectedValue = none;
 				break;
 			case CommonSolidBrush _:
-				brushChoice.SelectedValue = solid;
+				this.brushChoice.SelectedValue = solid;
 				break;
 			}
 		}

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -35,6 +35,8 @@ namespace Xamarin.PropertyEditing.Windows
 					break;
 				case solid:
 					ViewModel.Value = ViewModel.Solid?.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));
+					ViewModel.Solid.CommitLastColor ();
+					ViewModel.Solid.CommitHue ();
 					break;
 				}
 			};

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -28,7 +28,7 @@ namespace Xamarin.PropertyEditing.Windows
 					StorePreviousBrush ();
 					switch ((string)((ChoiceItem)(this.brushChoice.SelectedItem)).Value) {
 					case none:
-						ViewModel.Value = null;
+						if (ViewModel.Value != null) ViewModel.Value = null;
 						break;
 					case solid:
 						ViewModel.Value = ViewModel.Solid.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -31,7 +31,7 @@ namespace Xamarin.PropertyEditing.Windows
 						if (ViewModel.Value != null) ViewModel.Value = null;
 						break;
 					case solid:
-						ViewModel.Value = ViewModel.Solid.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));
+						ViewModel.Value = ViewModel.Solid?.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));
 						break;
 					}
 				};

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -77,7 +77,7 @@ namespace Xamarin.PropertyEditing.Windows
 			}
 		}
 
-		private void SelectTabFromBrush ()
+		internal void SelectTabFromBrush ()
 		{
 			if (this.brushChoice == null) return;
 			switch (ViewModel?.Value) {

--- a/Xamarin.PropertyEditing.Windows/ColorComponentBox.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentBox.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/Xamarin.PropertyEditing.Windows/ColorComponentBox.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentBox.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 
 namespace Xamarin.PropertyEditing.Windows
@@ -56,25 +57,32 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			this.innerTextBox = GetTemplateChild ("innerTextBox") as TextBox;
-			if (this.innerTextBox != null) {
-				this.innerTextBox.GotKeyboardFocus += (s, e) => {
-					this.innerTextBox.SelectAll ();
-					previousValue = Value;
-				};
-				this.innerTextBox.PreviewMouseLeftButtonDown += (s, e) => {
-					this.innerTextBox.Focus ();
-					e.Handled = true;
-				};
-				this.innerTextBox.LostFocus += (s, e) => {
-					if (Value != previousValue) {
-						RaiseEvent (new RoutedEventArgs (ValueChangedEvent));
-					}
-				};
-			}
+			this.innerTextBox = GetTemplateChild ("innerTextBox") as TextBoxEx;
+
+			if (this.innerTextBox == null)
+				throw new InvalidOperationException ($"{nameof (ColorComponentBox)} is missing a child TextBoxEx named \"innerTextBox\"");
+
+			this.innerTextBox.GotKeyboardFocus += (s, e) => {
+				this.innerTextBox.SelectAll ();
+				this.previousValue = Value;
+			};
+			this.innerTextBox.PreviewMouseLeftButtonDown += (s, e) => {
+				this.innerTextBox.Focus ();
+				e.Handled = true;
+			};
+			this.innerTextBox.LostFocus += (s, e) => {
+				if (Value != this.previousValue) {
+					RaiseEvent (new RoutedEventArgs (ValueChangedEvent));
+				}
+			};
+			this.innerTextBox.PreviewKeyDown += (s, e) => {
+				if (e.Key == Key.Return) {
+					RaiseEvent (new RoutedEventArgs (ValueChangedEvent));
+				}
+			};
 		}
 
-		private TextBox innerTextBox;
+		private TextBoxEx innerTextBox;
 		private double previousValue;
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/ColorComponentBox.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentBox.cs
@@ -64,12 +64,7 @@ namespace Xamarin.PropertyEditing.Windows
 				throw new InvalidOperationException ($"{nameof (ColorComponentBox)} is missing a child TextBoxEx named \"innerTextBox\"");
 
 			this.innerTextBox.GotKeyboardFocus += (s, e) => {
-				this.innerTextBox.SelectAll ();
 				this.previousValue = Value;
-			};
-			this.innerTextBox.PreviewMouseLeftButtonDown += (s, e) => {
-				this.innerTextBox.Focus ();
-				e.Handled = true;
 			};
 			this.innerTextBox.LostFocus += (s, e) => {
 				if (Value != this.previousValue) {

--- a/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Xamarin.PropertyEditing.Drawing;
 
 namespace Xamarin.PropertyEditing.Windows
@@ -177,19 +178,6 @@ namespace Xamarin.PropertyEditing.Windows
 			}
 			foreach (Button button in this.GetDescendants<Button> ()) {
 				button.Click += OnComponentLabelClick;
-			}
-			foreach (TextBox textbox in this.GetDescendants<TextBox> ()) {
-				// This will not get TextBoxes buried inside templates of derived TextBox types, such as ColorComponentBox,
-				// those will have to do their own focus management.
-				if (!textbox.GetType ().IsSubclassOf (typeof (TextBox))) {
-					textbox.GotKeyboardFocus += (s, e) => {
-						textbox.SelectAll ();
-					};
-					textbox.PreviewMouseLeftButtonDown += (s, e) => {
-						textbox.Focus ();
-						e.Handled = true;
-					};
-				}
 			}
 		}
 

--- a/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
@@ -103,6 +103,17 @@ namespace Xamarin.PropertyEditing.Windows
 			set => SetValue (HueProperty, value);
 		}
 
+		public static readonly DependencyProperty HueColorProperty =
+			DependencyProperty.Register (
+				"HueColor", typeof (CommonColor), typeof (ColorEditorControlBase),
+				new PropertyMetadata (new CommonColor (255, 0, 0), OnHueColorChanged));
+
+		public CommonColor HueColor
+		{
+			get => (CommonColor)GetValue (HueColorProperty);
+			set => SetValue (HueColorProperty, value);
+		}
+
 		public static readonly DependencyProperty SaturationProperty =
 			DependencyProperty.Register (
 				nameof (Saturation), typeof (double), typeof (ColorComponentsEditorControl),
@@ -193,7 +204,6 @@ namespace Xamarin.PropertyEditing.Windows
 			if (M != newColor.M) M = newColor.M;
 			if (Y != newColor.Y) Y = newColor.Y;
 			if (K != newColor.K) K = newColor.K;
-			if (Hue != newColor.Hue) Hue = newColor.Hue;
 			if (Saturation != newColor.Saturation) Saturation = newColor.Saturation;
 			if (Lightness != newColor.Lightness) Lightness = newColor.Lightness;
 			if (Brightness != newColor.Brightness) Brightness = newColor.Brightness;
@@ -203,6 +213,20 @@ namespace Xamarin.PropertyEditing.Windows
 		private UIElement cmykPane;
 		private UIElement hlsPane;
 		private UIElement hsbPane;
+
+
+		static void OnHueColorChanged (DependencyObject source, DependencyPropertyChangedEventArgs e)
+		{
+			var control = (ColorComponentsEditorControl)source;
+			control.OnHueColorChanged ((CommonColor)e.OldValue, (CommonColor)e.NewValue);
+		}
+
+		void OnHueColorChanged (CommonColor oldColor, CommonColor newColor) {
+			var newHue = newColor.Hue;
+			if (newHue != Hue) {
+				Hue = newHue;
+			}
+		}
 
 		private void OnRGBComponentBoxChanged (object sender, RoutedEventArgs e)
 		{
@@ -226,6 +250,10 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnHLSComponentBoxChanged (object sender, RoutedEventArgs e)
 		{
+			var oldHue = HueColor.Hue;
+			if (oldHue != Hue) {
+				HueColor = CommonColor.GetHueColorFromHue (Hue);
+			}
 			var newColor = CommonColor.FromHLS (Hue, Lightness, Saturation, A);
 			if (!newColor.Equals (Color)) {
 				Color = newColor;
@@ -236,6 +264,10 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnHSBComponentBoxChanged (object sender, RoutedEventArgs e)
 		{
+			var oldHue = HueColor.Hue;
+			if (oldHue != Hue) {
+				HueColor = CommonColor.GetHueColorFromHue (Hue);
+			}
 			var newColor = CommonColor.FromHSB (Hue, Saturation, Brightness, A);
 			if (!newColor.Equals (Color)) {
 				Color = newColor;

--- a/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 using Xamarin.PropertyEditing.Drawing;
 
 namespace Xamarin.PropertyEditing.Windows
@@ -225,10 +224,7 @@ namespace Xamarin.PropertyEditing.Windows
 
 
 		static void OnHueColorChanged (DependencyObject source, DependencyPropertyChangedEventArgs e)
-		{
-			var control = (ColorComponentsEditorControl)source;
-			control.OnHueColorChanged ((CommonColor)e.OldValue, (CommonColor)e.NewValue);
-		}
+			=> (source as ColorComponentsEditorControl)?.OnHueColorChanged ((CommonColor)e.OldValue, (CommonColor)e.NewValue);
 
 		void OnHueColorChanged (CommonColor oldColor, CommonColor newColor) {
 			var newHue = newColor.Hue;
@@ -266,9 +262,8 @@ namespace Xamarin.PropertyEditing.Windows
 			var newColor = CommonColor.FromHLS (Hue, Lightness, Saturation, A);
 			if (!newColor.Equals (Color)) {
 				Color = newColor;
+				RaiseEvent (new RoutedEventArgs (CommitCurrentColorEvent));
 			}
-
-			RaiseEvent (new RoutedEventArgs (CommitCurrentColorEvent));
 		}
 
 		private void OnHSBComponentBoxChanged (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
@@ -163,6 +163,15 @@ namespace Xamarin.PropertyEditing.Windows
 			this.hlsPane = GetTemplateChild ("hlsPane") as UIElement;
 			this.hsbPane = GetTemplateChild ("hsbPane") as UIElement;
 
+			if (this.rgbPane == null)
+				throw new InvalidOperationException ($"{nameof (ColorComponentsEditorControl)} is missing a child UIElement named \"rgbPane\"");
+			if (this.cmykPane == null)
+				throw new InvalidOperationException ($"{nameof (ColorComponentsEditorControl)} is missing a child UIElement named \"cmykPane\"");
+			if (this.hlsPane == null)
+				throw new InvalidOperationException ($"{nameof (ColorComponentsEditorControl)} is missing a child UIElement named \"hlsPane\"");
+			if (this.hsbPane == null)
+				throw new InvalidOperationException ($"{nameof (ColorComponentsEditorControl)} is missing a child UIElement named \"hsbPane\"");
+
 			if (ContextMenu != null) {
 				foreach (MenuItem item in ContextMenu.Items) {
 					item.Click += (s, e) => {

--- a/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorComponentsEditorControl.cs
@@ -45,7 +45,7 @@ namespace Xamarin.PropertyEditing.Windows
 		public static readonly DependencyProperty AlphaProperty =
 			DependencyProperty.Register (
 				nameof (A), typeof (byte), typeof (ColorComponentsEditorControl),
-				new PropertyMetadata ((byte)0));
+				new PropertyMetadata ((byte)255));
 
 		public byte A {
 			get => (byte)GetValue (AlphaProperty);

--- a/Xamarin.PropertyEditing.Windows/ColorEditorControlBase.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorEditorControlBase.cs
@@ -14,15 +14,6 @@ namespace Xamarin.PropertyEditing.Windows
 			add { AddHandler (CommitCurrentColorEvent, value); }
 			remove { RemoveHandler (CommitCurrentColorEvent, value); }
 		}
-
-		public static readonly RoutedEvent CommitShadeEvent =
-			EventManager.RegisterRoutedEvent (
-				nameof(CommitShade), RoutingStrategy.Bubble, typeof (RoutedEventHandler), typeof (CurrentColorCommitterControlBase));
-
-		public event RoutedEventHandler CommitShade {
-			add { AddHandler (CommitShadeEvent, value); }
-			remove { RemoveHandler (CommitShadeEvent, value); }
-		}
 	}
 
 	internal abstract class ColorEditorControlBase : CurrentColorCommitterControlBase

--- a/Xamarin.PropertyEditing.Windows/ColorEditorControlBase.cs
+++ b/Xamarin.PropertyEditing.Windows/ColorEditorControlBase.cs
@@ -14,6 +14,16 @@ namespace Xamarin.PropertyEditing.Windows
 			add { AddHandler (CommitCurrentColorEvent, value); }
 			remove { RemoveHandler (CommitCurrentColorEvent, value); }
 		}
+
+		public static readonly RoutedEvent CommitHueEvent =
+			EventManager.RegisterRoutedEvent (
+				nameof (CommitHueColor), RoutingStrategy.Bubble, typeof (RoutedEventHandler), typeof (CurrentColorCommitterControlBase));
+
+		public event RoutedEventHandler CommitHueColor
+		{
+			add { AddHandler (CommitHueEvent, value); }
+			remove { RemoveHandler (CommitHueEvent, value); }
+		}
 	}
 
 	internal abstract class ColorEditorControlBase : CurrentColorCommitterControlBase

--- a/Xamarin.PropertyEditing.Windows/CurrentColorEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/CurrentColorEditorControl.cs
@@ -41,6 +41,7 @@ namespace Xamarin.PropertyEditing.Windows
 			initialColorButton.Click += (s, e) => {
 				Color = InitialColor;
 				RaiseEvent (new RoutedEventArgs (CommitCurrentColorEvent));
+				RaiseEvent (new RoutedEventArgs (CommitHueEvent));
 			};
 		}
 	}

--- a/Xamarin.PropertyEditing.Windows/CurrentColorEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/CurrentColorEditorControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using Xamarin.PropertyEditing.Drawing;
@@ -8,20 +9,22 @@ namespace Xamarin.PropertyEditing.Windows
 	{
 		public static readonly DependencyProperty InitialColorProperty =
 			DependencyProperty.Register (
-				nameof(InitialColor), typeof (CommonColor), typeof (CurrentColorEditorControl),
+				nameof (InitialColor), typeof (CommonColor), typeof (CurrentColorEditorControl),
 				new PropertyMetadata (new CommonColor (0, 0, 0)));
 
-		public CommonColor InitialColor {
+		public CommonColor InitialColor
+		{
 			get => (CommonColor)GetValue (InitialColorProperty);
 			set => SetValue (InitialColorProperty, value);
 		}
 
 		public static readonly DependencyProperty LastColorProperty =
 			DependencyProperty.Register (
-				nameof(LastColor), typeof (CommonColor), typeof (CurrentColorEditorControl),
+				nameof (LastColor), typeof (CommonColor), typeof (CurrentColorEditorControl),
 				new PropertyMetadata (new CommonColor (0, 0, 0)));
 
-		public CommonColor LastColor {
+		public CommonColor LastColor
+		{
 			get => (CommonColor)GetValue (LastColorProperty);
 			set => SetValue (LastColorProperty, value);
 		}
@@ -30,13 +33,15 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			var initialColorBox = (Button)GetTemplateChild ("initialColorButton");
-			if (initialColorBox != null) {
-				initialColorBox.Click += (s, e) => {
-					Color = InitialColor;
-					RaiseEvent (new RoutedEventArgs (CommitCurrentColorEvent));
-				};
-			}
+			var initialColorButton = GetTemplateChild ("initialColorButton") as Button;
+
+			if (initialColorButton == null)
+				throw new InvalidOperationException ($"{nameof (CurrentColorEditorControl)} is missing a child Button named \"initialColorButton\"");
+
+			initialColorButton.Click += (s, e) => {
+				Color = InitialColor;
+				RaiseEvent (new RoutedEventArgs (CommitCurrentColorEvent));
+			};
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/HueEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/HueEditorControl.cs
@@ -39,20 +39,20 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			hueChooser = (Rectangle)GetTemplateChild ("hueChooser");
+			this.hueChooser = (Rectangle)GetTemplateChild ("hueChooser");
 
-			hueChooser.MouseLeftButtonDown += (s, e) => {
-				if (!hueChooser.IsMouseCaptured)
-					hueChooser.CaptureMouse ();
+			this.hueChooser.MouseLeftButtonDown += (s, e) => {
+				if (!this.hueChooser.IsMouseCaptured)
+					this.hueChooser.CaptureMouse ();
 			};
-			hueChooser.MouseMove += (s, e) => {
-				if (hueChooser.IsMouseCaptured && e.LeftButton == MouseButtonState.Pressed && hueChooser != null) {
+			this.hueChooser.MouseMove += (s, e) => {
+				if (this.hueChooser.IsMouseCaptured && e.LeftButton == MouseButtonState.Pressed && this.hueChooser != null) {
 					var cursorPosition = e.GetPosition ((IInputElement)s).Y;
 					SetHueFromPosition (cursorPosition);
 				}
 			};
-			hueChooser.MouseLeftButtonUp += (s, e) => {
-				if (hueChooser.IsMouseCaptured) hueChooser.ReleaseMouseCapture ();
+			this.hueChooser.MouseLeftButtonUp += (s, e) => {
+				if (this.hueChooser.IsMouseCaptured) this.hueChooser.ReleaseMouseCapture ();
 				var cursorPosition = e.GetPosition ((IInputElement)s).Y;
 				SetHueFromPosition (cursorPosition);
 				RaiseEvent (new RoutedEventArgs (CommitCurrentColorEvent));
@@ -69,9 +69,9 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			if (cursorPosition < 0)
 				cursorPosition = 0;
-			if (cursorPosition >= hueChooser.ActualHeight)
-				cursorPosition = hueChooser.ActualHeight - 1;
-			HueColor = CommonColor.GetHueColorFromHue (360 * cursorPosition / hueChooser.ActualHeight);
+			if (cursorPosition >= this.hueChooser.ActualHeight)
+				cursorPosition = this.hueChooser.ActualHeight - 1;
+			HueColor = CommonColor.GetHueColorFromHue (360 * cursorPosition / this.hueChooser.ActualHeight);
 		}
 
 		static void OnHueChanged (DependencyObject source, DependencyPropertyChangedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/HueEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/HueEditorControl.cs
@@ -39,7 +39,10 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			this.hueChooser = (Rectangle)GetTemplateChild ("hueChooser");
+			this.hueChooser = GetTemplateChild ("hueChooser") as Rectangle;
+
+			if (this.hueChooser == null)
+				throw new InvalidOperationException ($"{nameof(HueEditorControl)} is missing a child Rectangle named \"hueChooser\"");
 
 			this.hueChooser.MouseLeftButtonDown += (s, e) => {
 				if (!this.hueChooser.IsMouseCaptured)

--- a/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
@@ -47,6 +47,15 @@ namespace Xamarin.PropertyEditing.Windows
 			private set { SetValue (IsSubPropertyPropertyKey, value); }
 		}
 
+		public static readonly DependencyProperty ShowPropertyButtonProperty = DependencyProperty.Register (
+			nameof (ShowPropertyButton), typeof (bool), typeof (PropertyPresenter), new PropertyMetadata (true));
+
+		public bool ShowPropertyButton
+		{
+			get { return (bool)GetValue (ShowPropertyButtonProperty); }
+			set { SetValue (ShowPropertyButtonProperty, value); }
+		}
+
 		protected override Size ArrangeOverride (Size arrangeBounds)
 		{
 			return base.ArrangeOverride (arrangeBounds);

--- a/Xamarin.PropertyEditing.Windows/ShadeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ShadeEditorControl.cs
@@ -40,23 +40,23 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			saturationLayer = (Rectangle)GetTemplateChild ("saturationLayer");
-			brightnessLayer = (Rectangle)GetTemplateChild ("brightnessLayer");
+			this.saturationLayer = (Rectangle)GetTemplateChild ("saturationLayer");
+			this.brightnessLayer = (Rectangle)GetTemplateChild ("brightnessLayer");
 
 			OnHueChanged (HueColor);
 
-			brightnessLayer.MouseLeftButtonDown += (s, e) => {
-				if (!brightnessLayer.IsMouseCaptured)
-					brightnessLayer.CaptureMouse ();
+			this.brightnessLayer.MouseLeftButtonDown += (s, e) => {
+				if (!this.brightnessLayer.IsMouseCaptured)
+					this.brightnessLayer.CaptureMouse ();
 			};
-			brightnessLayer.MouseMove += (s, e) => {
-				if (brightnessLayer.IsMouseCaptured && e.LeftButton == MouseButtonState.Pressed && saturationLayer != null) {
+			this.brightnessLayer.MouseMove += (s, e) => {
+				if (this.brightnessLayer.IsMouseCaptured && e.LeftButton == MouseButtonState.Pressed && this.saturationLayer != null) {
 					Point cursorPosition = e.GetPosition ((IInputElement)s);
 					SetColorFromMousePosition (cursorPosition);
 				}
 			};
-			brightnessLayer.MouseLeftButtonUp += (s, e) => {
-				if (brightnessLayer.IsMouseCaptured) brightnessLayer.ReleaseMouseCapture ();
+			this.brightnessLayer.MouseLeftButtonUp += (s, e) => {
+				if (this.brightnessLayer.IsMouseCaptured) this.brightnessLayer.ReleaseMouseCapture ();
 				Point cursorPosition = e.GetPosition ((IInputElement)s);
 				SetColorFromMousePosition (cursorPosition);
 				RaiseEvent (new RoutedEventArgs (CommitShadeEvent));
@@ -67,12 +67,12 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			if (cursorPosition.X < 0)
 				cursorPosition.X = 0;
-			if (cursorPosition.X > brightnessLayer.ActualWidth)
-				cursorPosition.X = brightnessLayer.ActualWidth;
+			if (cursorPosition.X > this.brightnessLayer.ActualWidth)
+				cursorPosition.X = this.brightnessLayer.ActualWidth;
 			if (cursorPosition.Y < 0)
 				cursorPosition.Y = 0;
-			if (cursorPosition.Y > brightnessLayer.ActualHeight)
-				cursorPosition.Y = brightnessLayer.ActualHeight;
+			if (cursorPosition.Y > this.brightnessLayer.ActualHeight)
+				cursorPosition.Y = this.brightnessLayer.ActualHeight;
 
 			CursorPosition = cursorPosition;
 			CommonColor newColor = GetColorFromPosition (cursorPosition);
@@ -90,7 +90,7 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnColorChanged (oldColor, newColor);
 
-			if (brightnessLayer == null || !brightnessLayer.IsMouseCaptured)
+			if (this.brightnessLayer == null || !this.brightnessLayer.IsMouseCaptured)
 				CursorPosition = GetPositionFromColor (newColor);
 		}
 
@@ -103,12 +103,12 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnHueChanged (CommonColor newHue)
 		{
-			if (saturationLayer == null) return;
-			var newBrush = (LinearGradientBrush)saturationLayer.Fill.Clone ();
+			if (this.saturationLayer == null) return;
+			var newBrush = (LinearGradientBrush)this.saturationLayer.Fill.Clone ();
 			GradientStopCollection gradientStops = newBrush.GradientStops;
 			gradientStops.RemoveAt (1);
 			gradientStops.Add (new GradientStop (System.Windows.Media.Color.FromRgb (newHue.R, newHue.G, newHue.B), 1));
-			saturationLayer.Fill = newBrush;
+			this.saturationLayer.Fill = newBrush;
 		}
 
 		/// <summary>
@@ -131,8 +131,8 @@ namespace Xamarin.PropertyEditing.Windows
 		/// <returns>The shade</returns>
 		CommonColor GetColorFromPosition (Point position)
 		{
-			var saturation = position.X / saturationLayer.ActualWidth;
-			var brightness = 1 - position.Y / brightnessLayer.ActualHeight;
+			var saturation = position.X / this.saturationLayer.ActualWidth;
+			var brightness = 1 - position.Y / this.brightnessLayer.ActualHeight;
 
 			return CommonColor.FromHSB (HueColor.Hue, saturation, brightness);
 		}
@@ -148,10 +148,10 @@ namespace Xamarin.PropertyEditing.Windows
 			var brightness = color.Brightness;
 			var saturation = color.Saturation;
 
-			if (saturationLayer == null || brightnessLayer == null) return new Point (0, 0);
+			if (this.saturationLayer == null || this.brightnessLayer == null) return new Point (0, 0);
 			return new Point (
-				saturation * saturationLayer.ActualWidth + saturationLayer.Margin.Left ,
-				(1 - brightness) * brightnessLayer.ActualHeight + brightnessLayer.Margin.Top);
+				saturation * this.saturationLayer.ActualWidth + this.saturationLayer.Margin.Left ,
+				(1 - brightness) * this.brightnessLayer.ActualHeight + this.brightnessLayer.Margin.Top);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/ShadeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ShadeEditorControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -40,10 +41,15 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			base.OnApplyTemplate ();
 
-			this.saturationLayer = (Rectangle)GetTemplateChild ("saturationLayer");
-			this.brightnessLayer = (Rectangle)GetTemplateChild ("brightnessLayer");
+			this.saturationLayer = GetTemplateChild ("saturationLayer") as Rectangle;
+			this.brightnessLayer = GetTemplateChild ("brightnessLayer") as Rectangle;
 
 			OnHueChanged (HueColor);
+
+			if (this.saturationLayer == null)
+				throw new InvalidOperationException ($"{nameof (ShadeEditorControl)} is missing a child Rectangle named \"saturationLayer\"");
+			if (this.brightnessLayer == null)
+				throw new InvalidOperationException ($"{nameof (ShadeEditorControl)} is missing a child Rectangle named \"brightnessLayer\"");
 
 			this.brightnessLayer.MouseLeftButtonDown += (s, e) => {
 				if (!this.brightnessLayer.IsMouseCaptured)
@@ -103,6 +109,7 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnHueChanged (CommonColor newHue)
 		{
+			// OnHueChanged may be called before the template is applied, so the layer may not yet be available.
 			if (this.saturationLayer == null) return;
 			var newBrush = (LinearGradientBrush)this.saturationLayer.Fill.Clone ();
 			GradientStopCollection gradientStops = newBrush.GradientStops;
@@ -148,7 +155,9 @@ namespace Xamarin.PropertyEditing.Windows
 			var brightness = color.Brightness;
 			var saturation = color.Saturation;
 
+			// OnHueChanged may be called before the template is applied, so the layer may not yet be available.
 			if (this.saturationLayer == null || this.brightnessLayer == null) return new Point (0, 0);
+
 			return new Point (
 				saturation * this.saturationLayer.ActualWidth + this.saturationLayer.Margin.Left ,
 				(1 - brightness) * this.brightnessLayer.ActualHeight + this.brightnessLayer.Margin.Top);

--- a/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
@@ -45,10 +45,6 @@ namespace Xamarin.PropertyEditing.Windows
 			AddHandler (CurrentColorCommitterControlBase.CommitCurrentColorEvent, new RoutedEventHandler((s, e) => {
 				ViewModel.Solid.CommitLastColor ();
 			}));
-
-			AddHandler (CurrentColorCommitterControlBase.CommitShadeEvent, new RoutedEventHandler ((s, e) => {
-				ViewModel.Solid.CommitShade ();
-			}));
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
@@ -23,14 +23,14 @@ namespace Xamarin.PropertyEditing.Windows
 
 			if (ViewModel == null) return;
 
-			colorSpacePicker = (ComboBox)GetTemplateChild ("colorSpacePicker");
+			this.colorSpacePicker = (ComboBox)GetTemplateChild ("colorSpacePicker");
 			if (ViewModel.Solid.ColorSpaces == null || ViewModel.Solid.ColorSpaces.Count == 0) {
-				colorSpacePicker.Visibility = Visibility.Collapsed;
+				this.colorSpacePicker.Visibility = Visibility.Collapsed;
 			}
 
 			if (ViewModel.Property.CanWrite) {
 				// Handle color space changes
-				colorSpacePicker.SelectionChanged += (s, e) => {
+				this.colorSpacePicker.SelectionChanged += (s, e) => {
 					if (ViewModel != null && ViewModel.Value != null) {
 						ViewModel.Value = new CommonSolidBrush (ViewModel.Solid.Color, (string)e.AddedItems[0]);
 					}

--- a/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
@@ -42,9 +42,11 @@ namespace Xamarin.PropertyEditing.Windows
 				};
 			}
 
-			AddHandler (CurrentColorCommitterControlBase.CommitCurrentColorEvent, new RoutedEventHandler((s, e) => {
-				ViewModel.Solid.CommitLastColor ();
-			}));
+			AddHandler (CurrentColorCommitterControlBase.CommitCurrentColorEvent,
+				new RoutedEventHandler((s, e) => ViewModel.Solid.CommitLastColor ()));
+
+			AddHandler (CurrentColorCommitterControlBase.CommitHueEvent,
+				new RoutedEventHandler ((s, e) => ViewModel.Solid.CommitHue ()));
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/SolidBrushEditorControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using Xamarin.PropertyEditing.Drawing;
@@ -23,7 +24,11 @@ namespace Xamarin.PropertyEditing.Windows
 
 			if (ViewModel == null) return;
 
-			this.colorSpacePicker = (ComboBox)GetTemplateChild ("colorSpacePicker");
+			this.colorSpacePicker = GetTemplateChild ("colorSpacePicker") as ComboBox;
+
+			if (this.colorSpacePicker == null)
+				throw new InvalidOperationException ($"{nameof (SolidBrushEditorControl)} is missing a child ComboBox named \"colorSpacePicker\"");
+
 			if (ViewModel.Solid.ColorSpaces == null || ViewModel.Solid.ColorSpaces.Count == 0) {
 				this.colorSpacePicker.Visibility = Visibility.Collapsed;
 			}

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -27,6 +27,9 @@
 		</Setter>
 	</Style>
 
+	<SolidColorBrush x:Key="BrushBoxCheckerBoardLight">#FFFFFF</SolidColorBrush>
+	<SolidColorBrush x:Key="BrushBoxCheckerBoardDark">#D3D3D3</SolidColorBrush>
+
 	<DrawingBrush x:Key="CheckerBoard" Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
 		<DrawingBrush.Drawing>
 			<DrawingGroup>
@@ -491,8 +494,8 @@
 			<DataTemplate>
 				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
 					<Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="30" Height="20" Margin="4,4,0,0">
-						<Polygon Points="0,0 24,0 0,14" Fill="{DynamicResource VectorGlyphBrush}" StrokeThickness="0"/>
-						<Polygon Points="25,1 25,15 1,15" Fill="{DynamicResource VectorGlyphBrush}" StrokeThickness="0"/>
+						<Polygon Points="0,0 24,0 0,14" Fill="{DynamicResource ToggleItemForegroundBrush}" StrokeThickness="0"/>
+						<Polygon Points="25,1 25,15 1,15" Fill="{DynamicResource ToggleItemForegroundBrush}" StrokeThickness="0"/>
 					</Canvas>
 				</RadioButton>
 			</DataTemplate>
@@ -501,8 +504,8 @@
 			<DataTemplate>
 				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
 					<Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="30" Height="20" Margin="4,4,0,0">
-						<Rectangle Canvas.Left="0" Canvas.Top="0" Width="25" Height="15" Stroke="{DynamicResource VectorGlyphBrush}" StrokeThickness="1"/>
-						<Rectangle Canvas.Left="2" Canvas.Top="2" Width="21" Height="11" Fill="{DynamicResource VectorGlyphBrush}" StrokeThickness="0"/>
+						<Rectangle Canvas.Left="0" Canvas.Top="0" Width="25" Height="15" Stroke="{DynamicResource ToggleItemForegroundBrush}" StrokeThickness="1"/>
+						<Rectangle Canvas.Left="2" Canvas.Top="2" Width="21" Height="11" Fill="{DynamicResource ToggleItemForegroundBrush}" StrokeThickness="0"/>
 					</Canvas>
 				</RadioButton>
 			</DataTemplate>
@@ -623,6 +626,8 @@
 		</Setter>
 	</Style>
 
+	<SolidColorBrush x:Key="HueSelectionGlyphBrush">#000000</SolidColorBrush>
+
 	<Style TargetType="local:HueEditorControl">
 		<Setter Property="Focusable" Value="False"/>
 		<Setter Property="Template">
@@ -646,8 +651,8 @@
 							<Canvas Width="{Binding ActualWidth, ElementName=cursorCanvas}" Height="{Binding ActualHeight, ElementName=cursorCanvas}"
 									Canvas.Top="{TemplateBinding CursorPosition}">
 								<Canvas.RenderTransform><TranslateTransform X="0" Y="-4"/></Canvas.RenderTransform>
-								<Polygon Points="0,0 5,5 0,10" Stroke="{DynamicResource HuePickerCursorBrush}" Fill="{DynamicResource HuePickerCursorBrush}"/>
-								<Polygon Points="20,0 15,5 20,10" Stroke="{DynamicResource HuePickerCursorBrush}" Fill="{DynamicResource HuePickerCursorBrush}"/>
+								<Polygon Points="0,0 5,5 0,10" Stroke="{DynamicResource HueSelectionGlyphBrush}" Fill="{DynamicResource HueSelectionGlyphBrush}"/>
+								<Polygon Points="20,0 15,5 20,10" Stroke="{DynamicResource HueSelectionGlyphBrush}" Fill="{DynamicResource HueSelectionGlyphBrush}"/>
 							</Canvas>
 						</Canvas>
 					</Grid>
@@ -655,6 +660,9 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<Color x:Key="ShadePickerCursorStrokeColor">#000000</Color>
+	<Color x:Key="ShadePickerCursorOutlineColor">#FFFFFF</Color>
 
 	<Style TargetType="local:ShadeEditorControl">
 		<Setter Property="Focusable" Value="False"/>
@@ -1176,19 +1184,29 @@
 
 	<Style TargetType="{x:Type TabItem}">
 		<Setter Property="Foreground" Value="{DynamicResource PanelForegroundBrush}"/>
-		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="BorderThickness" Value="1"/>
+		<Setter Property="TextElement.Foreground" Value="{DynamicResource ToggleItemForegroundBrush}"/>
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type TabItem}">
-					<Border x:Name="grid" Background="{DynamicResource PanelBackgroundBrush}" BorderThickness="0" Padding="4">
+					<Border x:Name="grid" BorderThickness="1" Padding="4" BorderBrush="{DynamicResource ToggleItemBorderBrush}"
+							Background="{DynamicResource ToggleItemBackgroundBrush}" TextElement.Foreground="{DynamicResource ToggleItemForegroundBrush}">
 						<ContentPresenter x:Name="tabContent" ContentSource="Header"/>
 					</Border>
 					<ControlTemplate.Triggers>
 						<Trigger Property="IsSelected" Value="True">
-							<Setter TargetName="grid" Property="Background" Value="{DynamicResource SelectedTabBackgroundBrush}"/>
+							<Setter TargetName="grid" Property="BorderBrush" Value="{DynamicResource ToggleItemSelectedBorderBrush}"/>
+							<Setter TargetName="grid" Property="Background" Value="{DynamicResource ToggleItemSelectedBackgroundBrush}"/>
+							<Setter TargetName="grid" Property="TextElement.Foreground" Value="{DynamicResource ToggleItemSelectedForegroundBrush}"/>
 						</Trigger>
-						<Trigger Property="IsSelected" Value="False">
-							<Setter TargetName="grid" Property="Background" Value="{DynamicResource TabBackgroundBrush}"/>
+						<Trigger Property="IsMouseOver" Value="True">
+							<Setter TargetName="grid" Property="BorderBrush" Value="{DynamicResource ToggleItemMouseOverBorderBrush}"/>
+							<Setter TargetName="grid" Property="Background" Value="{DynamicResource ToggleItemMouseOverBackgroundBrush}"/>
+							<Setter TargetName="grid" Property="TextElement.Foreground" Value="{DynamicResource ToggleItemMouseOverForegroundBrush}"/>
+						</Trigger>
+						<Trigger Property="Button.IsPressed" Value="True">
+							<Setter TargetName="grid" Property="BorderBrush" Value="{DynamicResource ToggleItemPressedBorderBrush}"/>
+							<Setter TargetName="grid" Property="Background" Value="{DynamicResource ToggleItemPressedBackgroundBrush}"/>
 						</Trigger>
 					</ControlTemplate.Triggers>
 				</ControlTemplate>
@@ -1208,7 +1226,8 @@
 							<RowDefinition Height="*" />
 						</Grid.RowDefinitions>
 						<TabPanel IsItemsHost="True" Grid.Row="0" Panel.ZIndex="1" />
-						<Border Grid.Row="1" Panel.ZIndex="0" BorderThickness="0" Background="{DynamicResource SelectedTabBackgroundBrush}" Padding="4">
+						<Border Grid.Row="1" Panel.ZIndex="0" BorderThickness="0,1,1,1" Padding="4"
+							Background="{DynamicResource ToggleItemOuterBorderBrush}" BorderBrush="{DynamicResource ToggleItemOuterBorderBrush}">
 							<ContentPresenter ContentSource="SelectedContent" />
 						</Border>
 					</Grid>
@@ -1218,7 +1237,7 @@
 	</Style>
 
 	<Style TargetType="Label">
-		<Setter Property="Foreground" Value="{DynamicResource LabelForegroundBrush}"/>
+		<Setter Property="Foreground" Value="{DynamicResource PanelForegroundBrush}"/>
 	</Style>
 
 	<Style TargetType="ListBox">
@@ -1271,7 +1290,7 @@
 	<Style TargetType="MenuItem">
 		<Setter Property="HorizontalContentAlignment" Value="{Binding Path=HorizontalContentAlignment, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type ItemsControl}}}"/>
 		<Setter Property="VerticalContentAlignment" Value="{Binding Path=VerticalContentAlignment, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type ItemsControl}}}"/>
-		<Setter Property="Foreground" Value="{DynamicResource MenuItemForegroundBrush}" />
+		<Setter Property="Foreground" Value="{DynamicResource ListItemForegroundBrush}" />
 		<Setter Property="Background" Value="Transparent" />
 		<Setter Property="BorderBrush" Value="Transparent" />
 		<Setter Property="BorderThickness" Value="1" />

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -552,9 +552,11 @@
 							<ColumnDefinition Width="*" MinWidth="200"/>
 							<ColumnDefinition Width="Auto"/>
 						</Grid.ColumnDefinitions>
-						<ComboBox Name="colorSpacePicker" Grid.ColumnSpan="2" Grid.Row="0" Grid.Column="0" ItemsSource="{Binding Solid.ColorSpaces}"
+						<local:PropertyPresenter Label="{x:Static prop:Resources.ColorSpace}" Grid.ColumnSpan="2" Grid.Row="0" Grid.Column="0">
+							<ComboBox Name="colorSpacePicker" ItemsSource="{Binding Solid.ColorSpaces}"
 								  SelectedItem="{Binding Solid.ColorSpace, Mode=OneTime}" VerticalContentAlignment="Center"
 								  AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}" AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
+						</local:PropertyPresenter>
 						<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 							<Grid.RowDefinitions>
 								<RowDefinition Height="*"/>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -950,7 +950,7 @@
 								GradientBrush="{TemplateBinding Color, Converter={local:ColorComponentToAlphaBrushConverter}}"/>
 						</Grid>
 						
-						<TextBox Name="hexEntry" HorizontalContentAlignment="Left" HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="77" Grid.Column="0" Grid.Row="2"
+						<local:TextBoxEx x:Name="hexEntry" HorizontalContentAlignment="Left" HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="77" Grid.Column="0" Grid.Row="2"
 							AutomationProperties.Name="{x:Static prop:Resources.HexValue}" AutomationProperties.HelpText="{x:Static prop:Resources.HexValue}" ToolTip="{x:Static prop:Resources.HexValue}"
 							Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Color, Converter={local:HexColorConverter}, Mode=TwoWay}"/>
 					</Grid>
@@ -966,7 +966,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="local:ColorComponentBox">
 					<Grid>
-						<TextBox Name="innerTextBox" VerticalContentAlignment="Center"
+						<local:TextBoxEx x:Name="innerTextBox" VerticalContentAlignment="Center"
 								 BitmapEffect="{TemplateBinding BitmapEffect}" BitmapEffectInput="{TemplateBinding BitmapEffectInput}"
 								 CacheMode="{TemplateBinding CacheMode}" Clip="{TemplateBinding Clip}" ClipToBounds="{TemplateBinding ClipToBounds}" ContextMenu="{TemplateBinding ContextMenu}"
 								 Cursor="{TemplateBinding Cursor}" DataContext="{TemplateBinding DataContext}" FlowDirection="{TemplateBinding FlowDirection}"
@@ -984,7 +984,7 @@
 									<Binding Path="Unit" RelativeSource="{RelativeSource TemplatedParent}"/>
 								</MultiBinding>
 							</TextBox.Text>
-						</TextBox>
+						</local:TextBoxEx>
 						<local:BrushBoxControl x:Name="brushBoxControl" Visibility="Visible"
 							Brush="{Binding Path=GradientBrush, RelativeSource={RelativeSource TemplatedParent}}"
 							Height="3" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -584,18 +584,23 @@
 									<ColumnDefinition Width="*"/>
 									<ColumnDefinition Width="Auto"/>
 								</Grid.ColumnDefinitions>
-								<local:ShadeEditorControl
-									x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
-									Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
+								<local:ShadeEditorControl x:Name="shadeChooser"
+									Shade="{Binding Path=Solid.Shade, Mode=TwoWay}"
+									HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
+									Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+									Margin="0,6,0,1" Panel.ZIndex="1"/>
 								<local:HueEditorControl
 									x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
 									Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
 								<local:CurrentColorEditorControl
-									Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
-									Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
+									Color="{Binding Path=Solid.Color, Mode=TwoWay}"
+									InitialColor="{Binding Solid.InitialColor}"
+									LastColor="{Binding Solid.LastColor}"
+									Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20"
+									Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
 							</Grid>
 							<local:ColorComponentsEditorControl x:Name="componentEditor"
-								Color="{Binding Path=Solid.Shade, Mode=TwoWay}"
+								Color="{Binding Path=Solid.Color, Mode=TwoWay}"
 								HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
 								Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"
 								VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,4,0,0" Focusable="False"/>
@@ -739,7 +744,8 @@
 							<Label HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Column="0" Grid.Row="0" Margin="3,0,0,0">
 								<TextBlock TextDecorations="Underline" Text="{x:Static prop:Resources.HueInitial}"/>
 							</Label>
-							<local:ColorComponentBox x:Name="hueEntry" HorizontalAlignment="Stretch" VerticalAlignment="Center" Grid.Column="1" Grid.Row="0"
+							<local:ColorComponentBox x:Name="hueEntry"
+								HorizontalAlignment="Stretch" VerticalAlignment="Center" Grid.Column="1" Grid.Row="0"
 								AutomationProperties.Name="{x:Static prop:Resources.Hue}" AutomationProperties.HelpText="{x:Static prop:Resources.Hue}" ToolTip="{x:Static prop:Resources.Hue}"
 								Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Hue, Mode=TwoWay}" Unit="°">
 								<local:ColorComponentBox.GradientBrush>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -445,6 +445,16 @@
 		</StackPanel>
 	</DataTemplate>
 
+	<Style x:Key="BrushBoxFocusVisual">
+		<Setter Property="Control.Template">
+			<Setter.Value>
+				<ControlTemplate>
+					<Rectangle StrokeThickness="1" Margin="0" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeDashArray="1 2" SnapsToDevicePixels="true"/>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
 	<Style TargetType="local:BrushEditorControl">
 		<Setter Property="Template">
 			<Setter.Value>
@@ -454,16 +464,21 @@
 											   HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="0" Grid.Column="0"
 											   Height="24" BorderThickness="1" BorderBrush="{DynamicResource InputBorderBrush}"/>
 						<ToggleButton x:Name="brushBoxButton" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="0" Grid.Column="0" BorderThickness="0" Background="Transparent" Opacity="0"
-									  IsEnabled="{TemplateBinding IsEnabled}"
+									  IsEnabled="{TemplateBinding IsEnabled}" FocusVisualStyle="{StaticResource BrushBoxFocusVisual}"
 									  IsHitTestVisible="{Binding ElementName=brushBoxPopup, Path=IsOpen, Mode=OneWay, Converter={StaticResource OppositeBoolConverter}}"
 									  AutomationProperties.Name="{Binding Property.Name,Mode=OneTime}"/>
-						<Popup x:Name="brushBoxPopup" StaysOpen="False" MinWidth="350" Width="{TemplateBinding ActualWidth}" Placement="Bottom" PopupAnimation="Slide" AllowsTransparency="True"
+						<Popup x:Name="brushBoxPopup" StaysOpen="False" MaxWidth="300" Width="300" PopupAnimation="Slide" AllowsTransparency="True" Placement="Custom"
 							   IsOpen="{Binding ElementName=brushBoxButton, Path=IsChecked}">
-							<Grid>
-								<Rectangle VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.Column="0" Grid.Row="0"
-										   Fill="{DynamicResource MenuPopupBackgroundBrush}" Stroke="{DynamicResource MenuPopupBorderBrush}"/>
-								<local:BrushTabbedEditorControl Grid.Column="0" Grid.Row="0"/>
-							</Grid>
+								<Border Margin="0,0,5,5" Background="{DynamicResource PopupDropShadowColor}" BorderThickness="1">
+									<Border.Effect>
+										<DropShadowEffect BlurRadius="5" ShadowDepth="2" Opacity="0.6"/>
+									</Border.Effect>
+									<Grid>
+										<Rectangle VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.Column="0" Grid.Row="0"
+											   Fill="{DynamicResource MenuPopupBackgroundBrush}" Stroke="{DynamicResource MenuPopupBorderBrush}"/>
+										<local:BrushTabbedEditorControl Grid.Column="0" Grid.Row="0"/>
+									</Grid>
+							</Border>
 						</Popup>
 					</Grid>
 				</ControlTemplate>
@@ -499,7 +514,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="local:BrushTabbedEditorControl">
 					<StackPanel>
-						<Border Padding="8,10">
+						<Border Padding="8,10,8,4">
 							<StackPanel>
 								<local:ChoiceControl x:Name="brushChoice" ItemTemplateSelector="{StaticResource BrushChoiceTemplateSelector}" ItemTemplate="{x:Null}" HorizontalAlignment="Stretch">
 									<local:ChoiceItem Value="{x:Static local:BrushTabbedEditorControl.None}" Name="noBrushTab" Tooltip="{x:Static prop:Resources.NoBrush}"/>
@@ -554,7 +569,7 @@
 									<RowDefinition Height="*"/>
 								</Grid.RowDefinitions>
 								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" MinWidth="200"/>
+									<ColumnDefinition Width="*" MinWidth="150"/>
 									<ColumnDefinition Width="Auto"/>
 								</Grid.ColumnDefinitions>
 								<local:PropertyPresenter Label="{x:Static prop:Resources.ColorSpace}" Grid.ColumnSpan="2" Grid.Row="0" Grid.Column="0">
@@ -1148,15 +1163,15 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type TabItem}">
-					<Border x:Name="grid" Background="{DynamicResource PanelBackgroundBrush}" BorderThickness="0" Padding="0,0,4,0">
+					<Border x:Name="grid" Background="{DynamicResource PanelBackgroundBrush}" BorderThickness="0" Padding="4">
 						<ContentPresenter x:Name="tabContent" ContentSource="Header"/>
 					</Border>
 					<ControlTemplate.Triggers>
 						<Trigger Property="IsSelected" Value="True">
-							<Setter TargetName="grid" Property="Background" Value="Transparent"/>
+							<Setter TargetName="grid" Property="Background" Value="{DynamicResource SelectedTabBackgroundBrush}"/>
 						</Trigger>
 						<Trigger Property="IsSelected" Value="False">
-							<Setter TargetName="grid" Property="Background" Value="{DynamicResource PanelGroupSecondaryBackgroundBrush}"/>
+							<Setter TargetName="grid" Property="Background" Value="{DynamicResource TabBackgroundBrush}"/>
 						</Trigger>
 					</ControlTemplate.Triggers>
 				</ControlTemplate>
@@ -1176,7 +1191,7 @@
 							<RowDefinition Height="*" />
 						</Grid.RowDefinitions>
 						<TabPanel IsItemsHost="True" Grid.Row="0" Panel.ZIndex="1" />
-						<Border Grid.Row="1" Panel.ZIndex="0" BorderThickness="0" Background="Transparent">
+						<Border Grid.Row="1" Panel.ZIndex="0" BorderThickness="0" Background="{DynamicResource SelectedTabBackgroundBrush}" Padding="4">
 							<ContentPresenter ContentSource="SelectedContent" />
 						</Border>
 					</Grid>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -563,46 +563,45 @@
 							<TabItem.Header>
 								<local:PropertyPresenter Label="{x:Static prop:Resources.ColorEditorTabLabel}"/>
 							</TabItem.Header>
-							<Grid VerticalAlignment="Top" Margin="0,6,0,0" MinHeight="180">
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="*"/>
-								</Grid.RowDefinitions>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" MinWidth="150"/>
-									<ColumnDefinition Width="Auto"/>
-								</Grid.ColumnDefinitions>
-								<local:PropertyPresenter Label="{x:Static prop:Resources.ColorSpace}" Grid.ColumnSpan="2" Grid.Row="0" Grid.Column="0">
+							<StackPanel Orientation="Vertical">
+								<local:PropertyPresenter x:Name="colorSpacePresenter" Label="{x:Static prop:Resources.ColorSpace}">
 									<ComboBox
 										Name="colorSpacePicker" ItemsSource="{Binding Solid.ColorSpaces}"
 										SelectedItem="{Binding Solid.ColorSpace, Mode=OneTime}" VerticalContentAlignment="Center"
-										AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}" AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
+										AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}"
+										AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
 								</local:PropertyPresenter>
-								<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-									<Grid.RowDefinitions>
-										<RowDefinition Height="*"/>
-										<RowDefinition Height="Auto"/>
-									</Grid.RowDefinitions>
+								<Grid VerticalAlignment="Top" Margin="0,6,0,0" MinHeight="180">
 									<Grid.ColumnDefinitions>
-										<ColumnDefinition Width="*"/>
+										<ColumnDefinition Width="*" MinWidth="150"/>
 										<ColumnDefinition Width="Auto"/>
 									</Grid.ColumnDefinitions>
-									<local:ShadeEditorControl
-										x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
-										Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
-									<local:HueEditorControl
-										x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
-										Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
-									<local:CurrentColorEditorControl
-										Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
-										 Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
+									<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+										<Grid.RowDefinitions>
+											<RowDefinition Height="*"/>
+											<RowDefinition Height="Auto"/>
+										</Grid.RowDefinitions>
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="*"/>
+											<ColumnDefinition Width="Auto"/>
+										</Grid.ColumnDefinitions>
+										<local:ShadeEditorControl
+											x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
+											Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
+										<local:HueEditorControl
+											x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
+											Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
+										<local:CurrentColorEditorControl
+											Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
+											Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
+									</Grid>
 									<local:ColorComponentsEditorControl x:Name="componentEditor"
 										Color="{Binding Path=Solid.Shade, Mode=TwoWay}"
 										HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
 										Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"
 										VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,4,0,0" Focusable="False"/>
 								</Grid>
-							</Grid>
+							</StackPanel>
 						</TabItem>
 						<!--<TabItem>
 							<TabItem.Header>
@@ -610,6 +609,11 @@
 							</TabItem.Header>
 						</TabItem>-->
 					</TabControl>
+					<ControlTemplate.Triggers>
+						<DataTrigger Binding="{Binding Solid.ColorSpaces}" Value="{x:Null}">
+							<Setter TargetName="colorSpacePresenter" Property="Visibility" Value="Collapsed"/>
+						</DataTrigger>
+					</ControlTemplate.Triggers>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -543,39 +543,55 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="local:SolidBrushEditorControl">
-					<Grid VerticalAlignment="Top" Margin="0,6,0,0" MinHeight="180">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="*"/>
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*" MinWidth="200"/>
-							<ColumnDefinition Width="Auto"/>
-						</Grid.ColumnDefinitions>
-						<local:PropertyPresenter Label="{x:Static prop:Resources.ColorSpace}" Grid.ColumnSpan="2" Grid.Row="0" Grid.Column="0">
-							<ComboBox Name="colorSpacePicker" ItemsSource="{Binding Solid.ColorSpaces}"
-								  SelectedItem="{Binding Solid.ColorSpace, Mode=OneTime}" VerticalContentAlignment="Center"
-								  AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}" AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
-						</local:PropertyPresenter>
-						<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-							<Grid.RowDefinitions>
-								<RowDefinition Height="*"/>
-								<RowDefinition Height="Auto"/>
-							</Grid.RowDefinitions>
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="*"/>
-								<ColumnDefinition Width="Auto"/>
-							</Grid.ColumnDefinitions>
-							<local:ShadeEditorControl x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
-													  Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
-							<local:HueEditorControl x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
-													Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
-							<local:CurrentColorEditorControl Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
-															 Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
-						</Grid>
-						<local:ColorComponentsEditorControl x:Name="componentEditor" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" Margin="0,4,0,0"
+					<TabControl Margin="0,4,0,0">
+						<TabItem>
+							<TabItem.Header>
+								<local:PropertyPresenter Label="{x:Static prop:Resources.ColorEditorTabLabel}"/>
+							</TabItem.Header>
+							<Grid VerticalAlignment="Top" Margin="0,6,0,0" MinHeight="180">
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto"/>
+									<RowDefinition Height="*"/>
+								</Grid.RowDefinitions>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="*" MinWidth="200"/>
+									<ColumnDefinition Width="Auto"/>
+								</Grid.ColumnDefinitions>
+								<local:PropertyPresenter Label="{x:Static prop:Resources.ColorSpace}" Grid.ColumnSpan="2" Grid.Row="0" Grid.Column="0">
+									<ComboBox
+										Name="colorSpacePicker" ItemsSource="{Binding Solid.ColorSpaces}"
+										SelectedItem="{Binding Solid.ColorSpace, Mode=OneTime}" VerticalContentAlignment="Center"
+										AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}" AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
+								</local:PropertyPresenter>
+								<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+									<Grid.RowDefinitions>
+										<RowDefinition Height="*"/>
+										<RowDefinition Height="Auto"/>
+									</Grid.RowDefinitions>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*"/>
+										<ColumnDefinition Width="Auto"/>
+									</Grid.ColumnDefinitions>
+									<local:ShadeEditorControl
+										x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
+										Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
+									<local:HueEditorControl
+										x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
+										Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
+									<local:CurrentColorEditorControl
+										Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
+										 Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
+								</Grid>
+								<local:ColorComponentsEditorControl x:Name="componentEditor" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" Margin="0,4,0,0"
 															Grid.Column="1" Grid.Row="1" Grid.RowSpan="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Focusable="False"/>
-					</Grid>
+							</Grid>
+						</TabItem>
+						<!--<TabItem>
+							<TabItem.Header>
+								<Label>Color Resources</Label>
+							</TabItem.Header>
+						</TabItem>-->
+					</TabControl>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
@@ -1022,11 +1038,11 @@
 							   BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}" BorderBrush="{Binding BorderBrush, RelativeSource={RelativeSource TemplatedParent}}"
 							   Grid.Column="0" Grid.Row="0" Height="{Binding Height, RelativeSource={RelativeSource TemplatedParent}}" Padding="0"/>
 						<Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-								   Stroke="{Binding BorderBrush, RelativeSource={RelativeSource TemplatedParent}}" StrokeThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}"
+								   Stroke="{Binding BorderBrush, RelativeSource={RelativeSource TemplatedParent}}" StrokeThickness="1"
 								   Grid.Column="0" Grid.Row="0" Panel.ZIndex="0" Visibility="{Binding BrushVisible, RelativeSource={RelativeSource TemplatedParent}}"
 								   Fill="{StaticResource CheckerBoard}" Height="{Binding Height, RelativeSource={RelativeSource TemplatedParent}}"/>
 						<Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Column="0" Grid.Row="0" Panel.ZIndex="1"
-								   Stroke="{Binding BorderBrush, RelativeSource={RelativeSource TemplatedParent}}" StrokeThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}"
+								   Stroke="{Binding BorderBrush, RelativeSource={RelativeSource TemplatedParent}}" StrokeThickness="1"
 								   Fill="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Brush}" Visibility="{TemplateBinding BrushVisible}"
 								   Height="{Binding Height, RelativeSource={RelativeSource TemplatedParent}}"/>
 					</Grid>
@@ -1126,14 +1142,47 @@
 		</ControlTemplate.Triggers>
 	</ControlTemplate>
 
-	<Style TargetType="TabControl">
-		<Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}"/>
+	<Style TargetType="{x:Type TabItem}">
 		<Setter Property="Foreground" Value="{DynamicResource PanelForegroundBrush}"/>
+		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type TabItem}">
+					<Border x:Name="grid" Background="{DynamicResource PanelBackgroundBrush}" BorderThickness="0" Padding="0,0,4,0">
+						<ContentPresenter x:Name="tabContent" ContentSource="Header"/>
+					</Border>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsSelected" Value="True">
+							<Setter TargetName="grid" Property="Background" Value="Transparent"/>
+						</Trigger>
+						<Trigger Property="IsSelected" Value="False">
+							<Setter TargetName="grid" Property="Background" Value="{DynamicResource PanelGroupSecondaryBackgroundBrush}"/>
+						</Trigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
 	</Style>
-
-	<Style TargetType="TabItem">
-		<Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}"/>
+	
+	<Style TargetType="{x:Type TabControl}">
 		<Setter Property="Foreground" Value="{DynamicResource PanelForegroundBrush}"/>
+		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TabControl">
+					<Grid UseLayoutRounding="True">
+						<Grid.RowDefinitions>
+							<RowDefinition />
+							<RowDefinition Height="*" />
+						</Grid.RowDefinitions>
+						<TabPanel IsItemsHost="True" Grid.Row="0" Panel.ZIndex="1" />
+						<Border Grid.Row="1" Panel.ZIndex="0" BorderThickness="0" Background="Transparent">
+							<ContentPresenter ContentSource="SelectedContent" />
+						</Border>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
 	</Style>
 
 	<Style TargetType="Label">

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -964,7 +964,7 @@
 						
 						<local:TextBoxEx x:Name="hexEntry" HorizontalContentAlignment="Left" HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="77" Grid.Column="0" Grid.Row="2"
 							AutomationProperties.Name="{x:Static prop:Resources.HexValue}" AutomationProperties.HelpText="{x:Static prop:Resources.HexValue}" ToolTip="{x:Static prop:Resources.HexValue}"
-							Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Color, Converter={local:HexColorConverter}, Mode=TwoWay}"/>
+							Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Color, Converter={local:HexColorConverter}, Mode=TwoWay}" FocusSelectsAll="True"/>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -974,11 +974,12 @@
 	<Style TargetType="local:ColorComponentBox">
 		<Setter Property="KeyboardNavigation.TabNavigation" Value="Continue"/>
 		<Setter Property="IsTabStop" Value="False"/>
+		<Setter Property="FocusVisualStyle" Value="{x:Null}"/>
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="local:ColorComponentBox">
 					<Grid>
-						<local:TextBoxEx x:Name="innerTextBox" VerticalContentAlignment="Center"
+						<local:TextBoxEx x:Name="innerTextBox" FocusSelectsAll="True" VerticalContentAlignment="Center"
 								 BitmapEffect="{TemplateBinding BitmapEffect}" BitmapEffectInput="{TemplateBinding BitmapEffectInput}"
 								 CacheMode="{TemplateBinding CacheMode}" Clip="{TemplateBinding Clip}" ClipToBounds="{TemplateBinding ClipToBounds}" ContextMenu="{TemplateBinding ContextMenu}"
 								 Cursor="{TemplateBinding Cursor}" DataContext="{TemplateBinding DataContext}" FlowDirection="{TemplateBinding FlowDirection}"
@@ -1005,6 +1006,7 @@
 					<ControlTemplate.Triggers>
 						<DataTrigger Binding="{Binding IsKeyboardFocusWithin, ElementName=innerTextBox}" Value="True">
 							<Setter TargetName="innerTextBox" Property="Text" Value="{Binding Path=Value, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, StringFormat={}{0:##0.#}}"/>
+							<Setter TargetName="brushBoxControl" Property="Visibility" Value="Hidden"/>
 						</DataTrigger>
 						<DataTrigger Binding="{Binding IsFocused, ElementName=innerTextBox}" Value="True">
 							<Setter TargetName="innerTextBox" Property="Text" Value="{Binding Path=Value, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, StringFormat={}{0:##0.#}}"/>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -596,9 +596,12 @@
 									<local:CurrentColorEditorControl
 										Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
 										 Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
+									<local:ColorComponentsEditorControl x:Name="componentEditor"
+										Color="{Binding Path=Solid.Shade, Mode=TwoWay}"
+										HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
+										Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"
+										VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,4,0,0" Focusable="False"/>
 								</Grid>
-								<local:ColorComponentsEditorControl x:Name="componentEditor" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" Margin="0,4,0,0"
-															Grid.Column="1" Grid.Row="1" Grid.RowSpan="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Focusable="False"/>
 							</Grid>
 						</TabItem>
 						<!--<TabItem>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -527,8 +527,8 @@
 							<Expander Name="advancedPropertyPanel" Template="{DynamicResource AdvancedPropertiesExpander}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
 								  Background="{DynamicResource PanelGroupSecondaryBackgroundBrush}" Foreground="{DynamicResource PanelForegroundBrush}">
 								<Expander.Content>
-									<Border Padding="19,6,0,6" Background="{DynamicResource PanelGroupSecondaryBackgroundBrush}">
-										<local:PropertyPresenter Label="{x:Static prop:Resources.Opacity}">
+									<Border Padding="19,6,6,6" Background="{DynamicResource PanelGroupSecondaryBackgroundBrush}">
+										<local:PropertyPresenter Label="{x:Static prop:Resources.Opacity}" ShowPropertyButton="False">
 											<local:ColorComponentBox
 												Value="{Binding Path=Opacity, Converter={local:DoubleToPercentageConverter}, Mode=TwoWay}" Unit="%"
 												ToolTip="{x:Static prop:Resources.Opacity}" AutomationProperties.Name="{x:Static prop:Resources.Opacity}" AutomationProperties.HelpText="{x:Static prop:Resources.Opacity}"
@@ -558,57 +558,56 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="local:SolidBrushEditorControl">
-					<TabControl Margin="0,4,0,0">
+					<!--<TabControl Margin="0,4,0,0">
 						<TabItem>
 							<TabItem.Header>
 								<local:PropertyPresenter Label="{x:Static prop:Resources.ColorEditorTabLabel}"/>
-							</TabItem.Header>
-							<StackPanel Orientation="Vertical">
-								<local:PropertyPresenter x:Name="colorSpacePresenter" Label="{x:Static prop:Resources.ColorSpace}">
-									<ComboBox
-										Name="colorSpacePicker" ItemsSource="{Binding Solid.ColorSpaces}"
-										SelectedItem="{Binding Solid.ColorSpace, Mode=OneTime}" VerticalContentAlignment="Center"
-										AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}"
-										AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
-								</local:PropertyPresenter>
-								<Grid VerticalAlignment="Top" Margin="0,6,0,0" MinHeight="180">
-									<Grid.ColumnDefinitions>
-										<ColumnDefinition Width="*" MinWidth="150"/>
-										<ColumnDefinition Width="Auto"/>
-									</Grid.ColumnDefinitions>
-									<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-										<Grid.RowDefinitions>
-											<RowDefinition Height="*"/>
-											<RowDefinition Height="Auto"/>
-										</Grid.RowDefinitions>
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="*"/>
-											<ColumnDefinition Width="Auto"/>
-										</Grid.ColumnDefinitions>
-										<local:ShadeEditorControl
-											x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
-											Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
-										<local:HueEditorControl
-											x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
-											Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
-										<local:CurrentColorEditorControl
-											Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
-											Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
-									</Grid>
-									<local:ColorComponentsEditorControl x:Name="componentEditor"
-										Color="{Binding Path=Solid.Shade, Mode=TwoWay}"
-										HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
-										Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"
-										VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,4,0,0" Focusable="False"/>
-								</Grid>
-							</StackPanel>
-						</TabItem>
-						<!--<TabItem>
+							</TabItem.Header>-->
+					<StackPanel Orientation="Vertical">
+						<local:PropertyPresenter x:Name="colorSpacePresenter" Label="{x:Static prop:Resources.ColorSpace}" ShowPropertyButton="false">
+							<ComboBox Name="colorSpacePicker" ItemsSource="{Binding Solid.ColorSpaces}"
+								SelectedItem="{Binding Solid.ColorSpace, Mode=OneTime}" VerticalContentAlignment="Center"
+								AutomationProperties.Name="{x:Static prop:Resources.ColorSpace}"
+								AutomationProperties.HelpText="{x:Static prop:Resources.ColorSpace}" ToolTip="{x:Static prop:Resources.ColorSpace}"/>
+						</local:PropertyPresenter>
+						<Grid VerticalAlignment="Top" Margin="0,6,0,0" MinHeight="180">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" MinWidth="150"/>
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
+							<Grid Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+								<Grid.RowDefinitions>
+									<RowDefinition Height="*"/>
+									<RowDefinition Height="Auto"/>
+								</Grid.RowDefinitions>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="*"/>
+									<ColumnDefinition Width="Auto"/>
+								</Grid.ColumnDefinitions>
+								<local:ShadeEditorControl
+									x:Name="shadeChooser" Color="{Binding Path=Solid.Shade, Mode=TwoWay}" HueColor="{Binding Path=Solid.HueColor, Mode=OneWay}"
+									Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,6,0,1" Panel.ZIndex="1"/>
+								<local:HueEditorControl
+									x:Name="hueChooser" HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
+									Grid.Column="1" Grid.ColumnSpan="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1,6,3,1" Panel.ZIndex="0" Focusable="False"/>
+								<local:CurrentColorEditorControl
+									Color="{Binding Path=Solid.Shade, Mode=TwoWay}" InitialColor="{Binding Solid.InitialColor}" LastColor="{Binding Solid.LastColor}"
+									Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" Height="20" Margin="0,0,0,0" Panel.ZIndex="0" Focusable="False"/>
+							</Grid>
+							<local:ColorComponentsEditorControl x:Name="componentEditor"
+								Color="{Binding Path=Solid.Shade, Mode=TwoWay}"
+								HueColor="{Binding Path=Solid.HueColor, Mode=TwoWay}"
+								Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"
+								VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="0,4,0,0" Focusable="False"/>
+						</Grid>
+					</StackPanel>
+						<!--</TabItem>
+						<TabItem>
 							<TabItem.Header>
 								<Label>Color Resources</Label>
 							</TabItem.Header>
-						</TabItem>-->
-					</TabControl>
+						</TabItem>
+					</TabControl>-->
 					<ControlTemplate.Triggers>
 						<DataTrigger Binding="{Binding Solid.ColorSpaces}" Value="{x:Null}">
 							<Setter TargetName="colorSpacePresenter" Property="Visibility" Value="Collapsed"/>
@@ -1118,6 +1117,9 @@
 						<Trigger Property="Label" Value="{x:Null}">
 							<Setter TargetName="labelColumn" Property="MinWidth" Value="0" />
 							<Setter TargetName="labelColumn" Property="Width" Value="0" />
+							<Setter TargetName="propertyButtonColumn" Property="Width" Value="0" />
+						</Trigger>
+						<Trigger Property="ShowPropertyButton" Value="False">
 							<Setter TargetName="propertyButtonColumn" Property="Width" Value="0" />
 						</Trigger>
 					</ControlTemplate.Triggers>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
@@ -10,12 +10,15 @@
 	<SolidColorBrush x:Key="PanelGroupSecondaryDimmedForegroundBrush">#F1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="PanelHeaderBackgroundBrush">#252526</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertiesPanelIconBackgroundBrush">#252526</SolidColorBrush>
+	<SolidColorBrush x:Key="PopupDropShadowColor">#FFFFFFFF</SolidColorBrush>
 
 	<SolidColorBrush x:Key="AdvancedExpanderCollapsedForegroundBrush">#F1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverForegroundBrush">#007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBorderBrush">#3E3E40</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBackgroundBrush">#3E3E40</SolidColorBrush>
 
+	<SolidColorBrush x:Key="TabBackgroundBrush">#252526</SolidColorBrush>
+	<SolidColorBrush x:Key="SelectedTabBackgroundBrush">#1B1B1C</SolidColorBrush>
 	<SolidColorBrush x:Key="ToggleItemOuterBorderBrush" Color="#3F3F46" />
 	<SolidColorBrush x:Key="ToggleItemMouseOverBackgroundBrush" Color="#3E3E40"/>
 	<SolidColorBrush x:Key="ToggleItemMouseOverBorderBrush" Color="#3E3E40"/>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
@@ -17,8 +17,6 @@
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBorderBrush">#3E3E40</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBackgroundBrush">#3E3E40</SolidColorBrush>
 
-	<SolidColorBrush x:Key="TabBackgroundBrush">#252526</SolidColorBrush>
-	<SolidColorBrush x:Key="SelectedTabBackgroundBrush">#1B1B1C</SolidColorBrush>
 	<SolidColorBrush x:Key="ToggleItemOuterBorderBrush" Color="#3F3F46" />
 	<SolidColorBrush x:Key="ToggleItemMouseOverBackgroundBrush" Color="#3E3E40"/>
 	<SolidColorBrush x:Key="ToggleItemMouseOverBorderBrush" Color="#3E3E40"/>
@@ -79,20 +77,8 @@
 	<SolidColorBrush x:Key="PopupForegroundBrush">#FFF1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="PopupBorderBrush">#FF333337</SolidColorBrush>
 
-	<SolidColorBrush x:Key="LabelForegroundBrush">#F1F1F1</SolidColorBrush>
-
-	<SolidColorBrush x:Key="MenuItemForegroundBrush">#F1F1F1</SolidColorBrush>
-
 	<SolidColorBrush x:Key="ThicknessIconBackgroundBrush">#292929</SolidColorBrush>
 	<SolidColorBrush x:Key="ThicknessIconBorderBrush">#292929</SolidColorBrush>
-
-	<Color x:Key="ShadePickerCursorStrokeColor">#000000</Color>
-	<Color x:Key="ShadePickerCursorOutlineColor">#FFFFFF</Color>
-
-	<SolidColorBrush x:Key="HuePickerCursorBrush">#000000</SolidColorBrush>
-
-	<SolidColorBrush x:Key="BrushBoxCheckerBoardLight">#FFFFFF</SolidColorBrush>
-	<SolidColorBrush x:Key="BrushBoxCheckerBoardDark">#D3D3D3</SolidColorBrush>
 
 	<SolidColorBrush x:Key="DialogBackgroundBrush">#FF2D2D30</SolidColorBrush>
 	<SolidColorBrush x:Key="DialogForegroundBrush">#FFF1F1F1</SolidColorBrush>
@@ -103,8 +89,6 @@
 	<SolidColorBrush x:Key="IconButtonForegroundBrush">#FFF1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="IconButtonMouseOverForegroundBrush">#FF007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="IconButtonPressedForegroundBrush">#FFFFFFFF</SolidColorBrush>
-
-	<SolidColorBrush x:Key="VectorGlyphBrush">#C5C5C5</SolidColorBrush>
 
 	<SolidColorBrush x:Key="CategoryExpanderBorderBrush" Color="#333333" />
 

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
@@ -11,12 +11,14 @@
 	<SolidColorBrush x:Key="PanelGroupSecondaryDimmedForegroundBrush">#FF1E1E1E</SolidColorBrush>
 	<SolidColorBrush x:Key="PanelHeaderBackgroundBrush">#F5F5F5</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertiesPanelIconBackgroundBrush">#F5F5F5</SolidColorBrush>
+	<SolidColorBrush x:Key="PopupDropShadowColor">#FFFFFFFF</SolidColorBrush>
 
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverForegroundBrush">#007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBorderBrush">#C9DEF5</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBackgroundBruszh">#C9DEF5</SolidColorBrush>
 	
-	<SolidColorBrush x:Key="TabBackgroundBrush">#E7E8EC</SolidColorBrush>
+	<SolidColorBrush x:Key="TabBackgroundBrush">#F5F5F5</SolidColorBrush>
+	<SolidColorBrush x:Key="SelectedTabBackgroundBrush">#E7E8EC</SolidColorBrush>
 	<SolidColorBrush x:Key="SelectorBackgroundBrush">#FFFFFF</SolidColorBrush>
 	<SolidColorBrush x:Key="CategoryExpanderBorderBrush">#E9E9E9</SolidColorBrush>
 

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
@@ -15,10 +15,8 @@
 
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverForegroundBrush">#007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBorderBrush">#C9DEF5</SolidColorBrush>
-	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBackgroundBruszh">#C9DEF5</SolidColorBrush>
+	<SolidColorBrush x:Key="AdvancedExpanderMouseOverBackgroundBrush">#C9DEF5</SolidColorBrush>
 	
-	<SolidColorBrush x:Key="TabBackgroundBrush">#F5F5F5</SolidColorBrush>
-	<SolidColorBrush x:Key="SelectedTabBackgroundBrush">#E7E8EC</SolidColorBrush>
 	<SolidColorBrush x:Key="SelectorBackgroundBrush">#FFFFFF</SolidColorBrush>
 	<SolidColorBrush x:Key="CategoryExpanderBorderBrush">#E9E9E9</SolidColorBrush>
 
@@ -82,20 +80,8 @@
 	<SolidColorBrush x:Key="PopupForegroundBrush">#FF1E1E1E</SolidColorBrush>
 	<SolidColorBrush x:Key="PopupBorderBrush">#FFCCCEDB</SolidColorBrush>
 
-	<SolidColorBrush x:Key="LabelForegroundBrush">#1E1E1E</SolidColorBrush>
-
-	<SolidColorBrush x:Key="MenuItemForegroundBrush">#1E1E1E</SolidColorBrush>
-
 	<SolidColorBrush x:Key="ThicknessIconBackgroundBrush">#EEEEF2</SolidColorBrush>
 	<SolidColorBrush x:Key="ThicknessIconBorderBrush">#EEEEF2</SolidColorBrush>
-
-	<Color x:Key="ShadePickerCursorStrokeColor">#000000</Color>
-	<Color x:Key="ShadePickerCursorOutlineColor">#FFFFFF</Color>
-
-	<SolidColorBrush x:Key="HuePickerCursorBrush">#000000</SolidColorBrush>
-
-	<SolidColorBrush x:Key="BrushBoxCheckerBoardLight">#FFFFFF</SolidColorBrush>
-	<SolidColorBrush x:Key="BrushBoxCheckerBoardDark">#D3D3D3</SolidColorBrush>
 
 	<SolidColorBrush x:Key="DialogBackgroundBrush">#FFEEEEF2</SolidColorBrush>
 	<SolidColorBrush x:Key="DialogBorderBrush">#FF595959</SolidColorBrush>
@@ -106,7 +92,6 @@
 	<SolidColorBrush x:Key="IconButtonMouseOverForegroundBrush">#FF1E1E1E</SolidColorBrush>
 	<SolidColorBrush x:Key="IconButtonPressedForegroundBrush">#FFFFFFFF</SolidColorBrush>
 
-	<SolidColorBrush x:Key="VectorGlyphBrush">#424242</SolidColorBrush>
 	<SolidColorBrush x:Key="ComboBoxBackgroundBrush">#FFFFFFFF</SolidColorBrush>
 	<SolidColorBrush x:Key="ComboBoxBorderBrush">#FFCCCEDB</SolidColorBrush>
 	<SolidColorBrush x:Key="ComboBoxForegroundBrush">#FF1E1E1E</SolidColorBrush>

--- a/Xamarin.PropertyEditing/BrushPropertyInfo.cs
+++ b/Xamarin.PropertyEditing/BrushPropertyInfo.cs
@@ -7,7 +7,7 @@ namespace Xamarin.PropertyEditing
 	public class BrushPropertyInfo : IPropertyInfo, IColorSpaced
 	{
 		public BrushPropertyInfo (string name, string category, bool canWrite,
-			IReadOnlyList<string> colorSpaces = null, ValueSources valueSources = ValueSources.Local,
+			IReadOnlyList<string> colorSpaces = null, ValueSources valueSources = ValueSources.Local | ValueSources.Default,
 			IReadOnlyList<PropertyVariation> variations = null,
 			IReadOnlyList<IAvailabilityConstraint> availabilityConstraints = null)
 		{

--- a/Xamarin.PropertyEditing/Drawing/CommonColor.cs
+++ b/Xamarin.PropertyEditing/Drawing/CommonColor.cs
@@ -479,8 +479,8 @@ namespace Xamarin.PropertyEditing.Drawing
 		public override bool Equals (object obj)
 		{
 			if (obj == null) return false;
-			if (!(obj is CommonThickness)) return false;
-			return base.Equals ((CommonThickness)obj);
+			if (!(obj is CommonColor)) return false;
+			return base.Equals ((CommonColor)obj);
 		}
 
 		public bool Equals (CommonColor other)

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Editor.
+        /// </summary>
+        public static string ColorEditorTabLabel {
+            get {
+                return ResourceManager.GetString("ColorEditorTabLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Color space.
         /// </summary>
         public static string ColorSpace {

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -343,6 +343,9 @@
   <data name="CustomExpression" xml:space="preserve">
     <value>Custom expression</value>
   </data>
+  <data name="ColorEditorTabLabel" xml:space="preserve">
+    <value>Editor</value>
+  </data>
   <data name="SearchResourcesTitle" xml:space="preserve">
     <value>Search Resources</value>
   </data>

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -18,6 +18,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public SolidBrushViewModel Solid { get; }
 
+		// TODO: make this its own property view model so we can edit bindings, set to resources, etc.
 		public double Opacity {
 			get => Value == null ? 1.0 : Value.Opacity;
 			set {

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -45,9 +45,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		protected override async Task UpdateCurrentValueAsync ()
+		protected override void OnValueChanged ()
 		{
-			await base.UpdateCurrentValueAsync ();
+			base.OnValueChanged ();
 			OnPropertyChanged (nameof (Opacity));
 		}
 	}

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -48,6 +48,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 		protected override async Task UpdateCurrentValueAsync ()
 		{
 			await base.UpdateCurrentValueAsync ();
+			if (Solid != null) {
+				Solid.Reset();
+			}
 			OnPropertyChanged (nameof (Opacity));
 			OnPropertyChanged (nameof (Solid));
 		}

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -48,11 +48,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		protected override async Task UpdateCurrentValueAsync ()
 		{
 			await base.UpdateCurrentValueAsync ();
-			if (Solid != null) {
-				Solid.Reset();
-			}
 			OnPropertyChanged (nameof (Opacity));
-			OnPropertyChanged (nameof (Solid));
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -49,6 +49,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		{
 			await base.UpdateCurrentValueAsync ();
 			OnPropertyChanged (nameof (Opacity));
+			OnPropertyChanged (nameof (Solid));
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
@@ -18,6 +18,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public CommonSolidBrush PreviousSolidBrush { get; set; }
 
+		// TODO: make this its own property view model so we can edit bindings, set to resources, etc.
 		public string ColorSpace => Parent.Value is CommonSolidBrush solidBrush ? solidBrush.ColorSpace : null;
 
 		public CommonColor HueColor {
@@ -45,6 +46,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
+		// TODO: make this its own property view model so we can edit bindings, set to resources, etc.
 		public CommonColor Color {
 			get => Parent.Value is CommonSolidBrush solidBrush ? solidBrush.Color : new CommonColor (0, 0, 0);
 			set {

--- a/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
@@ -56,11 +56,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 					Parent.Value = new CommonSolidBrush (value, ColorSpace, Parent.Value.Opacity);
 					OnPropertyChanged ();
 					if (!newHue.Equals (oldHue)) {
-						hueColor = newHue;
+						this.hueColor = newHue;
 						OnPropertyChanged (nameof (HueColor));
 					}
-					if (!value.Equals (shade)) {
-						shade = value;
+					if (!value.Equals (this.shade)) {
+						this.shade = value;
 						OnPropertyChanged (nameof (Shade));
 					}
 					if (!this.initialColor.HasValue) {

--- a/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
@@ -81,6 +81,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 			Parent.Value = new CommonSolidBrush (Color, ColorSpace, opacity);
 		}
 
+		public void CommitHue ()
+		{
+			this.hueColor = null;
+			OnPropertyChanged (nameof (HueColor));
+		}
+
 		private BrushPropertyViewModel Parent { get; }
 
 		private CommonColor? hueColor;

--- a/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
@@ -27,10 +27,15 @@ namespace Xamarin.PropertyEditing.ViewModels
 				if (!this.hueColor.Equals (value)) {
 					var saturation = Color.Saturation;
 					var brightness = Color.Brightness;
-					Color = CommonColor.FromHSB (value.Hue, saturation, brightness, Color.A);
+					// We should not update the color value on a hue change if the current color is unsaturated, as grey has no hue.
+					if (saturation != 0) {
+						Color = CommonColor.FromHSB (value.Hue, saturation, brightness, Color.A);
+					}
 					this.hueColor = value;
 					OnPropertyChanged ();
-					Parent.Value = new CommonSolidBrush (Color, ColorSpace, Parent.Value.Opacity);
+					if (saturation != 0) {
+						Parent.Value = new CommonSolidBrush (Color, ColorSpace, Parent.Value.Opacity);
+					}
 				}
 			}
 		}
@@ -76,6 +81,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public void CommitLastColor ()
 		{
+			if (this.lastColor == Color) return;
 			this.lastColor = Color;
 			this.shade = Color;
 			this.hueColor = Color.HueColor;

--- a/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SolidBrushViewModel.cs
@@ -41,7 +41,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		}
 
 		public CommonColor Shade {
-			get => (this.shade.HasValue ? this.shade : (this.shade = LastColor)).Value;
+			get => (this.shade ?? (this.shade = LastColor)).Value;
 			set {
 				if (!this.shade.Equals (value)) {
 					this.shade = value;
@@ -98,6 +98,17 @@ namespace Xamarin.PropertyEditing.ViewModels
 			var opacity = Parent.Value != null ? Parent.Value.Opacity : 1.0;
 			OnPropertyChanged (nameof (LastColor));
 			Parent.Value = new CommonSolidBrush (Shade, ColorSpace, opacity);
+		}
+
+		public void Reset()
+		{
+			this.hueColor = null;
+			this.shade = null;
+			this.lastColor = null;
+			OnPropertyChanged (nameof (Color));
+			OnPropertyChanged (nameof (LastColor));
+			OnPropertyChanged (nameof (HueColor));
+			OnPropertyChanged (nameof (Shade));
 		}
 
 		private BrushPropertyViewModel Parent { get; }


### PR DESCRIPTION
Solid brush editor moved to a tab in preparation for future color resource tab. Also put a property presenter around, and did the same to the color space drop-down.

Note: the view model is not 100% ready for bindings and resources on deep properties such as the opacity, color space, and solid brush color. This is known, so I added TODOs in there to that effect.