### PR TITLE
Windows category memory

### DIFF
--- a/Xamarin.PropertyEditing.Tests/ObservableLookupTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ObservableLookupTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+using System;
+using System.Collections.Specialized;
 using System.Linq;
 using NUnit.Framework;
 
@@ -66,6 +67,54 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (groupRemoved, Is.True);
 			Assert.That (grouping, Does.Not.Contains (value));
 			Assert.That (lookup, Does.Not.Contain (grouping));
+		}
+
+		[TestCase ("group")]
+		[TestCase (null)]
+		[Description ("If removing the last item from a group removes the group, adding a group with no items shouldn't add it")]
+		public void AddingEmptyElementsIsIgnored (string groupName)
+		{
+			var lookup = new ObservableLookup<string, string> ();
+			bool changed = false;
+			lookup.CollectionChanged += (sender, args) => {
+				changed = true;
+			};
+			lookup.Add (groupName, Enumerable.Empty<string> ());
+
+			Assert.That (lookup, Is.Empty);
+			Assert.That (changed, Is.False);
+		}
+
+		[TestCase ("group")]
+		[TestCase (null)]
+		[Description ("If removing the last item from a group removes the group, adding a group with no items shouldn't add it")]
+		public void AddingEmptyGroupingIsIgnored (string groupName)
+		{
+			var lookup = new ObservableLookup<string, string> ();
+			bool changed = false;
+			lookup.CollectionChanged += (sender, args) => {
+				changed = true;
+			};
+			lookup.Add (new ObservableGrouping<string, string> (groupName));
+
+			Assert.That (lookup, Is.Empty);
+			Assert.That (changed, Is.False);
+		}
+
+		[TestCase ("group")]
+		[TestCase (null)]
+		[Description ("If removing the last item from a group removes the group, adding a group with no items shouldn't add it")]
+		public void InsertingEmptyIsIgnored (string groupName)
+		{
+			var lookup = new ObservableLookup<string, string> ();
+			bool changed = false;
+			lookup.CollectionChanged += (sender, args) => {
+				changed = true;
+			};
+			lookup.Insert (0, new ObservableGrouping<string, string> (groupName));
+
+			Assert.That (lookup, Is.Empty);
+			Assert.That (changed, Is.False);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -422,6 +422,40 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
+		public async Task PropertyListIsFiltered ()
+		{
+			var provider = new ReflectionEditorProvider ();
+			var obj = new TestClassSub ();
+			var editor = await provider.GetObjectEditorAsync (obj);
+			Assume.That (editor.Properties.Count, Is.EqualTo (2));
+
+			var vm = new PanelViewModel (provider, TargetPlatform.Default);
+			Assume.That (vm.ArrangeMode, Is.EqualTo (PropertyArrangeMode.Name));
+			vm.SelectedObjects.Add (obj);
+
+			Assume.That (vm.ArrangedEditors, Is.Not.Empty);
+			Assume.That (vm.ArrangedEditors[0].Count, Is.EqualTo (2));
+
+			Assume.That (vm.IsFiltering, Is.False);
+			bool changed = false;
+			vm.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof(PanelViewModel.IsFiltering)) {
+					changed = true;
+				}
+			};
+
+			vm.FilterText = "sub";
+			Assume.That (vm.ArrangedEditors[0].Count, Is.EqualTo (1));
+			Assert.That (vm.IsFiltering, Is.True);
+			Assert.That (changed, Is.True);
+			changed = false;
+
+			vm.FilterText = null;
+			Assert.That (vm.IsFiltering, Is.False);
+			Assert.That (changed, Is.True);
+		}
+
+		[Test]
 		[Description ("When filtered Text is cleared then list is restored back to its original.")]
 		public async Task PropertyListFilteredTextClearedRestoresList ()
 		{

--- a/Xamarin.PropertyEditing.Windows/CategoryExpander.cs
+++ b/Xamarin.PropertyEditing.Windows/CategoryExpander.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal class CategoryExpander
+		: Expander
+	{
+		public CategoryExpander ()
+		{
+			DataContextChanged += OnDataContextChanged;
+		}
+
+		public override void OnApplyTemplate ()
+		{
+			base.OnApplyTemplate ();
+			UpdateValue();
+		}
+
+		protected override void OnExpanded ()
+		{
+			base.OnExpanded ();
+			SetExpanded (true);
+		}
+
+		protected override void OnCollapsed ()
+		{
+			base.OnCollapsed ();
+			SetExpanded (false);
+		}
+
+		private FrameworkElement parent;
+
+		private void UpdateValue ()
+		{
+			var vm = GetViewModel ();
+			if (vm == null)
+				return;
+
+			SetCurrentValue (IsExpandedProperty, vm.GetIsExpanded ((string) Header));
+		}
+
+		private PanelViewModel GetViewModel ()
+		{
+			FrameworkElement element = (this.parent as ItemsControl) ?? (FrameworkElement)this;
+			while (!(element is ItemsControl)) {
+				element = VisualTreeHelper.GetParent (element) as FrameworkElement;
+			}
+			this.parent = element;
+
+			if (this.parent == null)
+				throw new InvalidOperationException ("Couldn't find valid parent");
+
+			return this.parent.DataContext as PanelViewModel;
+		}
+
+		private void SetExpanded (bool isExpanded)
+		{
+			var vm = GetViewModel ();
+			if (vm == null)
+				throw new InvalidOperationException ("Couldn't find valid parent");
+
+			vm.SetIsExpanded ((string) Header, isExpanded);
+		}
+
+		private void OnDataContextChanged (object sender, DependencyPropertyChangedEventArgs e)
+		{
+			UpdateValue ();
+		}
+    }
+}

