### PR TITLE
Replace strongly-typed resource usage with string.Format calls

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BaseNumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseNumericEditorControl.cs
@@ -69,7 +69,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateAccessibilityValues ()
 		{
 			NumericEditor.AccessibilityEnabled = NumericEditor.Enabled;
-			NumericEditor.AccessibilityTitle = Strings.AccessibilityNumeric (ViewModel.Property.Name);
+			NumericEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityNumeric, ViewModel.Property.Name);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -98,16 +98,16 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateAccessibilityValues ()
 		{
 			XEditor.AccessibilityEnabled = XEditor.Enabled;
-			XEditor.AccessibilityTitle = Strings.AccessibilityXEditor (ViewModel.Property.Name);
+			XEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityXEditor, ViewModel.Property.Name);
 
 			YEditor.AccessibilityEnabled = YEditor.Enabled;
-			YEditor.AccessibilityTitle = Strings.AccessibilityYEditor (ViewModel.Property.Name);
+			YEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityYEditor, ViewModel.Property.Name);
 
 			WidthEditor.AccessibilityEnabled = WidthEditor.Enabled;
-			WidthEditor.AccessibilityTitle = Strings.AccessibilityWidthEditor (ViewModel.Property.Name);
+			WidthEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityWidthEditor, ViewModel.Property.Name);
 
 			HeightEditor.AccessibilityEnabled = HeightEditor.Enabled;
-			HeightEditor.AccessibilityTitle = Strings.AccessibilityHeightEditor (ViewModel.Property.Name);
+			HeightEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityHeightEditor, ViewModel.Property.Name);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections;
-using System.Diagnostics;
 using AppKit;
-using Foundation;
-using ObjCRuntime;
 using Xamarin.PropertyEditing.Mac.Resources;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -79,7 +75,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateAccessibilityValues ()
 		{
 			BooleanEditor.AccessibilityEnabled = BooleanEditor.Enabled;
-			BooleanEditor.AccessibilityTitle = Strings.AccessibilityBoolean (ViewModel.Property.Name);
+			BooleanEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityBoolean, ViewModel.Property.Name);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CGPointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CGPointEditorControl.cs
@@ -39,10 +39,10 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateAccessibilityValues ()
 		{
 			XEditor.AccessibilityEnabled = XEditor.Enabled;
-			XEditor.AccessibilityTitle = Strings.AccessibilityXEditor (ViewModel.Property.Name);
+			XEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityXEditor, ViewModel.Property.Name);
 
 			YEditor.AccessibilityEnabled = YEditor.Enabled;
-			YEditor.AccessibilityTitle = Strings.AccessibilityYEditor (ViewModel.Property.Name);
+			YEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityYEditor, ViewModel.Property.Name);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CGSizeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CGSizeEditorControl.cs
@@ -39,10 +39,10 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateAccessibilityValues ()
 		{
 			XEditor.AccessibilityEnabled = XEditor.Enabled;
-			XEditor.AccessibilityTitle = Strings.AccessibilityWidthEditor (ViewModel.Property.Name);
+			XEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityWidthEditor, ViewModel.Property.Name);
 
 			YEditor.AccessibilityEnabled = YEditor.Enabled;
-			YEditor.AccessibilityTitle = Strings.AccessibilityHeightEditor (ViewModel.Property.Name);
+			YEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityHeightEditor, ViewModel.Property.Name);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
@@ -25,10 +25,10 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateAccessibilityValues ()
 		{
 			XEditor.AccessibilityEnabled = XEditor.Enabled;
-			XEditor.AccessibilityTitle = Strings.AccessibilityXEditor (ViewModel.Property.Name);
+			XEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityXEditor, ViewModel.Property.Name);
 
 			YEditor.AccessibilityEnabled = YEditor.Enabled;
-			YEditor.AccessibilityTitle = Strings.AccessibilityYEditor (ViewModel.Property.Name);
+			YEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityYEditor, ViewModel.Property.Name);
 		}
 	}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -146,10 +146,10 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			if (EditorViewModel.IsConstrainedToPredefined) {
 				popUpButton.AccessibilityEnabled = popUpButton.Enabled;
-				popUpButton.AccessibilityTitle = Strings.AccessibilityCombobox (ViewModel.Property.Name);
+				popUpButton.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityCombobox, ViewModel.Property.Name);
 			} else {
 				comboBox.AccessibilityEnabled = comboBox.Enabled;
-				comboBox.AccessibilityTitle = Strings.AccessibilityCombobox (ViewModel.Property.Name);
+				comboBox.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityCombobox, ViewModel.Property.Name);
 			}
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
@@ -24,8 +24,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void UpdateAccessibilityValues ()
 		{
-			XEditor.AccessibilityTitle = Strings.AccessibilityWidthEditor (ViewModel.Property.Name);
-			YEditor.AccessibilityTitle = Strings.AccessibilityHeightEditor (ViewModel.Property.Name);
+			XEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityWidthEditor, ViewModel.Property.Name);
+			YEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityHeightEditor, ViewModel.Property.Name);
 		}
 	}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -69,7 +69,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void UpdateAccessibilityValues ()
 		{
-			StringEditor.AccessibilityTitle = Strings.AccessibilityString (ViewModel.Property.Name);
+			StringEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityString, ViewModel.Property.Name);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -99,7 +99,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			propertyFilter = new NSSearchField (new CGRect (10, Frame.Height - 25, 170, 24)) {
 				TranslatesAutoresizingMaskIntoConstraints = false,
-				PlaceholderString = Strings.PropertyFilterLabel,
+				PlaceholderString = LocalizationResources.PropertyFilterLabel,
 				ControlSize = NSControlSize.Regular,
 			};
 			AddSubview (propertyFilter);
@@ -110,7 +110,7 @@ namespace Xamarin.PropertyEditing.Mac
 				TextColor = NSColor.Black,
 				Editable = false,
 				Bezeled = false,
-				StringValue = Strings.ArrangeByLabel,
+				StringValue = LocalizationResources.ArrangeByLabel,
 			};
 
 			propertyArrangeMode = new NSComboBox (new CGRect (320, Frame.Height - 25, 153, 24)) {

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -109,5 +109,4 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
-  <Import Project="..\packages\netfx-System.StringResources.3.0.14\build\netfx-System.StringResources.targets" Condition="Exists('..\packages\netfx-System.StringResources.3.0.14\build\netfx-System.StringResources.targets')" />
 </Project>

--- a/Xamarin.PropertyEditing/ViewModels/EnumPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/EnumPropertyViewModel.cs
@@ -33,7 +33,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			{
 				TValue realValue;
 				if (!Enum.TryParse (value, out realValue)) {
-					SetError (Strings.UnableToParseValue (value));
+					SetError (string.Format (LocalizationResources.UnableToParseValue, value));
 					return;
 				}
 

--- a/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
@@ -35,7 +35,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				TValue realValue;
 				if (!this.predefinedValues.PredefinedValues.TryGetValue (value, out realValue)) {
 					if (this.predefinedValues.IsConstrainedToPredefined) {
-						SetError (Strings.InvalidValue (value)); 
+						SetError (string.Format (LocalizationResources.InvalidValue, value)); 
 						return;
 					}
 

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -145,5 +145,4 @@
     <Folder Include="Themes\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\netfx-System.StringResources.3.0.14\build\netfx-System.StringResources.targets" Condition="Exists('..\packages\netfx-System.StringResources.3.0.14\build\netfx-System.StringResources.targets')" />
 </Project>


### PR DESCRIPTION
This removes the requirement to use the netfx-System.StringResources package to codegen strongly-typed helpers, and fixes a build problem when the projects are included in other solutions. It is a workaround.