--- a/Xamarin.PropertyEditing.Windows/GroupEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/GroupEditorControl.cs
@@ -13,10 +13,13 @@ namespace Xamarin.PropertyEditing.Windows
 	internal class GroupEditorControl
 		: Selector
 	{
-		public GroupEditorControl ()
+		static GroupEditorControl ()
 		{
 			FocusableProperty.OverrideMetadata (typeof(GroupEditorControl), new FrameworkPropertyMetadata (false));
+		}
 
+		public GroupEditorControl ()
+		{
 			ItemContainerGenerator.StatusChanged += OnItemContainerGeneratorStatusChanged;
 		}
 

--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -108,9 +108,9 @@
 	</Style>
 
 	<DataTemplate x:Key="PropertyGroupTemplate">
-		<Expander Header="{Binding Key,Mode=OneTime}" Style="{StaticResource TreeExpanderStyle}">
+		<local:CategoryExpander Header="{Binding Key,Mode=OneTime}" Style="{StaticResource TreeExpanderStyle}">
 			<ItemsControl Style="{StaticResource PropertyListStyle}" ItemsSource="{Binding}" />
-		</Expander>
+		</local:CategoryExpander>
 	</DataTemplate>
 
 	<Style TargetType="local:PropertyEditorPanel">

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -55,6 +55,7 @@
     <Compile Include="BrushChoiceTemplateSelector.cs" />
     <Compile Include="BrushEditorControl.cs" />
     <Compile Include="BrushTabbedEditorControl.cs" />
+    <Compile Include="CategoryExpander.cs" />
     <Compile Include="CommonBrushToBrushConverter.cs" />
     <Compile Include="ByteToPercentageConverter.cs" />
     <Compile Include="ChoiceControl.cs" />

--- a/Xamarin.PropertyEditing/CategoryComparer.cs
+++ b/Xamarin.PropertyEditing/CategoryComparer.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Xamarin.PropertyEditing
+{
+	internal class CategoryComparer
+		: IComparer<string>
+	{
+		public static readonly CategoryComparer Instance = new CategoryComparer();
+
+		public int Compare (string x, string y)
+		{
+			int result = Comparer<string>.Default.Compare (x, y);
+			if (result != 0 && (String.IsNullOrEmpty (x) || String.IsNullOrEmpty (y)))
+				result *= -1;
+
+			return result;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
@@ -22,6 +22,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public bool HasChildElements => (this.arranged.Count > 0);
 
+		public bool IsFiltering => !String.IsNullOrWhiteSpace (FilterText);
+
 		public string FilterText
 		{
 			get { return this.filterText; }
@@ -34,6 +36,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 				this.filterText = value;
 				Filter (oldFilter);
 				OnPropertyChanged ();
+				if (String.IsNullOrWhiteSpace (oldFilter) != String.IsNullOrWhiteSpace (value))
+					OnPropertyChanged (nameof(IsFiltering));
 			}
 		}
 

--- a/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
@@ -123,13 +123,19 @@ namespace Xamarin.PropertyEditing.ViewModels
 			if (groupedTypeProperties != null) { // Insert type-grouped properties back in sorted.
 				int i = 0;
 				foreach (var kvp in groupedTypeProperties.OrderBy (kvp => kvp.Key)) {
+					var group = new ObservableGrouping<string, EditorViewModel> (kvp.Key) {
+						new PropertyGroupViewModel (kvp.Key, kvp.Value, ObjectEditors)
+					};
+
 					for (; i < this.arranged.Count; i++) {
 						var g = (IGrouping<string, EditorViewModel>) this.arranged[i];
+
 						// TODO: Are we translating categories? If so this needs to lookup the resource and be culture specific
-						if (String.Compare (g.Key, kvp.Key, StringComparison.Ordinal) > 0) {
-							this.arranged.Insert (i++, new ObservableGrouping<string, EditorViewModel> (kvp.Key) {
-								new PropertyGroupViewModel (kvp.Key, kvp.Value, ObjectEditors)
-							});
+						if (g.Key == null) { // nulls go on the bottom.
+							this.arranged.Insert (i, group);
+							break;
+						} else if (String.Compare (g.Key, kvp.Key, StringComparison.Ordinal) > 0) {
+							this.arranged.Insert (i++, group);
 							break;
 						}
 					}
@@ -211,10 +217,10 @@ namespace Xamarin.PropertyEditing.ViewModels
 		{
 			if (String.IsNullOrWhiteSpace (FilterText))
 				return true;
-
-			if (ArrangeMode == PropertyArrangeMode.Category && vm.Category != null && vm.Category.Contains (FilterText, StringComparison.OrdinalIgnoreCase)) {
+			if (ArrangeMode == PropertyArrangeMode.Category && vm.Category != null && vm.Category.Contains (FilterText, StringComparison.OrdinalIgnoreCase))
 				return true;
-			}
+			if (String.IsNullOrWhiteSpace (vm.Name))
+				return false;
 
 			return vm.Name.Contains (FilterText, StringComparison.OrdinalIgnoreCase);
 		}

--- a/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
@@ -96,7 +96,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			Dictionary<string, List<PropertyViewModel>> groupedTypeProperties = null;
 
 			this.arranged.Clear ();
-			foreach (var grouping in props.GroupBy (GetGroup).OrderBy (g => g.Key)) {
+			foreach (var grouping in props.GroupBy (GetGroup).OrderBy (g => g.Key, CategoryComparer.Instance)) {
 				HashSet<EditorViewModel> remainingItems = null;
 
 				if (ArrangeMode == PropertyArrangeMode.Category) {
@@ -126,7 +126,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			if (groupedTypeProperties != null) { // Insert type-grouped properties back in sorted.
 				int i = 0;
-				foreach (var kvp in groupedTypeProperties.OrderBy (kvp => kvp.Key)) {
+				foreach (var kvp in groupedTypeProperties.OrderBy (kvp => kvp.Key, CategoryComparer.Instance)) {
 					var group = new ObservableGrouping<string, EditorViewModel> (kvp.Key) {
 						new PropertyGroupViewModel (kvp.Key, kvp.Value, ObjectEditors)
 					};

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -43,6 +43,7 @@
     <Compile Include="AsyncWorkQueue.cs" />
     <Compile Include="BidirectionalDictionary.cs" />
     <Compile Include="BrushPropertyInfo.cs" />
+    <Compile Include="CategoryComparer.cs" />
     <Compile Include="Drawing\CommonAlignment.cs" />
     <Compile Include="Drawing\CommonBrush.cs" />
     <Compile Include="Drawing\CommonBrushMappingMode.cs" />


### PR DESCRIPTION
This PR:
 - Closed #93, making the category expansion/closure remember and filtering auto-expand categories
 - Fixes a bug leaving empty categories in place when cleared from grouped properties
 - Fixes a crash from the group editor control metadata override.
