### PR TITLE
Object editor and type selector

### DIFF
--- a/Xamarin.PropertyEditing.Tests/AsyncValueTests.cs
+++ b/Xamarin.PropertyEditing.Tests/AsyncValueTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.PropertyEditing.Tests
+{
+	[TestFixture]
+	internal class AsyncValueTests
+	{
+		[Test]
+		public void ValueOnCompletion ()
+		{
+			var tcs = new TaskCompletionSource<string> ();
+			var asyncValue = new AsyncValue<string> (tcs.Task);
+
+			Assume.That (asyncValue.Value, Is.Null);
+
+			bool changed = false;
+			asyncValue.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof (AsyncValue<string>.Value))
+					changed = true;
+			};
+
+			const string value = "value";
+			tcs.SetResult (value);
+
+			Assert.That (asyncValue.Value, Is.EqualTo (value));
+			Assert.That (changed, Is.True, "PropertyChanged did not fire for Value");
+		}
+
+		[Test]
+		public void DefaultValue ()
+		{
+			var tcs = new TaskCompletionSource<bool> ();
+			var value = new AsyncValue<bool> (tcs.Task, defaultValue: true);
+
+			Assert.That (value.Value, Is.True);
+		}
+
+		[TestCase (true)]
+		[TestCase (false)]
+		public void ValueReplacesDefaultValue (bool value)
+		{
+			var tcs = new TaskCompletionSource<bool> ();
+			var asyncValue = new AsyncValue<bool> (tcs.Task, defaultValue: !value);
+
+			Assume.That (asyncValue.Value, Is.EqualTo (!value));
+
+			tcs.SetResult (value);
+
+			Assert.That (asyncValue.Value, Is.EqualTo (value));
+		}
+
+		[Test]
+		public void IsRunning ()
+		{
+			var tcs = new TaskCompletionSource<string> ();
+			var asyncValue = new AsyncValue<string> (tcs.Task);
+
+			Assume.That (asyncValue.Value, Is.Null);
+			Assert.That (asyncValue.IsRunning, Is.True);
+
+			bool changed = false;
+			asyncValue.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof (AsyncValue<string>.IsRunning))
+					changed = true;
+			};
+
+			const string value = "value";
+			tcs.SetResult (value);
+
+			Assume.That (asyncValue.Value, Is.EqualTo (value));
+			Assert.That (asyncValue.IsRunning, Is.False, "IsRunning did not flip to false");
+			Assert.That (changed, Is.True, "PropertyChanged did not fire for IsRunning");
+		}
+
+		[Test]
+		public void AsyncValueException ()
+		{
+			var tcs = new TaskCompletionSource<bool> ();
+			var asyncValue = new AsyncValue<bool> (tcs.Task, defaultValue: true);
+
+			Assume.That (asyncValue.Value, Is.True);
+
+			bool valueChanged = false, runningChanged = false;
+			asyncValue.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof (AsyncValue<string>.Value))
+					valueChanged = true;
+				else if (args.PropertyName == nameof (AsyncValue<string>.IsRunning))
+					runningChanged = true;
+			};
+
+			tcs.SetException (new Exception ());
+
+			Assert.That (asyncValue.Value, Is.True);
+			Assert.That (valueChanged, Is.False, "Value should not signal change when there's an exception");
+			Assert.That (asyncValue.IsRunning, Is.False);
+			Assert.That (runningChanged, Is.False);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Tests/MockEditorProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockEditorProvider.cs
@@ -20,6 +20,11 @@ namespace Xamarin.PropertyEditing.Tests
 			return Task.FromResult (editor);
 		}
 
+		public Task<object> CreateObjectAsync (ITypeInfo type)
+		{
+			throw new System.NotImplementedException ();
+		}
+
 		private Dictionary<object, IObjectEditor> editorCache = new Dictionary<object, IObjectEditor> ();
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/MockEditorProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockEditorProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xamarin.PropertyEditing.Reflection;
@@ -22,7 +23,11 @@ namespace Xamarin.PropertyEditing.Tests
 
 		public Task<object> CreateObjectAsync (ITypeInfo type)
 		{
-			throw new System.NotImplementedException ();
+			Type realType = Type.GetType ($"{type.NameSpace}.{type.Name}, {type.Assembly.Name}");
+			if (realType == null)
+				return Task.FromResult<object> (null);
+
+			return Task.FromResult (Activator.CreateInstance (realType));
 		}
 
 		private Dictionary<object, IObjectEditor> editorCache = new Dictionary<object, IObjectEditor> ();

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -106,6 +106,11 @@ namespace Xamarin.PropertyEditing.Tests
 			return Task.FromResult<IReadOnlyList<string>> (new string[0]);
 		}
 
+		public Task<IReadOnlyList<ITypeInfo>> GetAssignableTypesAsync (IPropertyInfo property)
+		{
+			throw new NotImplementedException();
+		}
+
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 		public async Task SetValueAsync<T> (IPropertyInfo property, ValueInfo<T> value, PropertyVariation variation = null)
 		{

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -119,9 +119,11 @@ namespace Xamarin.PropertyEditing.Tests
 			if (this.assignableTypes == null) {
 				return Task.Run<IReadOnlyList<ITypeInfo>> (() => {
 					return AppDomain.CurrentDomain.GetAssemblies().SelectMany (a => a.GetTypes()).AsParallel()
-						.Where (t => property.Type.IsAssignableFrom (t) && t.Namespace != null && !t.IsAbstract && !t.IsInterface && t.IsPublic)
-						.Select (t => new TypeInfo (new AssemblyInfo (t.Assembly.GetName().Name, true), t.Namespace, t.Name))
-						.ToList();
+						.Where (t => property.Type.IsAssignableFrom (t) && t.GetConstructor (Type.EmptyTypes) != null && t.Namespace != null && !t.IsAbstract && !t.IsInterface && t.IsPublic)
+						.Select (t => {
+							string asmName = t.Assembly.GetName().Name;
+							return new TypeInfo (new AssemblyInfo (asmName, isRelevant: asmName.StartsWith ("Xamarin")), t.Namespace, t.Name);
+						}).ToList();
 				});
 			} else if (!this.assignableTypes.TryGetValue (property, out IReadOnlyList<ITypeInfo> types))
 				return Task.FromResult<IReadOnlyList<ITypeInfo>> (Enumerable.Empty<ITypeInfo>().ToArray());

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -18,6 +18,13 @@ namespace Xamarin.PropertyEditing.Tests
 			Properties = properties.ToArray ();
 		}
 
+		public MockObjectEditor (IReadOnlyList<IPropertyInfo> properties,
+			IReadOnlyDictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> assignableTypes)
+		{
+			Properties = properties;
+			this.assignableTypes = assignableTypes;
+		}
+
 		public MockObjectEditor (MockControl control)
 		{
 			Properties = control.Properties.Values.ToArray();
@@ -108,7 +115,10 @@ namespace Xamarin.PropertyEditing.Tests
 
 		public Task<IReadOnlyList<ITypeInfo>> GetAssignableTypesAsync (IPropertyInfo property)
 		{
-			throw new NotImplementedException();
+			if (this.assignableTypes == null || !this.assignableTypes.TryGetValue (property, out IReadOnlyList<ITypeInfo> types))
+				return Task.FromResult<IReadOnlyList<ITypeInfo>> (Enumerable.Empty<ITypeInfo>().ToArray());
+
+			return Task.FromResult (types);
 		}
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -182,5 +192,6 @@ namespace Xamarin.PropertyEditing.Tests
 
 		internal readonly IDictionary<IPropertyInfo, object> values = new Dictionary<IPropertyInfo, object> ();
 		internal readonly IDictionary<IEventInfo, string> events = new Dictionary<IEventInfo, string> ();
+		internal readonly IReadOnlyDictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> assignableTypes;
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Tests
+{
+	[TestFixture]
+	internal class ObjectPropertyViewModelTests
+	{
+		[Test]
+		public void TypeAssumedWhenSingleAssignableType ()
+		{
+			object value = new object();
+
+			var p = CreatePropertyMock ("prop");
+
+			var childsubInfo = GetTypeInfo (typeof(SubChildClass));
+			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childsubInfo } }
+			});
+
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new[] { editor });
+
+			bool requested = false;
+			vm.TypeRequested += (sender, args) => {
+				requested = true;
+			};
+
+			Assume.That (vm.CreateInstanceCommand.CanExecute (childsubInfo), Is.True);
+			vm.CreateInstanceCommand.Execute (childsubInfo);
+			Assert.That (requested, Is.False, "TypeRequested was raised");
+
+			providerMock.Verify (pr => pr.CreateObjectAsync (childsubInfo));
+		}
+
+		[Test]
+		public void TypeRequestedWhenMultipleAssignableTypes ()
+		{
+			object value = new object();
+
+			var p = CreatePropertyMock ("prop");
+
+			var childsubInfo = GetTypeInfo (typeof(SubChildClass));
+			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{
+					p.Object,
+					new[] {
+						GetTypeInfo (typeof(ChildClass)),
+						childsubInfo
+					}
+				}
+			});
+
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new[] { editor });
+
+			bool requested = false;
+			vm.TypeRequested += (sender, args) => {
+				requested = true;
+			};
+
+			Assume.That (vm.CreateInstanceCommand.CanExecute (childsubInfo), Is.True);
+			vm.CreateInstanceCommand.Execute (childsubInfo);
+			Assert.That (requested, Is.True, "TypeRequested was not raised");
+		}
+
+		[Test]
+		[Description ("Values with multiple value sources should show unknown")]
+		public async Task MultiValueSourcesUnknown ()
+		{
+			object value = new object();
+
+			var p = CreatePropertyMock ("prop");
+
+			var childsubInfo = GetTypeInfo (typeof(SubChildClass));
+			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childsubInfo } }
+			});
+			await editor.SetValueAsync (p.Object, new ValueInfo<object> {
+				Value = value,
+				Source = ValueSource.Local,
+				ValueDescriptor = childsubInfo
+			});
+
+			var editor2 = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childsubInfo } }
+			});
+			await editor2.SetValueAsync (p.Object, new ValueInfo<object> {
+				Value = value,
+				Source = ValueSource.Default,
+				ValueDescriptor = childsubInfo
+			});
+
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new[] { editor, editor2 });
+			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Unknown));
+		}
+
+		[Test]
+		public async Task ClearedValueSourcesDefault ()
+		{
+			object value = new object();
+
+			var p = CreatePropertyMock ("prop");
+
+			var childsubInfo = GetTypeInfo (typeof(SubChildClass));
+			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childsubInfo } }
+			});
+			await editor.SetValueAsync (p.Object, new ValueInfo<object> {
+				Value = value,
+				Source = ValueSource.Local,
+				ValueDescriptor = childsubInfo
+			});
+
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new[] { editor });
+			Assume.That (vm.ValueSource, Is.EqualTo (ValueSource.Local));
+
+			bool changed = false;
+			vm.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof(ObjectPropertyViewModel.ValueSource))
+					changed = true;
+			};
+
+			vm.Editors.Clear();
+			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Default));
+			Assert.That (changed, Is.True, "PropertyChanged did not fire for ValueSource");
+		}
+
+		[Test]
+		public void NullEditors ()
+		{
+			object value = new object();
+
+			var p = CreatePropertyMock ("prop");
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new IObjectEditor[0]);
+			Assume.That (vm.ValueType, Is.Null);
+			Assume.That (vm.ValueSource, Is.EqualTo (ValueSource.Default));
+
+			bool changed = false;
+			vm.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof(ObjectPropertyViewModel.ValueSource))
+					changed = true;
+			};
+
+			vm.Editors.Add (null);
+
+			Assert.That (changed, Is.False);
+			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Default));
+		}
+
+		[Test]
+		public void CanDelve ()
+		{
+			object value = new object();
+
+			var p = CreatePropertyMock ("prop");
+
+			var childsubInfo = GetTypeInfo (typeof(SubChildClass));
+			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childsubInfo } }
+			});
+
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new IObjectEditor[0]);
+			Assert.That (vm.CanDelve, Is.False);
+
+			bool changed = false;
+			vm.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof(ObjectPropertyViewModel.CanDelve))
+					changed = true;
+			};
+
+			vm.Editors.Add (editor);
+
+			Assert.That (vm.CanDelve, Is.True);
+			Assert.That (changed, Is.True, "PropertyChanged for CanDelve didn't fire adding");
+
+			changed = false;
+			vm.Editors.Clear();
+
+			Assert.That (vm.CanDelve, Is.False);
+			Assert.That (changed, Is.True, "PropertyChanged for CanDelve didn't fire clearing");
+
+			changed = false;
+			vm.Editors.Add (null);
+
+			Assert.That (vm.CanDelve, Is.False);
+			Assert.That (changed, Is.False, "PropertyChanged for CanDelve when hasn't changed");
+		}
+
+		[Test]
+		[Description ("Values with multiple value types should be null")]
+		public async Task MultiValueTypesNull ()
+		{
+			object value = new object(), value2 = new object();
+
+			var p = CreatePropertyMock ("prop");
+
+			var childsubInfo = GetTypeInfo (typeof(SubChildClass));
+			var childInfo = GetTypeInfo (typeof(ChildClass));
+			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childInfo, childsubInfo } }
+			});
+			await editor.SetValueAsync (p.Object, new ValueInfo<object> {
+				Value = value,
+				Source = ValueSource.Local,
+				ValueDescriptor = childInfo
+			});
+
+			var editor2 = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
+				{ p.Object, new[] { childInfo, childsubInfo } }
+			});
+			await editor2.SetValueAsync (p.Object, new ValueInfo<object> {
+				Value = value2,
+				Source = ValueSource.Local,
+				ValueDescriptor = childsubInfo
+			});
+
+			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
+			providerMock.Setup (a => a.GetObjectEditorAsync (value2)).ReturnsAsync (new MockObjectEditor { Target = value2 });
+
+			var vm = new ObjectPropertyViewModel (providerMock.Object, TargetPlatform.Default, p.Object, new[] { editor, editor2 });
+			Assume.That (vm.ValueSource, Is.EqualTo (ValueSource.Local));
+			Assert.That (vm.ValueType, Is.Null);
+		}
+
+		private Mock<IEditorProvider> CreateProviderMock (object value, IObjectEditor editor)
+		{
+			var m = new Mock<IEditorProvider> ();
+			m.Setup (e => e.GetObjectEditorAsync (value)).ReturnsAsync (editor);
+
+			return m;
+		}
+
+		private Mock<IPropertyInfo> CreatePropertyMock (string name)
+		{
+			var m = new Mock<IPropertyInfo> ();
+			m.SetupGet (p => p.Type).Returns (typeof(object));
+			m.SetupGet (p => p.Name).Returns (name);
+
+			return m;
+		}
+
+		private ITypeInfo GetTypeInfo (Type type)
+		{
+			var asm = new AssemblyInfo (type.Assembly.FullName);
+			return new TypeInfo (asm, type.Namespace, type.Name);
+		}
+
+		private class SubChildClass
+			: ChildClass
+		{
+			
+		}
+
+		private class ChildClass
+		{
+			
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Tests
@@ -12,6 +14,20 @@ namespace Xamarin.PropertyEditing.Tests
 	[TestFixture]
 	internal class ObjectPropertyViewModelTests
 	{
+		[SetUp]
+		public void Setup ()
+		{
+			this.syncContext = new AsyncSynchronizationContext();
+			SynchronizationContext.SetSynchronizationContext (this.syncContext);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			this.syncContext.WaitForPendingOperationsToComplete ();
+			SynchronizationContext.SetSynchronizationContext (null);
+		}
+
 		[Test]
 		public void TypeAssumedWhenSingleAssignableType ()
 		{
@@ -238,6 +254,8 @@ namespace Xamarin.PropertyEditing.Tests
 			Assume.That (vm.ValueSource, Is.EqualTo (ValueSource.Local));
 			Assert.That (vm.ValueType, Is.Null);
 		}
+
+		private AsyncSynchronizationContext syncContext;
 
 		private Mock<IEditorProvider> CreateProviderMock (object value, IObjectEditor editor)
 		{

--- a/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
@@ -276,7 +276,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 		private ITypeInfo GetTypeInfo (Type type)
 		{
-			var asm = new AssemblyInfo (type.Assembly.FullName);
+			var asm = new AssemblyInfo (type.Assembly.FullName, true);
 			return new TypeInfo (asm, type.Namespace, type.Name);
 		}
 

--- a/Xamarin.PropertyEditing.Tests/SimpleCollectionViewTests.cs
+++ b/Xamarin.PropertyEditing.Tests/SimpleCollectionViewTests.cs
@@ -1,0 +1,288 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Tests
+{
+	[TestFixture]
+	public class SimpleCollectionViewTests
+	{
+		[Test]
+		public void Source()
+		{
+			TestNode[] nodes = new TestNode[] {
+				new TestNode { Key = "key" },
+				new TestNode { Key = "key2" }
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+				DisplaySelector = TestNodeDisplaySelector
+			});
+
+			Assume.That (view.FilterText, Is.Null.Or.Empty);
+			Assert.That (view, Contains.Item (nodes[0]));
+			Assert.That (view, Contains.Item (nodes[1]));
+		}
+
+		[Test]
+		public void PassThroughINCC()
+		{
+			var nodes = new ObservableCollection<TestNode> {
+				new TestNode { Key = "key" },
+				new TestNode { Key = "key2" }
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+				DisplaySelector = TestNodeDisplaySelector
+			});
+			bool changed = false;
+			NotifyCollectionChangedAction action = NotifyCollectionChangedAction.Reset;
+			view.CollectionChanged += (sender, e) => {
+				changed = true;
+				action = e.Action;
+			};
+
+			nodes.Add (new TestNode { Key = "key3" });
+			Assert.That (changed, Is.True);
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Add).Or.EqualTo (NotifyCollectionChangedAction.Reset));
+			changed = false;
+
+			nodes.RemoveAt (0);
+			Assert.That (changed, Is.True);
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Remove).Or.EqualTo (NotifyCollectionChangedAction.Reset));
+			changed = false;
+
+			nodes.Move (0, 1);
+			Assert.That (changed, Is.True);
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Move).Or.EqualTo (NotifyCollectionChangedAction.Reset));
+			changed = false;
+
+			nodes[0] = new TestNode { Key = "replace" };
+			Assert.That (changed, Is.True);
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Replace).Or.EqualTo (NotifyCollectionChangedAction.Reset));
+			changed = false;
+
+			nodes.Clear();
+			Assert.That (changed, Is.True);
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Reset));
+			changed = false;
+		}
+
+		[Test]
+		public void Filter()
+		{
+			TestNode[] nodes = new TestNode[] {
+				new TestNode { Key = "key" },
+				new TestNode { Key = "key2" }
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+				DisplaySelector = TestNodeDisplaySelector
+			});
+
+			Assume.That (view.FilterText, Is.Null.Or.Empty);
+			Assume.That (view, Contains.Item (nodes[0]));
+			Assume.That (view, Contains.Item (nodes[1]));
+
+			bool changed = false;
+			NotifyCollectionChangedAction action = NotifyCollectionChangedAction.Reset;
+			view.CollectionChanged += (sender, e) => {
+				changed = true;
+				action = e.Action;
+			};
+
+			view.FilterText = "key";
+			Assert.That (changed, Is.False);
+			Assert.That (view, Contains.Item (nodes[0]));
+			Assert.That (view, Contains.Item (nodes[1]));
+
+			view.FilterText = "key2";
+			Assert.That (changed, Is.True);
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Remove));
+			Assert.That (view, Does.Not.Contain (nodes[0]));
+			Assert.That (view, Contains.Item (nodes[1]));
+		}
+
+		[Test]
+		public void InOrder()
+		{
+			TestNode[] nodes = new TestNode[] {
+				new TestNode { Key = "Z" },
+				new TestNode { Key = "C" },
+				new TestNode { Key = "E" },
+				new TestNode { Key = "B" },
+				new TestNode { Key = "A" }
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+				DisplaySelector = TestNodeDisplaySelector
+			});
+
+			Assume.That (view.FilterText, Is.Null.Or.Empty);
+			Assume.That (view, Contains.Item (nodes[0]));
+			Assume.That (view, Contains.Item (nodes[1]));
+			Assume.That (view, Contains.Item (nodes[2]));
+			Assume.That (view, Contains.Item (nodes[3]));
+			Assume.That (view, Contains.Item (nodes[4]));
+
+			Assert.That (view.Cast<object>().ElementAt (0), Is.EqualTo (nodes[4]));
+			Assert.That (view.Cast<object>().ElementAt (1), Is.EqualTo (nodes[3]));
+			Assert.That (view.Cast<object>().ElementAt (2), Is.EqualTo (nodes[1]));
+			Assert.That (view.Cast<object>().ElementAt (3), Is.EqualTo (nodes[2]));
+			Assert.That (view.Cast<object>().ElementAt (4), Is.EqualTo (nodes[0]));
+		}
+
+		[Test]
+		public void AddedInOrder()
+		{
+			var nodes = new ObservableCollection<TestNode> {
+				new TestNode { Key = "Z" },
+				new TestNode { Key = "C" },
+				// F
+				new TestNode { Key = "E" },
+				new TestNode { Key = "B" },
+				new TestNode { Key = "A" }
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+				DisplaySelector = TestNodeDisplaySelector
+			});
+
+			Assume.That (view.FilterText, Is.Null.Or.Empty);
+			Assume.That (view.Cast<object>().ElementAt (0), Is.EqualTo (nodes[4]));
+			Assume.That (view.Cast<object>().ElementAt (1), Is.EqualTo (nodes[3]));
+			Assume.That (view.Cast<object>().ElementAt (2), Is.EqualTo (nodes[1]));
+			Assume.That (view.Cast<object>().ElementAt (3), Is.EqualTo (nodes[2]));
+			Assume.That (view.Cast<object>().ElementAt (4), Is.EqualTo (nodes[0]));
+
+			bool changed = false;
+			NotifyCollectionChangedAction action = NotifyCollectionChangedAction.Reset;
+			view.CollectionChanged += (sender, e) => {
+				changed = true;
+				action = e.Action;
+			};
+
+			nodes.Insert (2, new TestNode ("F"));
+			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Add).Or.EqualTo (NotifyCollectionChangedAction.Reset));
+
+			Assert.That (changed, Is.True);
+			Assert.That (view.Cast<object>().ElementAt (0), Is.EqualTo (nodes[5]));
+			Assert.That (view.Cast<object>().ElementAt (1), Is.EqualTo (nodes[4]));
+			Assert.That (view.Cast<object>().ElementAt (2), Is.EqualTo (nodes[1]));
+			Assert.That (view.Cast<object>().ElementAt (3), Is.EqualTo (nodes[3]));
+			Assert.That (view.Cast<object>().ElementAt (4), Is.EqualTo (nodes[2]));
+			Assert.That (view.Cast<object>().ElementAt (5), Is.EqualTo (nodes[0]));
+		}
+
+		[Test]
+		public void Grouping()
+		{
+			TestNode[] nodes = new TestNode[] {
+				new TestNode {
+					Key = "Group",
+					Children = new List<TestNode> {
+						new TestNode ("Child")
+					}
+				}
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+					DisplaySelector = TestNodeDisplaySelector,
+					ChildrenSelector = TestNodeChildrenSelector,
+					ChildOptions = new SimpleCollectionViewOptions {
+						DisplaySelector = TestNodeDisplaySelector
+					}
+				});
+
+			Assert.That (view, Is.Not.Empty);
+			var kvp = (KeyValuePair<string, SimpleCollectionView>)view.Cast<object>().Single();
+			Assert.That (kvp.Value, Is.Not.Empty);
+			Assert.That (kvp.Value, Contains.Item (nodes[0].Children[0]));
+		}
+
+		[Test]
+		public void FilterCategory()
+		{
+			TestNode[] nodes = new TestNode[] {
+				new TestNode {
+					Key = "Group",
+					Children = new List<TestNode> {
+						new TestNode ("Child")
+					}
+				}
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+					DisplaySelector = TestNodeDisplaySelector,
+					ChildrenSelector = TestNodeChildrenSelector,
+					ChildOptions = new SimpleCollectionViewOptions {
+						DisplaySelector = TestNodeDisplaySelector
+					}
+				});
+
+			Assume.That (view, Is.Not.Empty);
+
+			view.FilterText = "Chi";
+
+			Assert.That (view, Is.Not.Empty);
+		}
+
+		[Test]
+		[Description ("Even if a filter matches the group name, if it's empty it should not be displayed")]
+		public void FilterCategoryEmpty()
+		{
+			TestNode[] nodes = new TestNode[] {
+				new TestNode {
+					Key = "Group",
+					Children = new List<TestNode> {
+						new TestNode ("Child")
+					}
+				}
+			};
+
+			var view = new SimpleCollectionView (nodes, new SimpleCollectionViewOptions {
+					DisplaySelector = TestNodeDisplaySelector,
+					ChildrenSelector = TestNodeChildrenSelector,
+					ChildOptions = new SimpleCollectionViewOptions {
+						DisplaySelector = TestNodeDisplaySelector
+					}
+				});
+
+			Assume.That (view, Is.Not.Empty);
+
+			view.FilterText = "Group";
+
+			Assert.That (view, Is.Empty);
+		}
+
+		private IEnumerable TestNodeChildrenSelector (object o)
+		{
+			return ((TestNode)o).Children;
+		}
+
+		private string TestNodeDisplaySelector (object o)
+		{
+			return ((TestNode)o).Key;
+		}
+
+		private class TestNode
+		{
+			public TestNode()
+			{
+
+			}
+
+			public TestNode (string key)
+			{
+				Key = key;
+			}
+
+			public string Key;
+			public List<TestNode> Children;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Tests/SimpleCollectionViewTests.cs
+++ b/Xamarin.PropertyEditing.Tests/SimpleCollectionViewTests.cs
@@ -23,7 +23,6 @@ namespace Xamarin.PropertyEditing.Tests
 				DisplaySelector = TestNodeDisplaySelector
 			});
 
-			Assume.That (view.FilterText, Is.Null.Or.Empty);
 			Assert.That (view, Contains.Item (nodes[0]));
 			Assert.That (view, Contains.Item (nodes[1]));
 		}
@@ -84,7 +83,6 @@ namespace Xamarin.PropertyEditing.Tests
 				DisplaySelector = TestNodeDisplaySelector
 			});
 
-			Assume.That (view.FilterText, Is.Null.Or.Empty);
 			Assume.That (view, Contains.Item (nodes[0]));
 			Assume.That (view, Contains.Item (nodes[1]));
 
@@ -95,12 +93,12 @@ namespace Xamarin.PropertyEditing.Tests
 				action = e.Action;
 			};
 
-			view.FilterText = "key";
+			view.Filter (o => ((TestNode)o).Key.StartsWith ("key"), isSuperset: false);
 			Assert.That (changed, Is.False);
 			Assert.That (view, Contains.Item (nodes[0]));
 			Assert.That (view, Contains.Item (nodes[1]));
 
-			view.FilterText = "key2";
+			view.Filter (o => ((TestNode)o).Key.StartsWith ("key2"), isSuperset: false);
 			Assert.That (changed, Is.True);
 			Assert.That (action, Is.EqualTo (NotifyCollectionChangedAction.Remove));
 			Assert.That (view, Does.Not.Contain (nodes[0]));
@@ -122,7 +120,6 @@ namespace Xamarin.PropertyEditing.Tests
 				DisplaySelector = TestNodeDisplaySelector
 			});
 
-			Assume.That (view.FilterText, Is.Null.Or.Empty);
 			Assume.That (view, Contains.Item (nodes[0]));
 			Assume.That (view, Contains.Item (nodes[1]));
 			Assume.That (view, Contains.Item (nodes[2]));
@@ -152,7 +149,6 @@ namespace Xamarin.PropertyEditing.Tests
 				DisplaySelector = TestNodeDisplaySelector
 			});
 
-			Assume.That (view.FilterText, Is.Null.Or.Empty);
 			Assume.That (view.Cast<object>().ElementAt (0), Is.EqualTo (nodes[4]));
 			Assume.That (view.Cast<object>().ElementAt (1), Is.EqualTo (nodes[3]));
 			Assume.That (view.Cast<object>().ElementAt (2), Is.EqualTo (nodes[1]));
@@ -226,7 +222,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 			Assume.That (view, Is.Not.Empty);
 
-			view.FilterText = "Chi";
+			view.Filter (o => ((TestNode)o).Key.StartsWith ("Chi"), isSuperset: false);
 
 			Assert.That (view, Is.Not.Empty);
 		}
@@ -254,7 +250,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 			Assume.That (view, Is.Not.Empty);
 
-			view.FilterText = "Group";
+			view.Filter (o => ((TestNode)o).Key.StartsWith ("Group"), isSuperset: false);
 
 			Assert.That (view, Is.Empty);
 		}

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncSynchronizationContext.cs" />
+    <Compile Include="AsyncValueTests.cs" />
     <Compile Include="AsyncWorkQueueTests.cs" />
     <Compile Include="BoolViewModelTests.cs" />
     <Compile Include="BrushPropertyViewModelTests.cs" />

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="BoolViewModelTests.cs" />
     <Compile Include="BrushPropertyViewModelTests.cs" />
     <Compile Include="BytePropertyViewModelTests.cs" />
+    <Compile Include="SimpleCollectionViewTests.cs" />
     <Compile Include="CommonColorTests.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="IPropertyConverter.cs" />

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="MockPropertyInfo\MockEnumPropertyInfo.cs" />
     <Compile Include="MockPropertyProviderTests.cs" />
     <Compile Include="MultiAvailabilityConstraintTests.cs" />
+    <Compile Include="ObjectPropertyViewModelTests.cs" />
     <Compile Include="ObservableLookupTests.cs" />
     <Compile Include="PointViewModelTests.cs" />
     <Compile Include="PropertyGroupViewModelTests.cs" />

--- a/Xamarin.PropertyEditing.Windows/BoolsToVisibilityConverter.cs
+++ b/Xamarin.PropertyEditing.Windows/BoolsToVisibilityConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal class BoolsToVisibilityConverter
+		: IMultiValueConverter
+	{
+		public object Convert (object[] values, Type targetType, object parameter, CultureInfo culture)
+		{
+			bool value = false;
+			if (values != null) {
+				value = (bool)values[0];
+				for (int i = 1; i < values.Length; i++) {
+					value = value && (bool)values[i];
+				}
+			}
+
+			return (value) ? Visibility.Visible : Visibility.Collapsed;
+		}
+
+		public object[] ConvertBack (object value, Type[] targetTypes, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
+++ b/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
@@ -43,7 +43,7 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			var vm = item as EditorViewModel;
 			if (vm != null) {
-				if (!(vm is PropertyViewModel) || !((PropertyViewModel)vm).CanDelve)
+				if (vm is PropertyViewModel)
 					return Options.EditorTemplate;
 				else
 					return Options.ParentTemplate;

--- a/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
+++ b/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
@@ -106,7 +106,9 @@ namespace Xamarin.PropertyEditing.Windows
 			{ typeof(ThicknessPropertyViewModel), typeof(ThicknessEditorControl) },
 			{ typeof(PredefinedValuesViewModel<>), typeof(EnumEditorControl) },
 			{ typeof(BrushPropertyViewModel), typeof(BrushEditorControl) },
-			{ typeof(PropertyGroupViewModel), typeof(GroupEditorControl) }
+			{ typeof(PropertyGroupViewModel), typeof(GroupEditorControl) },
+			{ typeof(ObjectPropertyViewModel), typeof(ObjectEditorControl) },
+
 		};
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/MultiplyMarginConverter.cs
+++ b/Xamarin.PropertyEditing.Windows/MultiplyMarginConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal class MultiplyMarginConverter
+		: IMultiValueConverter
+	{
+		public object Convert (object[] values, Type targetType, object parameter, CultureInfo culture)
+		{
+			Thickness thickness = (Thickness)values[0];
+			int by = (int)values[1];
+
+			return new Thickness (thickness.Left * by, thickness.Top * by, thickness.Right * by, thickness.Bottom * by);
+		}
+
+		public object[] ConvertBack (object value, Type[] targetTypes, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
@@ -1,0 +1,38 @@
+using System.Windows;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+    internal class ObjectEditorControl
+		: PropertyEditorControl
+    {
+		static ObjectEditorControl()
+		{
+			DefaultStyleKeyProperty.OverrideMetadata (typeof(ObjectEditorControl), new FrameworkPropertyMetadata (typeof(ObjectEditorControl)));
+		}
+
+		public ObjectEditorControl()
+		{
+			DataContextChanged += OnDataContextChanged;
+		}
+
+		private void OnDataContextChanged (object sender, DependencyPropertyChangedEventArgs e)
+		{
+			var vm = e.OldValue as ObjectPropertyViewModel;
+			if (vm != null)
+				vm.TypeRequested -= OnTypeRequested;
+
+			vm = e.NewValue as ObjectPropertyViewModel;
+			if (vm != null)
+				vm.TypeRequested += OnTypeRequested;
+		}
+
+		private void OnTypeRequested (object sender, TypeRequestedEventArgs e)
+		{
+			var vm = (ObjectPropertyViewModel)sender;
+
+			ITypeInfo type = TypeSelectorWindow.RequestType (Window.GetWindow (this), vm.AssignableTypes);
+			e.SelectedType = type;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -18,6 +19,15 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			get { return (object)GetValue (LabelProperty); }
 			set { SetValue (LabelProperty, value); }
+		}
+
+		public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register (
+			nameof(ItemsSource), typeof(IEnumerable), typeof(PropertyPresenter), new PropertyMetadata ());
+
+		public IEnumerable ItemsSource
+		{
+			get { return (IEnumerable)GetValue (ItemsSourceProperty); }
+			set { SetValue (ItemsSourceProperty, value); }
 		}
 
 		protected override Size ArrangeOverride (Size arrangeBounds)

--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -25,7 +25,7 @@
 				<ControlTemplate TargetType="{x:Type Expander}">
 					<Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="true">
 						<DockPanel>
-							<ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpandCollapseToggleStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+							<ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{DynamicResource ExpandCollapseToggleStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
 							<ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
 						</DockPanel>
 					</Border>
@@ -43,7 +43,12 @@
 	</Style>
 
 	<DataTemplate x:Key="PropertyEditorTemplate">
-		<local:PropertyPresenter Padding="19,0,0,0" Background="{DynamicResource PanelBackgroundBrush}" Label="{Binding Property.Name,Mode=OneTime}" Content="{Binding Mode=OneTime}" ContentTemplateSelector="{StaticResource PropertyEditorSelector}" />
+		<local:PropertyPresenter x:Name="presenter" Padding="19,0,0,0" Label="{Binding Property.Name,Mode=OneTime}" Content="{Binding Mode=OneTime}" ContentTemplateSelector="{StaticResource PropertyEditorSelector}" />
+		<DataTemplate.Triggers>
+			<DataTrigger Binding="{Binding CanDelve}" Value="True">
+				<Setter TargetName="presenter" Property="ItemsSource" Value="{Binding ValueModel.Properties,FallbackValue={x:Null}}" />
+			</DataTrigger>
+		</DataTemplate.Triggers>
 	</DataTemplate>
 	
 	<Style x:Key="PropertyListStyle" TargetType="ItemsControl">
@@ -137,7 +142,7 @@
 							</Grid>
 
 							<ScrollViewer Name="eventsPane" Grid.Row="1" Visibility="Collapsed">
-								<ItemsControl ItemsSource="{Binding Events}">
+								<ItemsControl ItemsSource="{Binding Events}" Background="{TemplateBinding Background}">
 									<ItemsControl.ItemTemplate>
 										<DataTemplate DataType="{x:Type vms:EventViewModel}">
 											<Grid>

--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -15,56 +15,6 @@
 		</local:EditorTreeSelector.Options>
 	</local:EditorTreeSelector>
 
-	<PathGeometry x:Key="TreeArrow" Figures="M0,0 L0,6 L6,0 z"/>
-	<Style x:Key="ExpandCollapseToggleStyle" TargetType="{x:Type ToggleButton}">
-		<Setter Property="Focusable" Value="False"/>
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type ToggleButton}">
-					<Grid>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="19" />
-							<ColumnDefinition Width="*" />
-						</Grid.ColumnDefinitions>
-						
-						<Border Grid.Column="0" Background="Transparent" Height="16" Padding="5,5,5,5" Width="16">
-							<Path x:Name="ExpandPath" Data="{StaticResource TreeArrow}" Fill="{DynamicResource TreeViewItem.TreeArrow.Static.Fill}" Stroke="{DynamicResource TreeViewItem.TreeArrow.Static.Stroke}">
-								<Path.RenderTransform>
-									<RotateTransform Angle="135" CenterY="3" CenterX="3"/>
-								</Path.RenderTransform>
-							</Path>
-						</Border>
-						
-						<ContentPresenter Grid.Column="1" />
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="IsChecked" Value="True">
-							<Setter Property="RenderTransform" TargetName="ExpandPath">
-								<Setter.Value>
-									<RotateTransform Angle="180" CenterY="3" CenterX="3"/>
-								</Setter.Value>
-							</Setter>
-							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.Static.Checked.Fill}"/>
-							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.Static.Checked.Stroke}"/>
-						</Trigger>
-						<Trigger Property="IsMouseOver" Value="True">
-							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Stroke}"/>
-							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Fill}"/>
-						</Trigger>
-						<MultiTrigger>
-							<MultiTrigger.Conditions>
-								<Condition Property="IsMouseOver" Value="True"/>
-								<Condition Property="IsChecked" Value="True"/>
-							</MultiTrigger.Conditions>
-							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Checked.Stroke}"/>
-							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Checked.Fill}"/>
-						</MultiTrigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-
 	<Style x:Key="TreeExpanderStyle" TargetType="Expander">
 		<Setter Property="Foreground" Value="{DynamicResource PanelGroupForegroundBrush}" />
 		<Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -12,8 +12,6 @@
         <ResourceDictionary Source="PropertyEditorPanelStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-	<BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
-
 	<Color x:Key="DropShadowBackgroundColor">#72000000</Color>
 
 	<Style x:Key="GenericVisualFocusStyle" TargetType="Control">
@@ -39,6 +37,8 @@
 
 	<Geometry x:Key="SearchLoopIcon" options:Freeze="True">F1 M 8.499,7.000 C 7.118,7.000 5.999,5.881 5.999,4.500 C 5.999,3.119 7.118,2.000 8.499,2.000 C 9.880,2.000 10.999,3.119 10.999,4.500 C 10.999,5.881 9.880,7.000 8.499,7.000 Z M 8.499,0.000 C 6.015,0.000 3.999,2.015 3.999,4.500 C 3.999,5.225 4.187,5.901 4.492,6.507 L 0.000,11.000 L 1.999,13.000 L 6.492,8.508 C 7.099,8.813 7.773,9.000 8.499,9.000 C 10.985,9.000 12.999,6.985 12.999,4.500 C 12.999,2.015 10.985,0.000 8.499,0.000 Z</Geometry>
 	<Geometry x:Key="ClearSearchIcon" options:Freeze="True">F1 M 0.000,1.000 L 1.000,0.000 L 4.000,3.000 L 7.000,0.000 L 8.000,1.000 L 5.000,4.000 L 8.000,7.000 L 7.000,8.000 L 4.000,5.000 L 1.000,8.000 L 0.000,7.000 L 3.000,4.000 L 0.000,1.000 Z</Geometry>
+
+	<local:BoolsToVisibilityConverter x:Key="BoolsToVisibilityConverter" />
 
 	<Style TargetType="{x:Type local:EnumEditorControl}">
 		<Setter Property="Template">
@@ -440,8 +440,8 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
-						<TextBlock Text="{Binding ValueType.Name,StringFormat=({0})}" Grid.Column="0" />
-						<Button MinHeight="20" MinWidth="40" HorizontalAlignment="Right" Content="{x:Static prop:Resources.New}" Command="{Binding CreateInstanceCommand}" />
+						<TextBlock Text="{Binding ValueType.Name,StringFormat=({0})}" Grid.Column="0" VerticalAlignment="Center" />
+						<Button MinHeight="20" MinWidth="40" Grid.Column="1" HorizontalAlignment="Right" Content="{x:Static prop:Resources.New}" Command="{Binding CreateInstanceCommand}" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -1102,14 +1102,29 @@
 					<Border Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
 						<Grid>
 							<Grid.ColumnDefinitions>
+								<ColumnDefinition Name="delveColumn" Width="Auto" />
 								<ColumnDefinition Name="labelColumn" MinWidth="100" MaxWidth="180" Width="0.4*" />
 								<ColumnDefinition MinWidth="134" Width="0.6*" />
 								<ColumnDefinition Name="propertyButtonColumn" Width="12" />
 							</Grid.ColumnDefinitions>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
 
-							<TextBlock Name="Label" Grid.Column="0" Text="{TemplateBinding Label}" ToolTip="{TemplateBinding Label}" Height="16" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
-							<ContentPresenter Grid.Column="1" Margin="4,2,0,2" IsEnabled="{Binding Property.CanWrite}" />
-							<local:PropertyButton Grid.Column="2" ValueSource="{Binding ValueSource}" />
+							<ToggleButton Name="delveButton" Grid.Column="0" Style="{DynamicResource StandaloneToggleStyle}" Width="11" Height="11" Visibility="{Binding HasItems,ElementName=subProperties,Converter={StaticResource BoolToVisibilityConverter}}" />
+							<TextBlock Name="Label" Grid.Column="1" Text="{TemplateBinding Label}" ToolTip="{TemplateBinding Label}" Height="16" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
+							<ContentPresenter Grid.Column="2" Margin="4,2,0,2" IsEnabled="{Binding Property.CanWrite}" />
+							<local:PropertyButton Grid.Column="3" ValueSource="{Binding ValueSource}" />
+
+							<ItemsControl Name="subProperties" Background="{DynamicResource PanelGroupSecondaryBackgroundBrush}" Margin="-19,0,0,0" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4" ItemsSource="{TemplateBinding ItemsSource}" ItemTemplate="{DynamicResource PropertyEditorTemplate}">
+								<ItemsControl.Visibility>
+									<MultiBinding Converter="{StaticResource BoolsToVisibilityConverter}">
+										<Binding ElementName="delveButton" Path="IsChecked" />
+										<Binding RelativeSource="{RelativeSource Self}" Path="HasItems" />
+									</MultiBinding>
+								</ItemsControl.Visibility>
+							</ItemsControl>
 						</Grid>
 					</Border>
 					<ControlTemplate.Triggers>
@@ -1508,6 +1523,45 @@
 
 						<ContentPresenter Grid.Column="1" />
 					</Grid>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsChecked" Value="True">
+							<Setter Property="RenderTransform" TargetName="ExpandPath">
+								<Setter.Value>
+									<RotateTransform Angle="180" CenterY="3" CenterX="3"/>
+								</Setter.Value>
+							</Setter>
+							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.Static.Checked.Fill}"/>
+							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.Static.Checked.Stroke}"/>
+						</Trigger>
+						<Trigger Property="IsMouseOver" Value="True">
+							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Stroke}"/>
+							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Fill}"/>
+						</Trigger>
+						<MultiTrigger>
+							<MultiTrigger.Conditions>
+								<Condition Property="IsMouseOver" Value="True"/>
+								<Condition Property="IsChecked" Value="True"/>
+							</MultiTrigger.Conditions>
+							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Checked.Stroke}"/>
+							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Checked.Fill}"/>
+						</MultiTrigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="StandaloneToggleStyle" TargetType="ToggleButton">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="ToggleButton">
+					<Border Grid.Column="0" Background="Transparent">
+						<Path x:Name="ExpandPath" Data="{StaticResource TreeArrow}" Fill="{DynamicResource TreeViewItem.TreeArrow.Static.Fill}" Stroke="{DynamicResource TreeViewItem.TreeArrow.Static.Stroke}">
+							<Path.RenderTransform>
+								<RotateTransform Angle="135" CenterY="3" CenterX="3"/>
+							</Path.RenderTransform>
+						</Path>
+					</Border>
 					<ControlTemplate.Triggers>
 						<Trigger Property="IsChecked" Value="True">
 							<Setter Property="RenderTransform" TargetName="ExpandPath">

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -16,6 +16,18 @@
 
 	<Color x:Key="DropShadowBackgroundColor">#72000000</Color>
 
+	<Style x:Key="GenericVisualFocusStyle" TargetType="Control">
+		<Setter Property="Margin" Value="2" />
+		<Setter Property="Foreground" Value="{DynamicResource FocusVisualBorderBrush}" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Control">
+					<Rectangle Margin="{TemplateBinding Margin}" SnapsToDevicePixels="True" Stroke="{TemplateBinding Foreground}" StrokeThickness="1" StrokeDashArray="1 2"/>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
 	<DrawingBrush x:Key="CheckerBoard" Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
 		<DrawingBrush.Drawing>
 			<DrawingGroup>
@@ -412,6 +424,24 @@
 							<Path Style="{StaticResource ThicknessIconStyle}" Data="{StaticResource BottomThicknessGeometry}" />
 						</Border>
 						<local:IntegerUpDownControl Grid.Column="1" Grid.Row="1" Margin="14,4,2,0" Value="{Binding Bottom}" MaximumValue="{Binding MaximumValue}" MinimumValue="{Binding MinimumValue}" IsEnabled="{Binding Property.CanWrite,Mode=OneTime}" AutomationProperties.HelpText="Bottom" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style TargetType="local:ObjectEditorControl">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="local:ObjectEditorControl">
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+
+						<TextBlock Text="{Binding ValueType.Name,StringFormat=({0})}" Grid.Column="0" />
+						<Button MinHeight="20" MinWidth="40" HorizontalAlignment="Right" Content="{x:Static prop:Resources.New}" Command="{Binding CreateInstanceCommand}" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -1428,14 +1458,15 @@
 	<Style x:Key="SearchTextBox" TargetType="local:TextBoxEx" BasedOn="{StaticResource {x:Type local:TextBoxEx}}">
 		<Setter Property="ShowClearButton" Value="True" />
 		<Setter Property="SubmitButtonStyle" Value="{StaticResource SearchButton}" />
-	</Style>
-
-	<Style x:Key="PropertySearchTextBox" TargetType="local:TextBoxEx" BasedOn="{StaticResource SearchTextBox}">
-		<Setter Property="Margin" Value="4,1,4,2" />
-		<Setter Property="Height" Value="18" />
 		<Setter Property="Background" Value="{DynamicResource SearchControlBackgroundBrush}" />
 		<Setter Property="BorderBrush" Value="{DynamicResource SearchControlBorderBrush}" />
-
+		<Setter Property="HintTemplate">
+			<Setter.Value>
+				<DataTemplate>
+					<TextBlock Text="{Binding}" Foreground="{DynamicResource SearchControlWatermarkBrush}" />
+				</DataTemplate>
+			</Setter.Value>
+		</Setter>
 		<Style.Triggers>
 			<Trigger Property="IsMouseOver" Value="True">
 				<Setter Property="Background" Value="{DynamicResource SearchControlActiveBackgroundBrush}" />
@@ -1448,6 +1479,155 @@
 				<Setter Property="Foreground" Value="{DynamicResource SearchControlActiveForegroundBrush}" />
 			</Trigger>
 		</Style.Triggers>
+	</Style>
+
+	<Style x:Key="PropertySearchTextBox" TargetType="local:TextBoxEx" BasedOn="{StaticResource SearchTextBox}">
+		<Setter Property="Margin" Value="4,1,4,2" />
+		<Setter Property="Height" Value="18" />
+	</Style>
+
+	<PathGeometry x:Key="TreeArrow" Figures="M0,0 L0,6 L6,0 z"/>
+	<Style x:Key="ExpandCollapseToggleStyle" TargetType="{x:Type ToggleButton}">
+		<Setter Property="Focusable" Value="False"/>
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type ToggleButton}">
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="19" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+
+						<Border Grid.Column="0" Background="Transparent" Height="16" Padding="5,5,5,5" Width="16">
+							<Path x:Name="ExpandPath" Data="{StaticResource TreeArrow}" Fill="{DynamicResource TreeViewItem.TreeArrow.Static.Fill}" Stroke="{DynamicResource TreeViewItem.TreeArrow.Static.Stroke}">
+								<Path.RenderTransform>
+									<RotateTransform Angle="135" CenterY="3" CenterX="3"/>
+								</Path.RenderTransform>
+							</Path>
+						</Border>
+
+						<ContentPresenter Grid.Column="1" />
+					</Grid>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsChecked" Value="True">
+							<Setter Property="RenderTransform" TargetName="ExpandPath">
+								<Setter.Value>
+									<RotateTransform Angle="180" CenterY="3" CenterX="3"/>
+								</Setter.Value>
+							</Setter>
+							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.Static.Checked.Fill}"/>
+							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.Static.Checked.Stroke}"/>
+						</Trigger>
+						<Trigger Property="IsMouseOver" Value="True">
+							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Stroke}"/>
+							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Fill}"/>
+						</Trigger>
+						<MultiTrigger>
+							<MultiTrigger.Conditions>
+								<Condition Property="IsMouseOver" Value="True"/>
+								<Condition Property="IsChecked" Value="True"/>
+							</MultiTrigger.Conditions>
+							<Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Checked.Stroke}"/>
+							<Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource TreeViewItem.TreeArrow.MouseOver.Checked.Fill}"/>
+						</MultiTrigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<local:MultiplyMarginConverter x:Key="MultiplyMarginConverter" />
+
+	<Style x:Key="SelectionTreeViewItem" TargetType="{x:Type local:TreeViewItemEx}">
+		<Setter Property="OverridesDefaultStyle" Value="True" />
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Foreground" Value="{DynamicResource ListItemForegroundBrush}" />
+		<Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+		<Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+		<Setter Property="Padding" Value="1,0,0,0"/>
+		<Setter Property="FocusVisualStyle">
+			<Setter.Value>
+				<Style BasedOn="{StaticResource GenericVisualFocusStyle}" TargetType="Control">
+					<Setter Property="Margin" Value="0" />
+				</Style>
+			</Setter.Value>
+		</Setter>
+		<Setter Property="MinHeight" Value="20" />
+		<Setter Property="Padding" Value="4,2,4,2" />
+		<Setter Property="BorderThickness" Value="1" />
+		<Setter Property="ChildMargin" Value="19,0,0,0" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type local:TreeViewItemEx}">
+					<StackPanel Orientation="Vertical">
+						<Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+							<Grid MinHeight="18">
+								<Grid.Margin>
+									<MultiBinding Converter="{StaticResource MultiplyMarginConverter}">
+										<Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ChildMargin" />
+										<Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IndentLevel" />
+									</MultiBinding>
+								</Grid.Margin>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition MinWidth="19" Width="Auto"/>
+									<ColumnDefinition Width="Auto"/>
+									<ColumnDefinition Width="*"/>
+								</Grid.ColumnDefinitions>
+
+								<ToggleButton x:Name="Expander" ClickMode="Press" IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource ExpandCollapseToggleStyle}"/>
+								<ContentPresenter x:Name="PART_Header" Grid.Column="1" ContentSource="Header" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+							</Grid>
+						</Border>
+						
+						<ItemsPresenter x:Name="ItemsHost" />
+					</StackPanel>
+					<ControlTemplate.Triggers>
+						<Trigger Property="IsExpanded" Value="false">
+							<Setter Property="Visibility" TargetName="ItemsHost" Value="Collapsed"/>
+						</Trigger>
+						<Trigger Property="HasItems" Value="false">
+							<Setter Property="Visibility" TargetName="Expander" Value="Hidden"/>
+						</Trigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+		<Style.Triggers>
+			<Trigger Property="IsMouseOverItem" Value="True">
+				<Setter Property="Background" Value="{DynamicResource ListItemHighlightBackgroundBrush}" />
+				<Setter Property="Foreground" Value="{DynamicResource ListItemHighlightForegroundBrush}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ListItemHighlightBorderBrush}" />
+			</Trigger>
+			<MultiTrigger>
+				<MultiTrigger.Conditions>
+					<Condition Property="IsSelected" Value="True" />
+					<Condition Property="HasItems" Value="False" />
+				</MultiTrigger.Conditions>
+
+				<Setter Property="Background" Value="{DynamicResource ListItemSelectedBackgroundBrush}"/>
+				<Setter Property="Foreground" Value="{DynamicResource ListItemSelectedForegroundBrush}"/>
+				<Setter Property="BorderBrush" Value="{DynamicResource ListItemSelectedBorderBrush}" />
+			</MultiTrigger>
+			<Trigger Property="IsEnabled" Value="false">
+				<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+			</Trigger>
+			<Trigger Property="HasItems" Value="True">
+				<Setter Property="IsSelectable" Value="False" />
+			</Trigger>
+			<Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
+				<Setter Property="ItemsPanel">
+					<Setter.Value>
+						<ItemsPanelTemplate>
+							<VirtualizingStackPanel/>
+						</ItemsPanelTemplate>
+					</Setter.Value>
+				</Setter>
+			</Trigger>
+		</Style.Triggers>
+	</Style>
+
+	<Style x:Key="SelectionTreeView" TargetType="local:TreeViewEx">
+		<Setter Property="ItemContainerStyle" Value="{StaticResource SelectionTreeViewItem}" />
 	</Style>
 
 	<Style x:Key="RepeatButtonTransparent" TargetType="{x:Type RepeatButton}">
@@ -1464,15 +1644,6 @@
 		</Setter>
 	</Style>
 
-	<Style x:Key="FocusVisual">
-		<Setter Property="Control.Template">
-			<Setter.Value>
-				<ControlTemplate>
-					<Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
 	<Style x:Key="ScrollBarThumbVertical" TargetType="{x:Type Thumb}">
 		<Setter Property="OverridesDefaultStyle" Value="true"/>
 		<Setter Property="IsTabStop" Value="false"/>
@@ -1684,17 +1855,6 @@
 				</Setter>
 			</Trigger>
 		</Style.Triggers>
-	</Style>
-
-	<Style x:Key="GenericVisualFocusStyle" TargetType="Control">
-		<Setter Property="Foreground" Value="{DynamicResource FocusVisualBorderBrush}" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate>
-					<Rectangle Margin="2" SnapsToDevicePixels="True" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
 	</Style>
 
 	<Style x:Key="EmptyCheckBoxFocusVisualSquare" TargetType="Control" BasedOn="{StaticResource GenericVisualFocusStyle}">

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
@@ -31,6 +31,7 @@
 
 	<SolidColorBrush x:Key="MenuPopupBackgroundBrush">#1B1B1C</SolidColorBrush>
 	<SolidColorBrush x:Key="MenuPopupBorderBrush">#333337</SolidColorBrush>
+	<SolidColorBrush x:Key="ListItemForegroundBrush">#FFF1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="ListItemHighlightForegroundBrush">#F1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="ListItemHighlightBorderBrush">#72555555</SolidColorBrush>
 	<SolidColorBrush x:Key="ListItemHighlightBackgroundBrush">#3E3E40</SolidColorBrush>
@@ -61,6 +62,7 @@
 	<SolidColorBrush x:Key="SearchControlButtonMouseOverBorderBrush">#FF007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="SearchControlButtonPressedBackgroundBrush">#FF007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="SearchControlButtonPressedBorderBrush">#FF007ACC</SolidColorBrush>
+	<SolidColorBrush x:Key="SearchControlWatermarkBrush">#FF999999</SolidColorBrush>
 
 	<SolidColorBrush x:Key="InputBackgroundBrush">#333337</SolidColorBrush>
 	<SolidColorBrush x:Key="InputBorderBrush">#434346</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
@@ -66,6 +66,7 @@
 	<SolidColorBrush x:Key="SearchControlButtonMouseOverBorderBrush">#FF007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="SearchControlButtonPressedBackgroundBrush">#FF007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="SearchControlButtonPressedBorderBrush">#FF007ACC</SolidColorBrush>
+	<SolidColorBrush x:Key="SearchControlWatermarkBrush">#FF717171</SolidColorBrush>
 
 	<SolidColorBrush x:Key="InputBackgroundBrush">#FFFFFFFF</SolidColorBrush>
 	<SolidColorBrush x:Key="InputBorderBrush">#FFCCCEDB</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/TreeViewItemEx.cs
+++ b/Xamarin.PropertyEditing.Windows/TreeViewItemEx.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal class TreeViewEx
+		: TreeView
+	{
+		static TreeViewEx()
+		{
+			setSelectedItem = (Action<TreeView, object>)typeof(TreeView).GetMethod ("SetSelectedItem", BindingFlags.NonPublic | BindingFlags.Instance).CreateDelegate (typeof(Action<TreeView, object>));
+		}
+
+		public event EventHandler ItemActivated;
+
+		protected override DependencyObject GetContainerForItemOverride ()
+		{
+			return new TreeViewItemEx();
+		}
+
+		protected override bool IsItemItsOwnContainerOverride (object item)
+		{
+			return item is TreeViewItemEx;
+		}
+
+		protected override void OnMouseDoubleClick (MouseButtonEventArgs e)
+		{
+			var inputElement = InputHitTest (e.GetPosition (this)) as UIElement;
+			if (inputElement != null) {
+				var item = inputElement.FindParentOrSelf<TreeViewItemEx>();
+				if (item != null && item.IsSelectable)
+					ItemActivated?.Invoke (this, EventArgs.Empty);
+			}
+
+			base.OnMouseDoubleClick (e);
+		}
+
+		internal TreeViewItemEx SelectedTreeItem
+		{
+			get { return this.selectedTreeItem; }
+			set
+			{
+				if (this.selectedTreeItem != null) {
+					if (this.selectedTreeItem != value)
+						this.selectedTreeItem.IsSelected = false;
+					else if (this.selectedTreeItem.IsSelected && SelectedItem == this.selectedTreeItem.DataContext)
+						return;
+				}
+
+				// This does break the selected value path features, but we don't care about those
+				object oldItem = this.selectedTreeItem?.DataContext;
+				this.selectedTreeItem = value;
+				if (value != null) {
+					value.IsSelected = true;
+				}
+
+				SetSelectedItem (oldItem, value?.DataContext);
+			}
+		}
+
+		private TreeViewItemEx selectedTreeItem;
+
+		private void SetSelectedItem (object oldItem, object item)
+		{
+			Dispatcher.InvokeAsync (() => {
+				setSelectedItem (this, item);
+
+				var e = new RoutedPropertyChangedEventArgs<object> (oldItem, item, SelectedItemChangedEvent);
+				RaiseEvent (e);
+			});
+		}
+
+		private static readonly Action<TreeView, object> setSelectedItem;
+	}
+
+	internal class TreeViewItemEx
+		: TreeViewItem
+	{
+		public TreeViewItemEx()
+		{
+		}
+
+		private static readonly DependencyPropertyKey IndentLevelKey = DependencyProperty.RegisterReadOnly ("IndentLevel", typeof(int), typeof(TreeViewItemEx), new PropertyMetadata());
+		public static readonly DependencyProperty IndentLevelProperty = IndentLevelKey.DependencyProperty;
+
+		public int IndentLevel
+		{
+			get { return (int)GetValue (IndentLevelProperty); }
+			private set { SetValue (IndentLevelKey, value); }
+		}
+
+		public static readonly DependencyProperty ChildMarginProperty = DependencyProperty.Register ("ChildMargin", typeof(Thickness), typeof(TreeViewItemEx), new PropertyMetadata());
+		public Thickness ChildMargin
+		{
+			get { return (Thickness)GetValue (ChildMarginProperty); }
+			set { SetValue (ChildMarginProperty, value); }
+		}
+
+		private static readonly DependencyPropertyKey IsMouseOverItemKey = DependencyProperty.RegisterReadOnly ("IsMouseOverItem", typeof(bool), typeof(TreeViewItemEx), new PropertyMetadata());
+		public static readonly DependencyProperty IsMouseOverItemProperty = IsMouseOverItemKey.DependencyProperty;
+
+		public bool IsMouseOverItem
+		{
+			get { return (bool)GetValue (IsMouseOverItemProperty); }
+			private set { SetValue (IsMouseOverItemKey, value); }
+		}
+
+		public static readonly DependencyProperty IsSelectableProperty = DependencyProperty.Register ("IsSelectable", typeof(bool), typeof(TreeViewItemEx), new PropertyMetadata (true));
+
+		public bool IsSelectable
+		{
+			get { return (bool)GetValue (IsSelectableProperty); }
+			set { SetValue (IsSelectableProperty, value); }
+		}
+
+		public override void OnApplyTemplate ()
+		{
+			base.OnApplyTemplate ();
+
+			int level = 0;
+			var parent = VisualTreeHelper.GetParent (this);
+			while (!(parent is TreeView)) {
+				parent = VisualTreeHelper.GetParent (parent);
+
+				if (parent is TreeViewItem)
+					level++;
+			}
+
+			this.topParent = parent as TreeViewEx;
+
+			IndentLevel = level;
+		}
+
+		protected override void OnMouseDown (MouseButtonEventArgs e)
+		{
+			if (IsSelectable) {
+				if (Keyboard.IsKeyDown (Key.LeftCtrl) || Keyboard.IsKeyDown (Key.RightCtrl)) {
+					IsSelected = !IsSelected;
+					e.Handled = true;
+				}
+			}
+
+			base.OnMouseDown (e);
+		}
+
+		protected override void OnKeyDown (KeyEventArgs e)
+		{
+			if (e.Key == Key.Up || e.Key == Key.Down) {
+				var next = GetNextElement (e.Key == Key.Up) as ItemsControl;
+				if (!(next is TreeView)) {
+					if (next.HasItems) {
+						var tree = GetParentTree();
+						tree.SelectedTreeItem = null;
+					}
+
+					next.Focus();
+					e.Handled = true;
+				}
+			}
+
+			base.OnKeyDown (e);
+		}
+
+		protected override void OnSelected (RoutedEventArgs e)
+		{
+			TreeViewEx parent = GetParentTree();
+			if (!IsSelectable) {
+				IsSelected = false;
+				e.Handled = true;
+
+				parent.SelectedTreeItem = parent.SelectedTreeItem;
+			} else if (parent.SelectedTreeItem != this) {
+				parent.SelectedTreeItem = this;
+			}
+		}
+
+		protected override DependencyObject GetContainerForItemOverride ()
+		{
+			return new TreeViewItemEx();
+		}
+
+		protected override bool IsItemItsOwnContainerOverride (object item)
+		{
+			return item is TreeViewItemEx;
+		}
+
+		protected override void OnMouseEnter (MouseEventArgs e)
+		{
+			base.OnMouseEnter (e);
+
+			CheckPosition (e);
+		}
+
+		protected override void OnMouseMove (MouseEventArgs e)
+		{
+			base.OnMouseMove (e);
+
+			CheckPosition (e);
+		}
+
+		protected override void OnMouseLeave (MouseEventArgs e)
+		{
+			base.OnMouseLeave (e);
+			IsMouseOverItem = false;
+		}
+
+		private TreeViewEx topParent;
+
+		private UIElement GetNextElement (bool previous)
+		{
+			if (!previous && HasItems && IsExpanded)
+				return (UIElement)ItemContainerGenerator.ContainerFromIndex (0);
+
+			var parentContainer = this.FindParent<ItemsControl>();
+			if (parentContainer == null)
+				return null;
+
+			int index = parentContainer.ItemContainerGenerator.IndexFromContainer (this);
+			index += (previous) ? -1 : 1;
+
+			if (index == -1)
+				return parentContainer;
+
+			while (index == parentContainer.Items.Count) {
+				if (parentContainer is TreeView)
+					return parentContainer;
+				
+				var parentsParent = parentContainer.FindParent<ItemsControl>();
+				index = parentsParent.ItemContainerGenerator.IndexFromContainer (parentContainer) + 1;
+
+				parentContainer = parentsParent;
+			}
+
+			var item = (TreeViewItem)parentContainer.ItemContainerGenerator.ContainerFromIndex (index);
+			if (!previous || (!item.IsExpanded || !item.HasItems))
+				return item;
+
+			return (UIElement)item.ItemContainerGenerator.ContainerFromIndex (item.Items.Count - 1);
+		}
+
+		private TreeViewEx GetParentTree()
+		{
+			if (this.topParent == null)
+				this.topParent = this.FindParent<TreeViewEx>();
+
+			return this.topParent;
+		}
+
+		private void CheckPosition (MouseEventArgs e)
+		{
+			UIElement element = InputHitTest (e.GetPosition (this)) as UIElement;
+			if (element == null) {
+				IsMouseOverItem = false;
+				return;
+			}
+
+			IsMouseOverItem = element.FindParentOrSelf<TreeViewItemEx>() == this;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml
+++ b/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml
@@ -1,0 +1,60 @@
+<local:WindowEx x:Class="Xamarin.PropertyEditing.Windows.TypeSelectorWindow"
+		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+		xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+		xmlns:local="clr-namespace:Xamarin.PropertyEditing.Windows"
+		xmlns:prop="clr-namespace:Xamarin.PropertyEditing.Properties;assembly=Xamarin.PropertyEditing"
+		mc:Ignorable="d" x:ClassModifier="internal" WindowStartupLocation="CenterOwner" ShowIcon="False"
+		MinWidth="300" MinHeight="400" Width="500" Height="600" ShowMinimize="False" ShowMaximize="False"
+		Background="{DynamicResource DialogBackgroundBrush}" Foreground="{DynamicResource DialogForegroundBrush}"
+		Title="{x:Static prop:Resources.SelectObjectTitle}">
+	<Grid Margin="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<local:TextBoxEx Margin="0,4,0,0" Style="{DynamicResource SearchTextBox}" MinHeight="20" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" ShowClearButton="True" Hint="{x:Static prop:Resources.SearchObjectsTitle}" />
+
+		<ProgressBar Grid.Row="1" IsIndeterminate="True" Height="10" Visibility="{Binding IsLoading,Converter={StaticResource BoolToVisibilityConverter}}" />
+		<local:TreeViewEx x:Name="tree" Grid.Row="1" Margin="0,4,0,0" Style="{DynamicResource SelectionTreeView}" ItemsSource="{Binding Types}" Foreground="{DynamicResource PanelGroupForegroundBrush}" Background="{DynamicResource ListBackgroundBrush}" BorderBrush="{DynamicResource ListBackgroundBrush}" SelectedItemChanged="OnSelectedItemChanged" ItemActivated="OnItemActivated">
+			<local:TreeViewEx.ItemTemplate>
+				<HierarchicalDataTemplate ItemsSource="{Binding Value,Mode=OneTime}">
+					<HierarchicalDataTemplate.ItemTemplate>
+						<HierarchicalDataTemplate ItemsSource="{Binding Value,Mode=OneTime}">
+							<HierarchicalDataTemplate.ItemTemplate>
+								<DataTemplate>
+									<StackPanel Orientation="Horizontal">
+										<!-- Icon -->
+										<TextBlock Margin="8,0,0,0" Text="{Binding Name,Mode=OneTime}" />
+									</StackPanel>
+
+								</DataTemplate>
+							</HierarchicalDataTemplate.ItemTemplate>
+
+							<StackPanel Orientation="Horizontal">
+								<!-- Icon -->
+								<TextBlock Text="{Binding Key}" Margin="8,0,0,0" />
+							</StackPanel>
+						</HierarchicalDataTemplate>
+					</HierarchicalDataTemplate.ItemTemplate>
+
+					<StackPanel Orientation="Horizontal">
+						<!-- Icon -->
+						<TextBlock Margin="8,0,0,0" Text="{Binding Key,Mode=OneTime}" />
+					</StackPanel>
+				</HierarchicalDataTemplate>
+			</local:TreeViewEx.ItemTemplate>
+		</local:TreeViewEx>
+
+		<CheckBox Grid.Row="2" HorizontalAlignment="Left" Margin="0,4,0,0" Foreground="{DynamicResource PanelGroupForegroundBrush}" Content="{x:Static prop:Resources.ShowAllAssemblies}" />
+
+		<StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+			<Button Name="ok" MinHeight="23" MinWidth="75" IsEnabled="False" Content="{x:Static prop:Resources.OK}" IsDefault="True" Click="OnOkClicked" />
+			<Button MinHeight="23" MinWidth="75" Margin="4,0,0,0" Content="{x:Static prop:Resources.Cancel}" IsCancel="True" />
+		</StackPanel>
+	</Grid>
+</local:WindowEx>

--- a/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml
+++ b/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml
@@ -50,7 +50,7 @@
 			</local:TreeViewEx.ItemTemplate>
 		</local:TreeViewEx>
 
-		<CheckBox Grid.Row="2" HorizontalAlignment="Left" Margin="0,4,0,0" Foreground="{DynamicResource PanelGroupForegroundBrush}" Content="{x:Static prop:Resources.ShowAllAssemblies}" />
+		<CheckBox Grid.Row="2" HorizontalAlignment="Left" Margin="0,4,0,0" IsChecked="{Binding ShowAllAssemblies}" Foreground="{DynamicResource PanelGroupForegroundBrush}" Content="{x:Static prop:Resources.ShowAllAssemblies}" />
 
 		<StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
 			<Button Name="ok" MinHeight="23" MinWidth="75" IsEnabled="False" Content="{x:Static prop:Resources.OK}" IsDefault="True" Click="OnOkClicked" />

--- a/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal partial class TypeSelectorWindow
+		: WindowEx
+	{
+		internal TypeSelectorWindow (AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
+		{
+			InitializeComponent ();
+			DataContext = new TypeSelectorViewModel (assignableTypes);
+		}
+
+		internal static ITypeInfo RequestType (Window owner, AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
+		{
+			var w = new TypeSelectorWindow (assignableTypes);
+			w.Owner = owner;
+			if (!w.ShowDialog () ?? false)
+				return null;
+
+			return w.tree.SelectedItem as ITypeInfo;
+		}
+
+		private void OnSelectedItemChanged (object sender, RoutedPropertyChangedEventArgs<object> e)
+		{
+			this.ok.IsEnabled = (e.NewValue as ITypeInfo) != null;
+		}
+
+		private void OnItemActivated (object sender, System.EventArgs e)
+		{
+			DialogResult = true;
+		}
+
+		private void OnOkClicked (object sender, RoutedEventArgs e)
+		{
+			DialogResult = true;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/WindowEx.cs
+++ b/Xamarin.PropertyEditing.Windows/WindowEx.cs
@@ -8,11 +8,25 @@ namespace Xamarin.PropertyEditing.Windows
 	internal class WindowEx
 		: Window
 	{
-		public static readonly DependencyProperty ShowIconProperty = DependencyProperty.Register ("ShowIcon", typeof(bool), typeof(WindowEx), new PropertyMetadata ((d, e) => ((WindowEx)d).UpdateExtendedStyles()));
+		public static readonly DependencyProperty ShowIconProperty = DependencyProperty.Register ("ShowIcon", typeof(bool), typeof(WindowEx), new PropertyMetadata (true, (d, e) => ((WindowEx)d).UpdateExtendedStyles()));
 		public bool ShowIcon
 		{
 			get { return (bool)GetValue (ShowIconProperty); }
 			set { SetValue (ShowIconProperty, value); }
+		}
+
+		public static readonly DependencyProperty ShowMaximizeProperty = DependencyProperty.Register ("ShowMaximize", typeof(bool), typeof(WindowEx), new PropertyMetadata (true, (d, e) => ((WindowEx)d).UpdateExtendedStyles()));
+		public bool ShowMaximize
+		{
+			get { return (bool)GetValue (ShowMaximizeProperty); }
+			set { SetValue (ShowMaximizeProperty, value); }
+		}
+
+		public static readonly DependencyProperty ShowMinimizeProperty = DependencyProperty.Register ("ShowMinimize", typeof(bool), typeof(WindowEx), new PropertyMetadata (true, (d, e) => ((WindowEx)d).UpdateExtendedStyles()));
+		public bool ShowMinimize
+		{
+			get { return (bool)GetValue (ShowMinimizeProperty); }
+			set { SetValue (ShowMinimizeProperty, value); }
 		}
 
 		protected override void OnSourceInitialized (EventArgs e)
@@ -31,26 +45,54 @@ namespace Xamarin.PropertyEditing.Windows
 			if (this.interop == null)
 				return;
 
-			int currentStyle = GetWindowLong (this.interop.Handle, WindowIndex.ExtendedStyle);
-			bool showingIcon = (currentStyle & WS_EX_DLGMODALFRAME) == 0;
-			if (ShowIcon == showingIcon)
-				return;
+			bool updateExStyle = false;
+			int currentExStyle = GetWindowLong (this.interop.Handle, WindowIndex.ExtendedStyle);
+			bool showingIcon = (currentExStyle & WS_EX_DLGMODALFRAME) == 0;
+			if (showingIcon != ShowIcon) {
+				if (ShowIcon && !showingIcon)
+					currentExStyle |= WS_EX_DLGMODALFRAME;
+				else
+					currentExStyle ^= WS_EX_DLGMODALFRAME;
 
-			if (ShowIcon && !showingIcon)
-				currentStyle |= WS_EX_DLGMODALFRAME;
-			else
-				currentStyle ^= WS_EX_DLGMODALFRAME;
+				SetWindowLong (this.interop.Handle, WindowIndex.ExtendedStyle, currentExStyle);
+				updateExStyle = true;
+			}
 
-			SetWindowLong (this.interop.Handle, WindowIndex.ExtendedStyle, currentStyle | WS_EX_DLGMODALFRAME);
-			SetWindowPos (this.interop.Handle, IntPtr.Zero, 0, 0, 0, 0, PositionFlags.NoMove | PositionFlags.NoSize | PositionFlags.NoZOrder | PositionFlags.FrameChanged);
+			int currentStyle = GetWindowLong (this.interop.Handle, WindowIndex.Style);
+			bool showingMinimize = (currentStyle & WS_MINIMIZEBOX) == WS_MINIMIZEBOX;
+			bool showingMaximize = (currentStyle & WS_MAXIMIZEBOX) == WS_MAXIMIZEBOX;
+
+			bool updateStyle = (showingMaximize != ShowMaximize || showingMinimize != ShowMinimize);
+			if (showingMaximize != ShowMaximize) {
+				if (ShowMaximize && !showingMaximize)
+					currentStyle |= WS_MAXIMIZEBOX;
+				else
+					currentStyle ^= WS_MAXIMIZEBOX;
+			}
+
+			if (showingMinimize != ShowMinimize) {
+				if (ShowMinimize && !showingMinimize)
+					currentStyle |= WS_MINIMIZEBOX;
+				else
+					currentStyle ^= WS_MINIMIZEBOX;
+			}
+
+			if (updateStyle)
+				SetWindowLong (this.interop.Handle, WindowIndex.Style, currentStyle);
+			
+			if (updateExStyle || updateStyle)
+				SetWindowPos (this.interop.Handle, IntPtr.Zero, 0, 0, 0, 0, PositionFlags.NoMove | PositionFlags.NoSize | PositionFlags.NoZOrder | PositionFlags.FrameChanged);
 		}
 
 		private enum WindowIndex
 		{
+			Style = -16,
 			ExtendedStyle = -20
 		}
 
 		const int WS_EX_DLGMODALFRAME = 0x001;
+		const int WS_MAXIMIZEBOX = 0x10000;
+		const int WS_MINIMIZEBOX = 0x20000;
 
 		[Flags]
 		private enum PositionFlags

--- a/Xamarin.PropertyEditing.Windows/WindowEx.cs
+++ b/Xamarin.PropertyEditing.Windows/WindowEx.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal class WindowEx
+		: Window
+	{
+		public static readonly DependencyProperty ShowIconProperty = DependencyProperty.Register ("ShowIcon", typeof(bool), typeof(WindowEx), new PropertyMetadata ((d, e) => ((WindowEx)d).UpdateExtendedStyles()));
+		public bool ShowIcon
+		{
+			get { return (bool)GetValue (ShowIconProperty); }
+			set { SetValue (ShowIconProperty, value); }
+		}
+
+		protected override void OnSourceInitialized (EventArgs e)
+		{
+			base.OnSourceInitialized (e);
+
+			this.interop = new WindowInteropHelper (this);
+
+			UpdateExtendedStyles();
+		}
+
+		private WindowInteropHelper interop;
+
+		private void UpdateExtendedStyles()
+		{
+			if (this.interop == null)
+				return;
+
+			int currentStyle = GetWindowLong (this.interop.Handle, WindowIndex.ExtendedStyle);
+			bool showingIcon = (currentStyle & WS_EX_DLGMODALFRAME) == 0;
+			if (ShowIcon == showingIcon)
+				return;
+
+			if (ShowIcon && !showingIcon)
+				currentStyle |= WS_EX_DLGMODALFRAME;
+			else
+				currentStyle ^= WS_EX_DLGMODALFRAME;
+
+			SetWindowLong (this.interop.Handle, WindowIndex.ExtendedStyle, currentStyle | WS_EX_DLGMODALFRAME);
+			SetWindowPos (this.interop.Handle, IntPtr.Zero, 0, 0, 0, 0, PositionFlags.NoMove | PositionFlags.NoSize | PositionFlags.NoZOrder | PositionFlags.FrameChanged);
+		}
+
+		private enum WindowIndex
+		{
+			ExtendedStyle = -20
+		}
+
+		const int WS_EX_DLGMODALFRAME = 0x001;
+
+		[Flags]
+		private enum PositionFlags
+		{
+			NoSize = 0x0001,
+			NoMove = 0x0002,
+			NoZOrder = 0x0004,
+			FrameChanged = 0x0020,
+		}
+
+		[DllImport ("user32.dll")]
+		private static extern bool SetWindowPos (IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int width, int theight, PositionFlags flags);
+
+		[DllImport ("user32.dll")]
+		private static extern int GetWindowLong (IntPtr hwnd, WindowIndex index);
+
+		[DllImport ("user32.dll")]
+		private static extern int SetWindowLong (IntPtr hWnd, WindowIndex index, int dwNewLong);
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -69,6 +69,7 @@
     <Compile Include="CurrentColorEditorControl.cs" />
     <Compile Include="DoubleToPercentageConverter.cs" />
     <Compile Include="DoubleToQuantityConverter.cs" />
+    <Compile Include="ObjectEditorControl.cs" />
     <Compile Include="TextBoxEx.cs" />
     <Compile Include="ToggleButtonEx.cs" />
     <Compile Include="EditorPropertySelector.cs" />

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -69,6 +69,7 @@
     <Compile Include="CurrentColorEditorControl.cs" />
     <Compile Include="DoubleToPercentageConverter.cs" />
     <Compile Include="DoubleToQuantityConverter.cs" />
+    <Compile Include="MultiplyMarginConverter.cs" />
     <Compile Include="ObjectEditorControl.cs" />
     <Compile Include="TextBoxEx.cs" />
     <Compile Include="ToggleButtonEx.cs" />
@@ -99,6 +100,10 @@
     <Compile Include="ThicknessEditorControl.cs" />
     <Compile Include="StringEditorControl.cs" />
     <Compile Include="Themes\WinThemeManager.cs" />
+    <Compile Include="TreeViewItemEx.cs" />
+    <Compile Include="TypeSelectorWindow.xaml.cs">
+      <DependentUpon>TypeSelectorWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="WindowEx.cs" />
     <Compile Include="XamlHelper.cs" />
   </ItemGroup>
@@ -116,6 +121,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Themes\VS.Light.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="TypeSelectorWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -99,6 +99,7 @@
     <Compile Include="ThicknessEditorControl.cs" />
     <Compile Include="StringEditorControl.cs" />
     <Compile Include="Themes\WinThemeManager.cs" />
+    <Compile Include="WindowEx.cs" />
     <Compile Include="XamlHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -51,6 +51,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="BoolEditorControl.cs" />
+    <Compile Include="BoolsToVisibilityConverter.cs" />
     <Compile Include="BrushBoxControl.cs" />
     <Compile Include="BrushChoiceTemplateSelector.cs" />
     <Compile Include="BrushEditorControl.cs" />

--- a/Xamarin.PropertyEditing.Windows/XamlHelper.cs
+++ b/Xamarin.PropertyEditing.Windows/XamlHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Media;
@@ -6,17 +7,44 @@ namespace Xamarin.PropertyEditing.Windows
 {
 	internal static class XamlHelper
 	{
-		public static IEnumerable<T> GetDescendants<T> (this UIElement parent)
+		public static IEnumerable<T> GetDescendants<T> (this UIElement self)
 			where T : UIElement
 		{
-			var childCount = VisualTreeHelper.GetChildrenCount (parent);
+			if (self == null)
+				throw new ArgumentNullException (nameof (self));
+
+			var childCount = VisualTreeHelper.GetChildrenCount (self);
 			for (var i = 0; i < childCount; i++) {
-				if (VisualTreeHelper.GetChild (parent, i) is UIElement child) {
+				if (VisualTreeHelper.GetChild (self, i) is UIElement child) {
 					if (child is T correctlyTypedChild) yield return correctlyTypedChild;
 					IEnumerable<T> grandChildren = GetDescendants<T> (child);
 					foreach (T grandChild in grandChildren) yield return grandChild;
 				}
 			}
+		}
+
+		public static T FindParent<T> (this UIElement self)
+			where T : UIElement
+		{
+			UIElement parent = VisualTreeHelper.GetParent (self) as UIElement;
+			if (parent == null)
+				return default(T);
+
+			return parent.FindParentOrSelf<T>();
+		}
+
+		public static T FindParentOrSelf<T> (this UIElement self)
+			where T : UIElement
+		{
+			if (self == null)
+				throw new ArgumentNullException (nameof (self));
+
+			DependencyObject parent = self;
+			while (!(parent is T) && parent != null) {
+				parent = VisualTreeHelper.GetParent (parent);
+			}
+
+			return (T)parent;
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/AsyncValue.cs
+++ b/Xamarin.PropertyEditing/AsyncValue.cs
@@ -1,0 +1,61 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.PropertyEditing
+{
+	internal sealed class AsyncValue<T>
+		: INotifyPropertyChanged
+	{
+		public AsyncValue (Task<T> task, T defaultValue = default(T))
+		{
+			if (task == null)
+				throw new ArgumentNullException (nameof(task));
+
+			this.task = task;
+			this.defaultValue = defaultValue;
+
+			TaskScheduler scheduler = TaskScheduler.Current;
+			if (SynchronizationContext.Current != null)
+				scheduler = TaskScheduler.FromCurrentSynchronizationContext ();
+
+			this.task.ContinueWith (t => {
+				IsRunning = false;
+			}, scheduler);
+
+			this.task.ContinueWith (t => {
+				OnPropertyChanged (nameof(Value));
+			}, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, scheduler);
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public bool IsRunning
+		{
+			get { return this.isRunning; }
+			set
+			{
+				if (this.isRunning == value)
+					return;
+
+				this.isRunning = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public Task<T> Task => this.task;
+
+		public T Value => (this.task.Status == TaskStatus.RanToCompletion) ? this.task.Result : this.defaultValue;
+
+		private bool isRunning = true;
+		private readonly Task<T> task;
+		private readonly T defaultValue;
+
+		private void OnPropertyChanged ([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/AsyncValue.cs
+++ b/Xamarin.PropertyEditing/AsyncValue.cs
@@ -9,7 +9,7 @@ namespace Xamarin.PropertyEditing
 	internal sealed class AsyncValue<T>
 		: INotifyPropertyChanged
 	{
-		public AsyncValue (Task<T> task, T defaultValue = default(T))
+		public AsyncValue (Task<T> task, T defaultValue = default(T), TaskScheduler scheduler = null)
 		{
 			if (task == null)
 				throw new ArgumentNullException (nameof(task));
@@ -17,9 +17,11 @@ namespace Xamarin.PropertyEditing
 			this.task = task;
 			this.defaultValue = defaultValue;
 
-			TaskScheduler scheduler = TaskScheduler.Current;
-			if (SynchronizationContext.Current != null)
-				scheduler = TaskScheduler.FromCurrentSynchronizationContext ();
+			if (scheduler == null) {
+				scheduler = TaskScheduler.Current;
+				if (SynchronizationContext.Current != null)
+					scheduler = TaskScheduler.FromCurrentSynchronizationContext ();
+			}
 
 			this.task.ContinueWith (t => {
 				IsRunning = false;

--- a/Xamarin.PropertyEditing/Extensions.cs
+++ b/Xamarin.PropertyEditing/Extensions.cs
@@ -30,6 +30,26 @@ namespace Xamarin.PropertyEditing
 				self.Add (item);
 		}
 
+		public static void ReplaceOrAdd<T> (this ICollection<T> self, T replace, T with)
+		{
+			if (self == null)
+				throw new ArgumentNullException (nameof (self));
+
+			IList<T> list = self as IList<T>;
+			if (list != null) {
+				int i = list.IndexOf (replace);
+				if (i != -1)
+					list[i] = with;
+				else
+					list.Add (with);
+
+				return;
+			}
+
+			self.Remove (replace);
+			self.Add (with);
+		}
+
 		public static bool TryRemove<TKey, TElement> (this IDictionary<TKey, TElement> self, TKey key, out TElement element)
 		{
 			if (!self.TryGetValue (key, out element))

--- a/Xamarin.PropertyEditing/IAssemblyInfo.cs
+++ b/Xamarin.PropertyEditing/IAssemblyInfo.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Xamarin.PropertyEditing
+{
+	public interface IAssemblyInfo
+	{
+		string Name { get; }
+	}
+
+	public class AssemblyInfo
+		: IAssemblyInfo, IEquatable<AssemblyInfo>
+	{
+		public AssemblyInfo (string name)
+		{
+			if (name == null)
+				throw new ArgumentNullException (nameof(name));
+
+			Name = name;
+		}
+
+		public string Name
+		{
+			get;
+		}
+
+		public bool Equals (AssemblyInfo other)
+		{
+			if (ReferenceEquals (null, other))
+				return false;
+			if (ReferenceEquals (this, other))
+				return true;
+
+			return string.Equals (Name, other.Name);
+		}
+
+		public override bool Equals (object obj)
+		{
+			if (ReferenceEquals (null, obj))
+				return false;
+			if (ReferenceEquals (this, obj))
+				return true;
+			if (obj.GetType () != GetType ())
+				return false;
+
+			return Equals ((AssemblyInfo) obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			return Name.GetHashCode ();
+		}
+
+		public static bool operator == (AssemblyInfo left, AssemblyInfo right)
+		{
+			return Equals (left, right);
+		}
+
+		public static bool operator != (AssemblyInfo left, AssemblyInfo right)
+		{
+			return !Equals (left, right);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/IAssemblyInfo.cs
+++ b/Xamarin.PropertyEditing/IAssemblyInfo.cs
@@ -5,20 +5,31 @@ namespace Xamarin.PropertyEditing
 	public interface IAssemblyInfo
 	{
 		string Name { get; }
+
+		/// <summary>
+		/// Gets whether the assembly is directly relevant to the current project.
+		/// </summary>
+		bool IsRelevant { get; }
 	}
 
 	public class AssemblyInfo
 		: IAssemblyInfo, IEquatable<AssemblyInfo>
 	{
-		public AssemblyInfo (string name)
+		public AssemblyInfo (string name, bool isRelevant)
 		{
 			if (name == null)
 				throw new ArgumentNullException (nameof(name));
 
 			Name = name;
+			IsRelevant = isRelevant;
 		}
 
 		public string Name
+		{
+			get;
+		}
+
+		public bool IsRelevant
 		{
 			get;
 		}
@@ -30,7 +41,7 @@ namespace Xamarin.PropertyEditing
 			if (ReferenceEquals (this, other))
 				return true;
 
-			return string.Equals (Name, other.Name);
+			return String.Equals (Name, other.Name) && (IsRelevant == other.IsRelevant);
 		}
 
 		public override bool Equals (object obj)
@@ -47,7 +58,11 @@ namespace Xamarin.PropertyEditing
 
 		public override int GetHashCode ()
 		{
-			return Name.GetHashCode ();
+			unchecked {
+				int hashCode = Name.GetHashCode ();
+				hashCode = (hashCode * 397) ^ IsRelevant.GetHashCode ();
+				return hashCode;
+			}
 		}
 
 		public static bool operator == (AssemblyInfo left, AssemblyInfo right)

--- a/Xamarin.PropertyEditing/IEditorProvider.cs
+++ b/Xamarin.PropertyEditing/IEditorProvider.cs
@@ -1,9 +1,14 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Xamarin.PropertyEditing
 {
 	public interface IEditorProvider
 	{
 		Task<IObjectEditor> GetObjectEditorAsync (object item);
+
+		/// <summary>
+		/// Creates a representation value of the <paramref name="type"/> and returns it.
+		/// </summary>
+		Task<object> CreateObjectAsync (ITypeInfo type);
 	}
 }

--- a/Xamarin.PropertyEditing/IObjectEditor.cs
+++ b/Xamarin.PropertyEditing/IObjectEditor.cs
@@ -58,6 +58,8 @@ namespace Xamarin.PropertyEditing
 		/// </summary>
 		event EventHandler<EditorPropertyChangedEventArgs> PropertyChanged;
 
+		Task<IReadOnlyList<ITypeInfo>> GetAssignableTypesAsync (IPropertyInfo property);
+
 		/*
 		 * Dealing with async values in the context of what's possible across all target platforms is a bit complex.
 		 * While implicit safety may be able to be ensured, it would be exhaustive to reason it out and could change

--- a/Xamarin.PropertyEditing/ITypeInfo.cs
+++ b/Xamarin.PropertyEditing/ITypeInfo.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace Xamarin.PropertyEditing
+{
+	public interface ITypeInfo
+	{
+		IAssemblyInfo Assembly { get; }
+		string NameSpace { get; }
+		string Name { get; }
+	}
+
+	public class TypeInfo
+		: ITypeInfo, IEquatable<TypeInfo>
+	{
+		public TypeInfo (IAssemblyInfo assembly, string nameSpace, string name)
+		{
+			if (assembly == null)
+				throw new ArgumentNullException (nameof(assembly));
+			if (nameSpace == null)
+				throw new ArgumentNullException (nameof(nameSpace));
+			if (name == null)
+				throw new ArgumentNullException (nameof(name));
+
+			Assembly = assembly;
+			NameSpace = nameSpace;
+			Name = name;
+		}
+
+		public IAssemblyInfo Assembly
+		{
+			get;
+		}
+
+		public string NameSpace
+		{
+			get;
+		}
+
+		public string Name
+		{
+			get;
+		}
+
+		public bool Equals (TypeInfo other)
+		{
+			if (ReferenceEquals (null, other))
+				return false;
+			if (ReferenceEquals (this, other))
+				return true;
+
+			return Assembly.Equals (other.Assembly) && String.Equals (NameSpace, other.NameSpace) && String.Equals (Name, other.Name);
+		}
+
+		public override bool Equals (object obj)
+		{
+			if (ReferenceEquals (null, obj))
+				return false;
+			if (ReferenceEquals (this, obj))
+				return true;
+			if (obj.GetType () != GetType ())
+				return false;
+
+			return Equals ((TypeInfo) obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			unchecked {
+				var hashCode = Assembly.GetHashCode ();
+				hashCode = (hashCode * 397) ^ NameSpace.GetHashCode ();
+				hashCode = (hashCode * 397) ^ Name.GetHashCode ();
+				return hashCode;
+			}
+		}
+
+		public static bool operator == (TypeInfo left, TypeInfo right)
+		{
+			return Equals (left, right);
+		}
+
+		public static bool operator != (TypeInfo left, TypeInfo right)
+		{
+			return !Equals (left, right);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/ObservableCollectionEx.cs
+++ b/Xamarin.PropertyEditing/ObservableCollectionEx.cs
@@ -9,6 +9,15 @@ namespace Xamarin.PropertyEditing
 	internal class ObservableCollectionEx<T>
 		: ObservableCollection<T>
 	{
+		public ObservableCollectionEx()
+		{
+		}
+
+		public ObservableCollectionEx (IEnumerable<T> collection)
+			: base (collection)
+		{
+		}
+
 		public void AddRange (IEnumerable<T> range)
 		{
 			if (range == null)

--- a/Xamarin.PropertyEditing/OrderedDictionary.cs
+++ b/Xamarin.PropertyEditing/OrderedDictionary.cs
@@ -217,6 +217,21 @@ namespace Cadenza.Collections
 			return this.keyOrder.IndexOf (key, startIndex);
 		}
 
+		public TKey KeyAt (int index)
+		{
+			return this.keyOrder[index];
+		}
+
+		public int BinarySearch (TKey key)
+		{
+			return this.keyOrder.BinarySearch (key);
+		}
+
+		public int BinarySearch (TKey key, int startIndex, int count)
+		{
+			return this.keyOrder.BinarySearch (startIndex, count, key, null);
+		}
+
 		/// <summary>
 		///	Gets the index of <paramref name="key"/> between the range given by <paramref name="startIndex"/> and <paramref name="count"/>.
 		/// </summary>

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string Cancel {
+            get {
+                return ResourceManager.GetString("Cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CMYK.
         /// </summary>
         public static string CMYK {
@@ -151,11 +160,29 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to Local Value.
+        /// </summary>
+        public static string ConvertToLocalValue {
+            get {
+                return ResourceManager.GetString("ConvertToLocalValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Current color.
         /// </summary>
         public static string CurrentColor {
             get {
                 return ResourceManager.GetString("CurrentColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom Expression….
+        /// </summary>
+        public static string CustomExpressionEllipsis {
+            get {
+                return ResourceManager.GetString("CustomExpressionEllipsis", resourceCulture);
             }
         }
         
@@ -183,24 +210,6 @@ namespace Xamarin.PropertyEditing.Properties {
         public static string CyanMagentaYellowBlack {
             get {
                 return ResourceManager.GetString("CyanMagentaYellowBlack", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Convert to Local Value.
-        /// </summary>
-        public static string ConvertToLocalValue {
-            get {
-                return ResourceManager.GetString("ConvertToLocalValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Custom Expression….
-        /// </summary>
-        public static string CustomExpressionEllipsis {
-            get {
-                return ResourceManager.GetString("CustomExpressionEllipsis", resourceCulture);
             }
         }
         
@@ -385,6 +394,15 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to New.
+        /// </summary>
+        public static string New {
+            get {
+                return ResourceManager.GetString("New", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No brush.
         /// </summary>
         public static string NoBrush {
@@ -399,6 +417,15 @@ namespace Xamarin.PropertyEditing.Properties {
         public static string NoName {
             get {
                 return ResourceManager.GetString("NoName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        public static string OK {
+            get {
+                return ResourceManager.GetString("OK", resourceCulture);
             }
         }
         
@@ -457,6 +484,15 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reset.
+        /// </summary>
+        public static string Reset {
+            get {
+                return ResourceManager.GetString("Reset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to RGB.
         /// </summary>
         public static string RGB {
@@ -484,11 +520,29 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search Objects.
+        /// </summary>
+        public static string SearchObjectsTitle {
+            get {
+                return ResourceManager.GetString("SearchObjectsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search properties.
         /// </summary>
         public static string SearchProperties {
             get {
                 return ResourceManager.GetString("SearchProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Object.
+        /// </summary>
+        public static string SelectObjectTitle {
+            get {
+                return ResourceManager.GetString("SelectObjectTitle", resourceCulture);
             }
         }
         
@@ -502,19 +556,20 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Show all assemblies.
+        /// </summary>
+        public static string ShowAllAssemblies {
+            get {
+                return ResourceManager.GetString("ShowAllAssemblies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Solid color brush.
         /// </summary>
         public static string SolidBrush {
             get {
                 return ResourceManager.GetString("SolidBrush", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to Reset.
-        /// </summary>
-        public static string Reset {
-            get {
-                return ResourceManager.GetString("Reset", resourceCulture);
             }
         }
         

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -319,7 +319,25 @@
   <data name="ShowAdvancedProperties" xml:space="preserve">
     <value>Show advanced properties</value>
   </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="ShowAllAssemblies" xml:space="preserve">
+    <value>_Show all assemblies</value>
+  </data>
   <data name="SearchProperties" xml:space="preserve">
     <value>Search properties</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="SearchObjectsTitle" xml:space="preserve">
+    <value>Search Objects</value>
+  </data>
+  <data name="SelectObjectTitle" xml:space="preserve">
+    <value>Select Object</value>
   </data>
 </root>

--- a/Xamarin.PropertyEditing/Reflection/ReflectionEditorProvider.cs
+++ b/Xamarin.PropertyEditing/Reflection/ReflectionEditorProvider.cs
@@ -10,5 +10,20 @@ namespace Xamarin.PropertyEditing.Reflection
 		{
 			return Task.FromResult<IObjectEditor> (new ReflectionObjectEditor (item));
 		}
+
+		public Task<object> CreateObjectAsync (ITypeInfo type)
+		{
+			var realType = GetRealType (type);
+			if (realType == null)
+				return Task.FromResult<object> (null);
+
+			object instance = Activator.CreateInstance (realType);
+			return Task.FromResult (instance);
+		}
+
+		public static Type GetRealType (ITypeInfo type)
+		{
+			return Type.GetType ($"{type.NameSpace}.{type.Name}, {type.Assembly.Name}");
+		}
 	}
 }

--- a/Xamarin.PropertyEditing/Reflection/ReflectionObjectEditor.cs
+++ b/Xamarin.PropertyEditing/Reflection/ReflectionObjectEditor.cs
@@ -97,8 +97,9 @@ namespace Xamarin.PropertyEditing.Reflection
 			return Task.Run (() => {
 				ReflectionPropertyInfo realInfo = (ReflectionPropertyInfo) property;
 				var assemblies = AppDomain.CurrentDomain.GetAssemblies ();
+				var entry = Assembly.GetEntryAssembly();
 
-				return (IReadOnlyList<ITypeInfo>)assemblies.Select (a => new { Assembly = a, Info = new AssemblyInfo (a.FullName)})
+				return (IReadOnlyList<ITypeInfo>)assemblies.Select (a => new { Assembly = a, Info = new AssemblyInfo (a.FullName, a == entry)})
 					.SelectMany (a =>
 						a.Assembly.DefinedTypes.Select (t => new { Type = t, Assembly = a }))
 					.AsParallel ()

--- a/Xamarin.PropertyEditing/ValueSource.cs
+++ b/Xamarin.PropertyEditing/ValueSource.cs
@@ -14,6 +14,7 @@ namespace Xamarin.PropertyEditing
 		Style = 4,
 		Inherited = 5,
 		DefaultStyle = 6,
+		Unknown = 7,
 	}
 
 	[Flags]

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xamarin.PropertyEditing.Drawing;
 
 namespace Xamarin.PropertyEditing.ViewModels
@@ -43,9 +44,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		protected override void UpdateCurrentValue ()
+		protected override async Task UpdateCurrentValueAsync ()
 		{
-			base.UpdateCurrentValue ();
+			await base.UpdateCurrentValueAsync ();
 			OnPropertyChanged (nameof (Opacity));
 		}
 	}

--- a/Xamarin.PropertyEditing/ViewModels/EditorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/EditorViewModel.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Threading.Tasks;
 
 namespace Xamarin.PropertyEditing.ViewModels
 {
@@ -17,8 +18,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 			Editors = observableEditors;
 			observableEditors.CollectionChanged += OnEditorsChanged;
 			observableEditors.AddItems (editors); // Purposefully after the event hookup
-
-			//TODO: Property is being set after the editors added trickle down since its in the subclass
 		}
 
 		public abstract string Category
@@ -72,11 +71,20 @@ namespace Xamarin.PropertyEditing.ViewModels
 					break;
 			}
 
-			UpdateCurrentValue ();
+			RequestCurrentValueUpdate();
 		}
 
-		protected virtual void UpdateCurrentValue()
+		/// <summary>
+		/// Requests that the current value be updated, not immediate.
+		/// </summary>
+		protected async void RequestCurrentValueUpdate ()
 		{
+			await UpdateCurrentValueAsync ();
+		}
+
+		protected virtual Task UpdateCurrentValueAsync()
+		{
+			return Task.FromResult (true);
 		}
 
 		protected virtual void SetupEditor (IObjectEditor editor)

--- a/Xamarin.PropertyEditing/ViewModels/EditorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/EditorViewModel.cs
@@ -82,6 +82,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 			await UpdateCurrentValueAsync ();
 		}
 
+		/// <remarks>
+		/// If your sub-class needs extra setup in the ctor before the value can be executed,
+		/// safe guard your override of this method as it will be run when the editors are
+		/// added in the base ctor before your sub-class' ctor has run. After you've completed
+		/// setup, call <see cref="RequestCurrentValueUpdate"/>.
+		/// </remarks>
 		protected virtual Task UpdateCurrentValueAsync()
 		{
 			return Task.FromResult (true);

--- a/Xamarin.PropertyEditing/ViewModels/EventViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/EventViewModel.cs
@@ -17,7 +17,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				throw new ArgumentNullException (nameof (ev));
 
 			Event = ev;
-			UpdateCurrentValue ();
+			RequestCurrentValueUpdate();
 		}
 
 		public IEventInfo Event
@@ -41,7 +41,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		protected override async void UpdateCurrentValue ()
+		protected override async Task UpdateCurrentValueAsync ()
 		{
 			if (Event == null)
 				return;
@@ -103,7 +103,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			if (!String.IsNullOrWhiteSpace (name))
 				await editor.AttachHandlerAsync (Event, name);
 
-			UpdateCurrentValue ();
+			await UpdateCurrentValueAsync ();
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Cadenza.Collections;
+
+namespace Xamarin.PropertyEditing.ViewModels
+{
+	internal class TypeRequestedEventArgs
+		: EventArgs
+	{
+		/// <summary>
+		/// Gets or sets the type selected by the user from the UI
+		/// </summary>
+		public ITypeInfo SelectedType
+		{
+			get;
+			set;
+		}
+	}
+
+	internal class ObjectPropertyViewModel
+		: PropertyViewModel
+	{
+		public ObjectPropertyViewModel (IEditorProvider provider, TargetPlatform targetPlatform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
+			: base (property, editors)
+		{
+			if (provider == null)
+				throw new ArgumentNullException (nameof(provider));
+			if (targetPlatform == null)
+				throw new ArgumentNullException (nameof(targetPlatform));
+
+			this.provider = provider;
+			ValueModel = new ObjectViewModel (provider, targetPlatform);
+			RequestCurrentValueUpdate();
+
+			QueryTypes();
+			CreateInstanceCommand = new RelayCommand (CreateInstance, () => IsAvailable && !IsCreateInstancePending);
+			ClearValueCommand = new RelayCommand (OnClearValue, CanClearValue);
+		}
+
+		public event EventHandler<TypeRequestedEventArgs> TypeRequested;
+
+		public AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> AssignableTypes
+		{
+			get { return this.assignableTypes; }
+			private set
+			{
+				if (this.assignableTypes == value)
+					return;
+
+				this.assignableTypes = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ICommand CreateInstanceCommand
+		{
+			get;
+		}
+
+		public bool CanDelve
+		{
+			get { return this.canDelve; }
+			private set
+			{
+				if (this.canDelve == value)
+					return;
+
+				this.canDelve = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ObjectViewModel ValueModel
+		{
+			get;
+		}
+
+		public ITypeInfo ValueType
+		{
+			get { return this.valueType; }
+			private set
+			{
+				if (Equals (this.valueType, value))
+					return;
+
+				this.valueType = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ValueSource ValueSource
+		{
+			get { return this.valueSource; }
+			private set
+			{
+				if (this.valueSource == value)
+					return;
+
+				this.valueSource = value;
+				OnPropertyChanged();
+			}
+		}
+
+		protected override void OnPropertyChanged ([CallerMemberName] string propertyName = null)
+		{
+			if (propertyName == nameof(IsAvailable)) {
+				((RelayCommand)CreateInstanceCommand).ChangeCanExecute();
+			}
+
+			base.OnPropertyChanged (propertyName);
+		}
+
+		protected override async Task UpdateCurrentValueAsync ()
+		{
+			if (ValueModel == null)
+				return;
+
+			using (await AsyncWork.RequestAsyncWork (this)) {
+				ValueModel.SelectedObjects.Clear();
+
+				bool multipleTypes = false, multipleSources = false;
+				ValueSource? source = null;
+				ITypeInfo type = null;
+
+				ValueInfo<object>[] values = await Task.WhenAll (Editors.Select (ed => ed.GetValueAsync<object> (Property)));
+				for (int i = 0; i < values.Length; i++) {
+					ValueInfo<object> info = values[i];
+					ValueModel.SelectedObjects.Add (info.Value);
+
+					if (source == null)
+						source = info.Source;
+					else if (source.Value != info.Source)
+						multipleSources = true;
+
+					if (type == null)
+						type = info.ValueDescriptor as ITypeInfo;
+					else if (!multipleTypes && !Equals (type, info.ValueDescriptor as ITypeInfo))
+						multipleTypes = true;
+				}
+
+				MultipleValues = multipleTypes;
+				ValueType = (!multipleTypes) ? type : null;
+				if (multipleSources)
+					ValueSource = ValueSource.Unknown;
+				else
+					ValueSource = source ?? ValueSource.Default;
+
+				CanDelve = Editors.Count > 0;
+			}
+		}
+
+		private readonly IEditorProvider provider;
+		private AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes;
+		private bool createInstancePending;
+		private ValueSource valueSource;
+		private ITypeInfo valueType;
+		private bool canDelve;
+
+		private bool IsCreateInstancePending
+		{
+			get { return this.createInstancePending; }
+			set
+			{
+				if (this.createInstancePending == value)
+					return;
+
+				this.createInstancePending = value;
+				((RelayCommand)CreateInstanceCommand).ChangeCanExecute();
+			}
+		}
+
+		private async void OnClearValue ()
+		{
+			await SetValueAsync (Enumerable.Repeat (new ValueInfo<object> {
+				Source = ValueSource.Default,
+				Value = null
+			}, Editors.Count).ToArray ());
+		}
+
+		private bool CanClearValue ()
+		{
+			return (Property.ValueSources.HasFlag (ValueSources.Local) && Property.ValueSources.HasFlag (ValueSources.Default) && ValueSource == ValueSource.Local);
+		}
+
+		private Task SetValueAsync (ValueInfo<object>[] valueInfo)
+		{
+			Task[] setValues = new Task[Editors.Count];
+			int i = 0;
+			foreach (IObjectEditor editors in Editors) {
+				setValues[i++] = editors.SetValueAsync (Property, valueInfo[i]);
+			}
+
+			return Task.WhenAll (setValues);
+		}
+
+		private void QueryTypes ()
+		{
+			AssignableTypes = new AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> (GetAssignableTypesAsync());
+		}
+
+		private async Task<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> GetAssignableTypesAsync ()
+		{
+			Task<IReadOnlyList<ITypeInfo>>[] typeTasks = Editors.Select (o => o.GetAssignableTypesAsync (Property)).ToArray();
+			IReadOnlyList<ITypeInfo>[] lists = await Task.WhenAll (typeTasks).ConfigureAwait (false);
+
+			var assemblies = new Dictionary<IAssemblyInfo, ILookup<string, ITypeInfo>> ();
+			foreach (ITypeInfo type in lists.SelectMany (t => t)) {
+				if (!assemblies.TryGetValue (type.Assembly, out ILookup<string, ITypeInfo> types)) {
+					assemblies[type.Assembly] = types = new ObservableLookup<string, ITypeInfo> ();
+				}
+
+				((IMutableLookup<string, ITypeInfo>) types).Add (type.NameSpace, type);
+			}
+
+			return assemblies;
+		}
+
+		private async void CreateInstance ()
+		{
+			IsCreateInstancePending = true;
+
+			try {
+				using (await AsyncWork.RequestAsyncWork (this)) {
+					ITypeInfo selectedType = null;
+				
+					var types = await AssignableTypes.Task;
+					// If there's only one assignable type, we'll skip selection
+					if (types.Count == 1) {
+						var kvp = types.First ();
+						if (kvp.Value.Count == 1) {
+							var group = kvp.Value.First ();
+							if (!group.Skip (1).Any ()) {
+								selectedType = group.First ();
+							}
+						}
+					}
+
+					if (selectedType == null) {
+						var args = new TypeRequestedEventArgs ();
+						TypeRequested?.Invoke (this, args);
+						if (args.SelectedType == null)
+							return;
+
+						selectedType = args.SelectedType;
+					}
+
+					var values = new ValueInfo<object>[Editors.Count];
+					for (int i = 0; i < values.Length; i++) {
+						values[i] = new ValueInfo<object> {
+							Value = await this.provider.CreateObjectAsync (selectedType),
+							Source = ValueSource.Local
+						};
+					}
+				}
+			} finally {
+				IsCreateInstancePending = false;
+			}
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -123,8 +123,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 				ValueInfo<object>[] values = await Task.WhenAll (Editors.Where (e => e != null).Select (ed => ed.GetValueAsync<object> (Property)));
 				for (int i = 0; i < values.Length; i++) {
 					ValueInfo<object> info = values[i];
-					ValueModel.SelectedObjects.Add (info.Value);
-
 					if (source == null)
 						source = info.Source;
 					else if (source.Value != info.Source)
@@ -134,6 +132,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 						type = info.ValueDescriptor as ITypeInfo;
 					else if (!multipleTypes && !Equals (type, info.ValueDescriptor as ITypeInfo))
 						multipleTypes = true;
+
+					if (info.Value != null)
+						ValueModel.SelectedObjects.Add (info.Value);
 				}
 
 				MultipleValues = multipleTypes;

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -128,7 +128,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				ValueSource? source = null;
 				ITypeInfo type = null;
 
-				ValueInfo<object>[] values = await Task.WhenAll (Editors.Select (ed => ed.GetValueAsync<object> (Property)));
+				ValueInfo<object>[] values = await Task.WhenAll (Editors.Where (e => e != null).Select (ed => ed.GetValueAsync<object> (Property)));
 				for (int i = 0; i < values.Length; i++) {
 					ValueInfo<object> info = values[i];
 					ValueModel.SelectedObjects.Add (info.Value);
@@ -151,7 +151,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				else
 					ValueSource = source ?? ValueSource.Default;
 
-				CanDelve = Editors.Count > 0;
+				CanDelve = values.Length > 0;
 			}
 		}
 

--- a/Xamarin.PropertyEditing/ViewModels/ObjectViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectViewModel.cs
@@ -3,27 +3,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 	internal class ObjectViewModel
 		: PropertiesViewModel
 	{
-		private object value;
-
 		public ObjectViewModel (IEditorProvider provider, TargetPlatform targetPlatform)
 			: base (provider, targetPlatform)
 		{
-		}
-
-		public object Value
-		{
-			get { return this.value; }
-			set
-			{
-				if (Equals (this.value, value))
-					return;
-
-				this.value = value;
-				OnPropertyChanged ();
-
-				SelectedObjects.Clear ();
-				SelectedObjects.Add (value);
-			}
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -156,7 +156,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				case NotifyCollectionChangedAction.Remove:
 					removedEditors = new IObjectEditor[e.OldItems.Count];
 					for (int i = 0; i < e.OldItems.Count; i++) {
-						IObjectEditor editor = this.objEditors.First (oe => oe.Target == e.OldItems[i]);
+						IObjectEditor editor = this.objEditors.First (oe => oe?.Target == e.OldItems[i]);
 						INotifyCollectionChanged notifier = editor.Properties as INotifyCollectionChanged;
 						if (notifier != null)
 							notifier.CollectionChanged -= OnObjectEditorPropertiesChanged;
@@ -172,7 +172,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 					removedEditors = new IObjectEditor[this.objEditors.Count];
 					for (int i = 0; i < removedEditors.Length; i++) {
 						removedEditors[i] = this.objEditors[i];
-						INotifyCollectionChanged notifier = removedEditors[i].Properties as INotifyCollectionChanged;
+						INotifyCollectionChanged notifier = removedEditors[i]?.Properties as INotifyCollectionChanged;
 						if (notifier != null)
 							notifier.CollectionChanged -= OnObjectEditorPropertiesChanged;
 					}
@@ -286,8 +286,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 			IObjectEventEditor events = this.objEditors[0] as IObjectEventEditor;
 			var newEventSet = new HashSet<IEventInfo> (events?.Events ?? Enumerable.Empty<IEventInfo> ());
 
-			string newTypeName = this.objEditors[0].TypeName;
-			var newPropertySet = new HashSet<IPropertyInfo> (this.objEditors[0].Properties);
+			string newTypeName = this.objEditors[0]?.TypeName;
+			var newPropertySet = new HashSet<IPropertyInfo> (this.objEditors[0]?.Properties ?? Enumerable.Empty<IPropertyInfo>());
 			for (int i = 1; i < this.objEditors.Count; i++) {
 				IObjectEditor editor = this.objEditors[i];
 				newPropertySet.IntersectWith (editor.Properties);
@@ -391,7 +391,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			IObjectEditor[] newEditors = await Task.WhenAll (newEditorTasks);
 			for (int i = 0; i < newEditors.Length; i++) {
-				var notifier = newEditors[i].Properties as INotifyCollectionChanged;
+				IObjectEditor editor = newEditors[i];
+				if (editor == null)
+					continue;
+
+				var notifier = editor.Properties as INotifyCollectionChanged;
 				if (notifier != null)
 					notifier.CollectionChanged += OnObjectEditorPropertiesChanged;
 			}

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -420,6 +420,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 			} else if (property.Type.IsEnum) {
 				Type type = typeof(EnumPropertyViewModel<>).MakeGenericType (property.Type);
 				return (PropertyViewModel) Activator.CreateInstance (type, property, this.objEditors);
+			} else if (property.Type == typeof(object)) {
+				return new ObjectPropertyViewModel (EditorProvider, TargetPlatform, property, this.objEditors);
 			}
 
 			Func<IPropertyInfo, IEnumerable<IObjectEditor>, PropertyViewModel> vmFactory;

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
@@ -20,7 +18,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		{
 			SetValueResourceCommand = new RelayCommand<Resource> (OnSetValueToResource, CanSetValueToResource);
 			ClearValueCommand = new RelayCommand (OnClearValue, CanClearValue);
-			UpdateCurrentValue ();
+			RequestCurrentValueUpdate();
 		}
 
 		public ValueSource ValueSource => this.value != null ? this.value.Source : ValueSource.Default;
@@ -69,11 +67,17 @@ namespace Xamarin.PropertyEditing.ViewModels
 			return validationValue;
 		}
 
+		/// <remarks>
+		/// For updating property-type-specific value properties, override this. <see cref="PropertyViewModel.MultipleValues"/> <see cref="Value"/> is up to date
+		/// </remarks>
 		protected virtual void OnValueChanged ()
 		{
 		}
 
-		protected override async void UpdateCurrentValue ()
+		/// <summary>
+		/// Obtains the current value from the editors and updates the value properties.
+		/// </summary>
+		protected override async Task UpdateCurrentValueAsync ()
 		{
 			if (Property == null)
 				return;
@@ -139,7 +143,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 					}
 
 					await Task.WhenAll (setValues);
-					UpdateCurrentValue ();
+					await UpdateCurrentValueAsync ();
 				} catch (Exception ex) {
 					AggregateException aggregate = ex as AggregateException;
 					if (aggregate != null) {
@@ -316,7 +320,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 					return;
 		
 				// TODO: Smarter querying, can query the single editor and check against MultipleValues
-				UpdateCurrentValue ();
+				await UpdateCurrentValueAsync ();
 			} finally {
 				work?.Dispose ();
 			}

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -52,16 +52,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		public ICommand SetValueResourceCommand
-		{
-			get;
-		}
-
-		public ICommand ClearValueCommand
-		{
-			get;
-		}
-
 		protected virtual TValue ValidateValue (TValue validationValue)
 		{
 			return validationValue;
@@ -261,6 +251,18 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
+		public ICommand SetValueResourceCommand
+		{
+			get;
+			protected set;
+		}
+
+		public ICommand ClearValueCommand
+		{
+			get;
+			protected set;
+		}
+
 		public bool HasErrors => this.error != null;
 
 		public IEnumerable GetErrors (string propertyName)
@@ -281,19 +283,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 				this.variation = value;
 				OnPropertyChanged ();
-			}
-		}
-
-		public bool CanDelve => ValueModel != null;
-
-		public ObjectViewModel ValueModel
-		{
-			get { return this.valueModel; }
-			private set
-			{
-				this.valueModel = value;
-				OnPropertyChanged ();
-				OnPropertyChanged (nameof (CanDelve));
 			}
 		}
 
@@ -328,18 +317,23 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		protected override void SetupEditor (IObjectEditor editor)
 		{
+			if (editor == null)
+				return;
+
 			base.SetupEditor (editor);
 			editor.PropertyChanged += OnEditorPropertyChanged;
 		}
 
 		protected override void TeardownEditor (IObjectEditor editor)
 		{
+			if (editor == null)
+				return;
+
 			base.TeardownEditor (editor);
 			editor.PropertyChanged -= OnEditorPropertyChanged;
 		}
 
 		private HashSet<IPropertyInfo> constraintProperties;
-		private ObjectViewModel valueModel;
 		private PropertyVariation variation;
 		private string error;
 		private Task<bool> isAvailable;

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -251,6 +251,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
+		public virtual bool CanDelve => false;
+
 		public ICommand SetValueResourceCommand
 		{
 			get;

--- a/Xamarin.PropertyEditing/ViewModels/SimpleCollectionView.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SimpleCollectionView.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using Cadenza.Collections;
+
+namespace Xamarin.PropertyEditing.ViewModels
+{
+	internal class SimpleCollectionViewOptions
+	{
+		public event EventHandler OptionsChanged;
+
+		public SimpleCollectionViewOptions ChildOptions
+		{
+			get { return this.childOptions; }
+			set
+			{
+				if (this.childOptions == value)
+					return;
+
+				if (this.childOptions != null) {
+					this.childOptions.OptionsChanged -= OnChildOptionsChanged;
+				}
+
+				this.childOptions = value;
+				if (this.childOptions != null)
+					this.childOptions.OptionsChanged += OnChildOptionsChanged;
+
+				OnOptionsChanged();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the element selector with which elements will be arranged and grouped.
+		/// </summary>
+		public Func<object, string> DisplaySelector
+		{
+			get { return this.displaySelector; }
+			set {
+				if (this.displaySelector == value)
+					return;
+
+				this.displaySelector = value;
+				OnOptionsChanged();
+			}
+		}
+
+		public Func<object, IEnumerable> ChildrenSelector
+		{
+			get { return this.childrenSelector; }
+			set
+			{
+				if (this.childrenSelector == value)
+					return;
+
+				this.childrenSelector = value;
+				OnOptionsChanged();
+			}
+		}
+
+		private Func<object, IEnumerable> childrenSelector;
+		private Func<object, string> displaySelector;
+		private SimpleCollectionViewOptions childOptions;
+
+		private void OnChildOptionsChanged (object sender, EventArgs e)
+		{
+			OnOptionsChanged();
+		}
+
+		private void OnOptionsChanged()
+		{
+			OptionsChanged?.Invoke (this, EventArgs.Empty);
+		}
+	}
+
+	internal class SimpleCollectionView
+		: NotifyingObject, IEnumerable, INotifyCollectionChanged
+	{
+		public SimpleCollectionView (IEnumerable source, SimpleCollectionViewOptions options)
+		{
+			if (source == null)
+				throw new ArgumentNullException (nameof (source));
+			if (options == null)
+				throw new ArgumentNullException (nameof (options));
+
+			this.source = source;
+			Options = options;
+
+			var changed = source as INotifyCollectionChanged;
+			if (changed != null) {
+				changed.CollectionChanged += OnSourceCollectionChanged;
+			}
+		}
+
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+		public SimpleCollectionViewOptions Options
+		{
+			get { return this.options; }
+			set
+			{
+				if (this.options == value)
+					return;
+
+				if (this.options != null)
+					this.options.OptionsChanged -= OnOptionsPropertyChanged;
+
+				this.options = value;
+				if (this.options != null)
+					this.options.OptionsChanged += OnOptionsPropertyChanged;
+
+				Reset();
+			}
+		}
+
+		public bool HasChildElements => (this.arranged.Count > 0);
+
+		public bool IsFiltering => !String.IsNullOrWhiteSpace (FilterText);
+
+		public string FilterText
+		{
+			get { return this.filterText; }
+			set
+			{
+				if (this.filterText == value)
+					return;
+			
+				Filter (value);
+			}
+		}
+
+		public IEnumerator GetEnumerator ()
+		{
+			bool haveChildren = (Options.ChildOptions != null);
+
+			foreach (var kvp in this.arranged) {
+				if (!haveChildren)
+					yield return kvp.Value.Item;
+				else
+					yield return new KeyValuePair<string, SimpleCollectionView> (kvp.Key, kvp.Value.ChildrenView);
+			}
+		}
+
+		private struct Element
+		{
+			public object Item;
+			public SimpleCollectionView ChildrenView;
+		}
+
+		private readonly OrderedDictionary<string, Element> arranged = new OrderedDictionary<string, Element>();
+		private SimpleCollectionViewOptions options;
+		private IEnumerable source;
+		private string filterText;
+
+		private void OnSourceCollectionChanged (object sender, NotifyCollectionChangedEventArgs e)
+		{
+			switch (e.Action) {
+				default:
+					Reset();
+					break;
+			}
+		}
+
+		private void OnOptionsPropertyChanged (object sender, EventArgs e)
+		{
+			Reset();
+		}
+
+		private bool MatchesFilter (Element element)
+		{
+			if (!IsFiltering)
+				return true;
+
+			string display = Options.DisplaySelector (element.Item);
+			if (String.IsNullOrWhiteSpace (display))
+				return false;
+			if (display.StartsWith (FilterText))
+				return true;
+
+			return false;
+		}
+
+		private void Filter (string oldFilter, string newFilter, bool notify = true)
+		{
+			bool hadChildren = HasChildElements;
+
+			if (IsFiltering && (String.IsNullOrWhiteSpace (oldFilter) || FilterText.StartsWith (oldFilter))) {
+				var toRemove = new List<string>();
+				foreach (var kvp in this.arranged) {
+					var childView = kvp.Value.ChildrenView;
+					if (childView != null) {
+						childView.Filter (newFilter);
+						if (!childView.HasChildElements) {
+							toRemove.Add (kvp.Key);
+						}
+
+						continue;
+					}
+
+					if (!MatchesFilter (kvp.Value))
+						toRemove.Add (kvp.Key);
+				}
+
+				Remove (toRemove, notify);
+			} else {
+				Reset();
+			}
+
+			if (hadChildren != HasChildElements)
+				OnPropertyChanged (nameof(HasChildElements));
+		}
+
+		private void Remove (IReadOnlyList<string> keys, bool notify)
+		{
+			List<object> oldItems = new List<object> (keys.Count);
+			foreach (string key in keys) {
+				if (!this.arranged.TryRemove (key, out Element e))
+					continue;
+
+				oldItems.Add (Options.ChildOptions != null ? e.ChildrenView : e.Item);
+			}
+
+			if (oldItems.Count > 0) {
+				OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Remove, oldItems));
+			}
+		}
+
+		private void Reset()
+		{
+			this.arranged.Clear();
+
+			foreach (var element in this.source.Cast<object>().Select (o => new { Item = o, Key = options.DisplaySelector (o) }).OrderBy (e => e.Key)) {
+				SimpleCollectionView childView = null;
+				IEnumerable children = (Options.ChildrenSelector != null) ? options.ChildrenSelector (element.Item) : element.Item as IEnumerable;
+				if (Options.ChildOptions != null) {
+					if (children == null) {
+						throw new InvalidOperationException ("ChildOptions specified, but element not enumerable or no selector");
+					}
+
+					childView = new SimpleCollectionView (children, Options.ChildOptions);
+				}
+
+				Element e = new Element {
+					Item = element.Item,
+					ChildrenView = childView
+				};
+
+				this.arranged.Add (element.Key, e);
+			}
+
+			if (IsFiltering)
+				Filter (FilterText, FilterText, notify: false);
+
+			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Reset));
+		}
+
+		private void Filter (string newFilter)
+		{
+			string oldFilter = this.filterText;
+			this.filterText = newFilter;
+
+			Filter (oldFilter, newFilter);
+			if (oldFilter != newFilter) {
+				OnPropertyChanged (nameof (FilterText));
+				if (String.IsNullOrWhiteSpace (oldFilter) != String.IsNullOrWhiteSpace (newFilter))
+					OnPropertyChanged (nameof(IsFiltering));
+			}
+		}
+
+		private void OnCollectionChanged (NotifyCollectionChangedEventArgs e)
+		{
+			CollectionChanged?.Invoke (this, e);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/ViewModels/SimpleCollectionView.cs
+++ b/Xamarin.PropertyEditing/ViewModels/SimpleCollectionView.cs
@@ -9,8 +9,8 @@ using Cadenza.Collections;
 namespace Xamarin.PropertyEditing.ViewModels
 {
 	internal class SimpleCollectionViewOptions
+		: NotifyingObject
 	{
-		public event EventHandler OptionsChanged;
 
 		public SimpleCollectionViewOptions ChildOptions
 		{
@@ -20,15 +20,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 				if (this.childOptions == value)
 					return;
 
-				if (this.childOptions != null) {
-					this.childOptions.OptionsChanged -= OnChildOptionsChanged;
-				}
-
 				this.childOptions = value;
-				if (this.childOptions != null)
-					this.childOptions.OptionsChanged += OnChildOptionsChanged;
-
-				OnOptionsChanged();
+				OnPropertyChanged();
 			}
 		}
 
@@ -43,7 +36,20 @@ namespace Xamarin.PropertyEditing.ViewModels
 					return;
 
 				this.displaySelector = value;
-				OnOptionsChanged();
+				OnPropertyChanged();
+			}
+		}
+
+		public IComparer<string> DisplayComparer
+		{
+			get { return this.displayComparer; }
+			set
+			{
+				if (this.displayComparer == value)
+					return;
+
+				this.displayComparer = value;
+				OnPropertyChanged();
 			}
 		}
 
@@ -56,42 +62,36 @@ namespace Xamarin.PropertyEditing.ViewModels
 					return;
 
 				this.childrenSelector = value;
-				OnOptionsChanged();
+				OnPropertyChanged();
 			}
 		}
 
+		public Predicate<object> Filter
+		{
+			get { return this.filter; }
+			set
+			{
+				if (this.filter == value)
+					return;
+
+				this.filter = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private IComparer<string> displayComparer = Comparer<string>.Default;
+		private Predicate<object> filter;
 		private Func<object, IEnumerable> childrenSelector;
 		private Func<object, string> displaySelector;
 		private SimpleCollectionViewOptions childOptions;
-
-		private void OnChildOptionsChanged (object sender, EventArgs e)
-		{
-			OnOptionsChanged();
-		}
-
-		private void OnOptionsChanged()
-		{
-			OptionsChanged?.Invoke (this, EventArgs.Empty);
-		}
 	}
 
 	internal class SimpleCollectionView
 		: NotifyingObject, IEnumerable, INotifyCollectionChanged
 	{
 		public SimpleCollectionView (IEnumerable source, SimpleCollectionViewOptions options)
+			: this (source, options, null, null)
 		{
-			if (source == null)
-				throw new ArgumentNullException (nameof (source));
-			if (options == null)
-				throw new ArgumentNullException (nameof (options));
-
-			this.source = source;
-			Options = options;
-
-			var changed = source as INotifyCollectionChanged;
-			if (changed != null) {
-				changed.CollectionChanged += OnSourceCollectionChanged;
-			}
 		}
 
 		public event NotifyCollectionChangedEventHandler CollectionChanged;
@@ -104,26 +104,19 @@ namespace Xamarin.PropertyEditing.ViewModels
 				if (this.options == value)
 					return;
 
-				if (this.options != null)
-					this.options.OptionsChanged -= OnOptionsPropertyChanged;
-
-				this.options = value;
-				if (this.options != null)
-					this.options.OptionsChanged += OnOptionsPropertyChanged;
-
-				Reset();
+				SetOptions (value);
 			}
 		}
 
-		public bool HasChildElements => (this.arranged.Count > 0);
+		public bool HasChildElements => (this.filtered.Count > 0);
 
-		public bool IsFiltering => this.filter != null;
+		public bool IsFiltering => Options?.Filter != null;
 
 		public IEnumerator GetEnumerator ()
 		{
 			bool haveChildren = (Options.ChildOptions != null);
 
-			foreach (var kvp in this.arranged) {
+			foreach (var kvp in this.filtered) {
 				if (!haveChildren)
 					yield return kvp.Value.Item;
 				else
@@ -131,43 +124,88 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-
-		/// <param name="isSuperset">Whether or not the new <paramref name="predicate"/> is more inclusive.</param>
-		public void Filter (Predicate<object> predicate, bool isSuperset)
-		{
-			bool wasFiltering = IsFiltering;
-
-			this.filter = predicate;
-			if (!wasFiltering)
-				OnPropertyChanged (nameof (IsFiltering));
-
-			FilterCore (isSuperset);
-		}
-
-		private struct Element
+		private class Element
 		{
 			public object Item;
 			public SimpleCollectionView ChildrenView;
 		}
 
+		private readonly OrderedDictionary<string, Element> filtered = new OrderedDictionary<string, Element>();
 		private readonly OrderedDictionary<string, Element> arranged = new OrderedDictionary<string, Element>();
+		private readonly SimpleCollectionView parent;
+		private readonly string key;
+		private readonly object item;
 		private SimpleCollectionViewOptions options;
+		private bool wasFilterNull;
 		private IEnumerable source;
-		private Predicate<object> filter;
 
-		private void OnSourceCollectionChanged (object sender, NotifyCollectionChangedEventArgs e)
+		private IComparer<string> Comparer => Options?.DisplayComparer ?? Comparer<string>.Default;
+
+		private SimpleCollectionView (IEnumerable source, SimpleCollectionViewOptions options, SimpleCollectionView parent = null, string key = null, object item = null)
 		{
-			// TODO: Fine grained handling
-			switch (e.Action) {
-				default:
-					Reset();
-					break;
+			if (source == null)
+				throw new ArgumentNullException (nameof (source));
+			if (options == null)
+				throw new ArgumentNullException (nameof (options));
+
+			this.wasFilterNull = (options.Filter == null);
+			this.source = source;
+			this.parent = parent;
+			this.item = item;
+			this.key = key;
+			SetOptions (options, notify: false);
+
+			var changed = source as INotifyCollectionChanged;
+			if (changed != null) {
+				changed.CollectionChanged += OnSourceCollectionChanged;
 			}
 		}
 
-		private void OnOptionsPropertyChanged (object sender, EventArgs e)
+		private void SetOptions (SimpleCollectionViewOptions newOptions, bool notify = true)
 		{
-			Reset();
+			if (this.options != null)
+				this.options.PropertyChanged -= OnOptionsPropertyChanged;
+
+			this.options = newOptions;
+			if (this.options != null)
+				this.options.PropertyChanged += OnOptionsPropertyChanged;
+
+			Reset (notify);
+		}
+
+		private void OnSourceCollectionChanged (object sender, NotifyCollectionChangedEventArgs e)
+		{
+			// TODO: More fine grained handling
+			switch (e.Action) {
+			/*case NotifyCollectionChangedAction.Remove:
+				if (e.OldStartingIndex == -1 || e.OldItems == null) {
+					Reset();
+					return;
+				}
+
+				// broken for rearranged
+				object firstElement = e.OldItems[0];
+				for (int i = 0; i < e.OldItems.Count; i++) {
+					this.arranged.RemoveAt (e.OldStartingIndex);
+				}
+
+				RemoveFilteredRange (firstElement, e.OldStartingIndex, e.OldItems.Count);
+				break;
+				*/
+			case NotifyCollectionChangedAction.Reset:
+			default:
+				Reset();
+				break;
+			}
+		}
+
+		private void OnOptionsPropertyChanged (object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(SimpleCollectionViewOptions.Filter)) {
+				FilterCore (isPureSubset: this.wasFilterNull);
+				this.wasFilterNull = Options.Filter == null;
+			} else
+				Reset();
 		}
 
 		private bool MatchesFilter (Element element)
@@ -175,54 +213,131 @@ namespace Xamarin.PropertyEditing.ViewModels
 			if (!IsFiltering)
 				return true;
 
-			return this.filter (element.Item);
+			return Options.Filter (element.Item);
 		}
 
-		private void FilterCore (bool isSuperset, bool notify = true)
+		private void FilterCore (bool notify = true, bool isPureSubset = false)
 		{
+			if (!IsFiltering) {
+				if (this.arranged.Count == this.filtered.Count)
+					return;
+			}
+
 			bool hadChildren = HasChildElements;
 
-			if (IsFiltering && !isSuperset) {
-				var toRemove = new List<string>();
-				foreach (var kvp in this.arranged) {
-					var childView = kvp.Value.ChildrenView;
-					if (childView != null) {
-						childView.Filter (this.filter, isSuperset);
-						if (!childView.HasChildElements) {
-							toRemove.Add (kvp.Key);
-						}
-
-						continue;
-					}
-
-					if (!MatchesFilter (kvp.Value))
-						toRemove.Add (kvp.Key);
-				}
-
-				Remove (toRemove, notify);
-			} else {
-				// TODO: Fine grained handling
-				Reset();
+			HashSet<string> filteredOut = null;
+			if (!isPureSubset) {
+				filteredOut = new HashSet<string> (this.arranged.Keys);
+				filteredOut.ExceptWith (this.filtered.Keys);
 			}
+
+			var toRemove = new List<string>();
+			foreach (var kvp in this.filtered) {
+				var childView = kvp.Value.ChildrenView;
+				if ((childView != null && !childView.HasChildElements) || !MatchesFilter (kvp.Value)) {
+					toRemove.Add (kvp.Key);
+				}
+			}
+
+			if (!isPureSubset) {
+				var toAdd = new List<string> (filteredOut.Count);
+				foreach (string key in filteredOut) {
+					Element e = this.arranged[key];
+					if (!IsFiltering || Options.Filter (e.Item))
+						toAdd.Add (key);
+				}
+				toAdd.Sort (Comparer);
+
+				AddFiltered (toAdd, notify);
+			}
+
+			RemoveFiltered (toRemove, notify);
 
 			if (hadChildren != HasChildElements)
 				OnPropertyChanged (nameof(HasChildElements));
 		}
 
-		private void Remove (IReadOnlyList<string> keys, bool notify)
+		private void AddFiltered (string key, bool notify = true)
 		{
-			int index = 0;
+			int sourceIndex = this.arranged.BinarySearch (key);
+			AddFiltered (key, sourceIndex, notify);
+		}
+
+		private void AddFiltered (string key, int sourceIndex, bool notify = true)
+		{
+			Element e = this.arranged[sourceIndex];
+			int maxMoved = this.arranged.Count - this.filtered.Count;
+			int index = Math.Max (0, sourceIndex - maxMoved);
+
+			bool added = false;
+			if (this.filtered.Count != 0) {
+				for (int i = index; i < this.filtered.Count; i++) {
+					string currentKey = this.filtered.KeyAt (i);
+					
+					if (Comparer.Compare (currentKey, key) > 0) {
+						index = i;
+						this.filtered.Insert (i, key, this.arranged[i]);
+						added = true;
+						break;
+					}
+				}
+			}
+
+			if (!added) {
+				index = this.filtered.Count;
+				this.filtered.Add (key, e);
+			}
+
+			if (notify)
+				OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, new[] { GetChangeItem (e, key) }, index));
+		}
+
+		private void AddFiltered (IReadOnlyList<string> keys, bool notify)
+		{
+			// TODO optimizations: single index lookup, batch up notices
+			foreach (string key in keys)
+				AddFiltered (key, notify);
+		}
+
+		private void RemoveFilteredRange (object firstElement, int sourceIndex, int count)
+		{
+			string key = Options.DisplaySelector (firstElement);
+
+			// Filtered is always a subset of arranged so if we know where we were in the original
+			// the most out of place we can be is the difference.
+			int maxMoved = this.arranged.Count - this.filtered.Count;
+			int index = (maxMoved > 0) ? this.filtered.BinarySearch (key, Math.Max (0, sourceIndex - maxMoved), maxMoved) : sourceIndex;
+
+			List<object> items = new List<object> (count);
+			for (int i = 0; i < count; i++) {
+				Element e = this.filtered[index];
+				items.Add (e.Item);
+				this.filtered.RemoveAt (index);
+			}
+
+			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Remove, items, index));
+		}
+
+		private object GetChangeItem (Element e, string itemKey)
+		{
+			return Options.ChildOptions != null ? new KeyValuePair<string, SimpleCollectionView> (itemKey, e.ChildrenView) : e.Item;
+		}
+
+		private void RemoveFiltered (IReadOnlyList<string> keys, bool notify = true)
+		{
+			if (keys.Count == 0)
+				return;
+
 			List<Tuple<object, int>> oldItems = new List<Tuple<object, int>> (keys.Count);
 			foreach (string key in keys) {
-				int find = this.arranged.IndexOf (key, index);
+				int find = this.filtered.IndexOf (key);
 				if (find == -1)
 					continue;
 
-				Element e = this.arranged[find];
-				this.arranged.RemoveAt (find);
+				Element e = this.filtered[find];
+				this.filtered.RemoveAt (find);
 
-				index = find;
-				object item = Options.ChildOptions != null ? new KeyValuePair<string, SimpleCollectionView> (key, e.ChildrenView) : e.Item;
+				object item = GetChangeItem (e, key);
 				oldItems.Add (new Tuple<object, int> (item, find));
 			}
 
@@ -247,38 +362,76 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		private void Reset()
+		private void Reset (bool notify = true)
 		{
 			this.arranged.Clear();
+			this.filtered.Clear();
 
-			foreach (var element in this.source.Cast<object>().Select (o => new { Item = o, Key = options.DisplaySelector (o) }).OrderBy (e => e.Key)) {
+			bool filtering = IsFiltering;
+
+			foreach (var sourceItem in this.source.Cast<object>().Select (o => new { Item = o, Key = this.options.DisplaySelector (o) }).OrderBy (e => e.Key, Comparer)) {
+				Element e = new Element {
+					Item = sourceItem.Item
+				};
+
+				this.arranged.Add (sourceItem.Key, e);
+
 				SimpleCollectionView childView = null;
-				IEnumerable children = (Options.ChildrenSelector != null) ? options.ChildrenSelector (element.Item) : element.Item as IEnumerable;
+				IEnumerable children = (Options.ChildrenSelector != null) ? this.options.ChildrenSelector (sourceItem.Item) : sourceItem.Item as IEnumerable;
 				if (Options.ChildOptions != null) {
 					if (children == null) {
 						throw new InvalidOperationException ("ChildOptions specified, but element not enumerable or no selector");
 					}
 
-					childView = new SimpleCollectionView (children, Options.ChildOptions);
+					childView = new SimpleCollectionView (children, Options.ChildOptions, this, sourceItem.Key, sourceItem.Item);
+					e.ChildrenView = childView;
 				}
 
-				Element e = new Element {
-					Item = element.Item,
-					ChildrenView = childView
-				};
-
-				this.arranged.Add (element.Key, e);
+				if (!filtering || this.options.Filter (e.Item))
+					this.filtered.Add (sourceItem.Key, e);
 			}
 
-			if (IsFiltering)
-				FilterCore (isSuperset: false, notify: false);
-
-			OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Reset));
+			if (notify)
+				OnCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Reset));
 		}
 
 		private void OnCollectionChanged (NotifyCollectionChangedEventArgs e)
 		{
 			CollectionChanged?.Invoke (this, e);
+			if (this.parent == null || (e.Action == NotifyCollectionChangedAction.Remove && HasChildElements) || e.Action == NotifyCollectionChangedAction.Move || e.Action == NotifyCollectionChangedAction.Replace)
+				return;
+
+			bool isVisible = HasChildElements;
+			SimpleCollectionView parent = this.parent;
+			SimpleCollectionView child = this;
+			if (isVisible) {
+				var parents = new Stack<Tuple<SimpleCollectionView, SimpleCollectionView>>();
+				while (parent != null && !parent.filtered.ContainsKey (child.key)) {
+					if (parent.Options.Filter != null && !parent.options.Filter (child.item))
+						break;
+
+					parents.Push (new Tuple<SimpleCollectionView, SimpleCollectionView> (parent, child));
+					child = parent;
+					parent = parent.parent;
+				}
+
+				while (parents.Count > 0) {
+					var pair = parents.Pop();
+					pair.Item1.AddFiltered (pair.Item2.key);
+				}
+			} else {
+				var parents = new List<Tuple<SimpleCollectionView, SimpleCollectionView>>();
+				while (parent != null && parent.filtered.ContainsKey (child.key) && !child.HasChildElements) {
+					parents.Add (new Tuple<SimpleCollectionView, SimpleCollectionView> (parent, child));
+					child = parent;
+					parent = parent.parent;
+				}
+
+				for (int i  = 0; i < parents.Count; i++) {
+					var pair = parents[i];
+					pair.Item1.RemoveFiltered (new[] { pair.Item2.key });
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/TypeSelectorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/TypeSelectorViewModel.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.PropertyEditing.ViewModels
+{
+	internal class TypeSelectorViewModel
+		: NotifyingObject
+	{
+		public TypeSelectorViewModel (AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
+		{
+			if (assignableTypes == null)
+				throw new ArgumentNullException (nameof (assignableTypes));
+
+			assignableTypes.Task.ContinueWith (t => {
+				this.assemblyView = new SimpleCollectionView (t.Result, new SimpleCollectionViewOptions {
+					DisplaySelector = (o) => ((KeyValuePair<IAssemblyInfo, ILookup<string, ITypeInfo>>)o).Key.Name,
+					ChildrenSelector = (o) => ((KeyValuePair<IAssemblyInfo, ILookup<string, ITypeInfo>>)o).Value,
+					ChildOptions = new SimpleCollectionViewOptions {
+						DisplaySelector = (o) => ((IGrouping<string, ITypeInfo>)o).Key,
+						ChildrenSelector = (o) => ((IGrouping<string, ITypeInfo>)o),
+						ChildOptions = new SimpleCollectionViewOptions {
+							DisplaySelector = (o) => ((ITypeInfo)o).Name
+						}
+					}
+				});
+				OnPropertyChanged (nameof(Types));
+				IsLoading = false;
+			}, TaskScheduler.FromCurrentSynchronizationContext());
+		}
+
+		public IEnumerable Types
+		{
+			get { return this.assemblyView; }
+		}
+
+		public bool IsLoading
+		{
+			get { return this.isLoading; }
+			set
+			{
+				if (this.isLoading == value)
+					return;
+
+				this.isLoading = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public bool ShowAllAssemblies
+		{
+			get {  return this.showAllAssemblies; }
+			set
+			{
+				if (this.showAllAssemblies == value)
+					return;
+
+				bool oldValue = this.showAllAssemblies;
+				this.showAllAssemblies = value;
+				OnPropertyChanged();
+				Filter (filterText, oldValue);
+			}
+		}
+
+		public string FilterText
+		{
+			get { return this.filterText; }
+			set
+			{
+				if (this.filterText == value)
+					return;
+
+				string oldFilter = this.filterText;
+				this.filterText = value;
+				OnPropertyChanged();
+				Filter (oldFilter, ShowAllAssemblies);
+			}
+		}
+
+		private string filterText;
+		private bool isLoading;
+		private bool showAllAssemblies;
+		private SimpleCollectionView assemblyView;
+
+		private void Filter (string oldFilter, bool wasShowingAll)
+		{
+			bool isSuperset = (wasShowingAll == ShowAllAssemblies) || ShowAllAssemblies;
+			isSuperset &= !(String.IsNullOrWhiteSpace (oldFilter) || FilterText.StartsWith (oldFilter, StringComparison.OrdinalIgnoreCase));
+
+			this.assemblyView.Filter (o => {
+				if (o is KeyValuePair<IAssemblyInfo, ILookup<string, ITypeInfo>> kvp) {
+					return ShowAllAssemblies || kvp.Key.IsRelevant;
+				} else if (o is IGrouping<string, ITypeInfo> g) {
+					return g.Key.StartsWith (FilterText, StringComparison.OrdinalIgnoreCase);
+				} else if (o is ITypeInfo t) {
+					return t.Name.StartsWith (FilterText, StringComparison.OrdinalIgnoreCase);
+				}
+
+				return false;
+			}, isSuperset);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncValue.cs" />
     <Compile Include="AsyncWorkQueue.cs" />
     <Compile Include="BidirectionalDictionary.cs" />
     <Compile Include="BrushPropertyInfo.cs" />

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Drawing\CommonTileBrush.cs" />
     <Compile Include="Drawing\CommonTileMode.cs" />
     <Compile Include="Drawing\CommonImageBrush.cs" />
+    <Compile Include="IAssemblyInfo.cs" />
     <Compile Include="IAvailabilityConstraint.cs" />
     <Compile Include="IClampedPropertyInfo.cs" />
     <Compile Include="IColorSpaced.cs" />
@@ -75,6 +76,7 @@
     <Compile Include="IPropertyInfo.cs" />
     <Compile Include="IResourceProvider.cs" />
     <Compile Include="ISelfConstrainedPropertyInfo.cs" />
+    <Compile Include="ITypeInfo.cs" />
     <Compile Include="MultiAvailabilityConstraint.cs" />
     <Compile Include="NotifyingObject.cs" />
     <Compile Include="ObservableCollectionEx.cs" />

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -132,6 +132,7 @@
     </Compile>
     <Compile Include="ViewModels\RectanglePropertyViewModel.cs" />
     <Compile Include="ViewModels\ThicknessPropertyViewModel.cs" />
+    <Compile Include="ViewModels\TypeSelectorViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Themes\BaseThemeManager.cs" />

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -106,6 +106,7 @@
     <Compile Include="ViewModels\EventViewModel.cs" />
     <Compile Include="ViewModels\IFilterable.cs" />
     <Compile Include="ViewModels\NumericPropertyViewModel.cs" />
+    <Compile Include="ViewModels\ObjectPropertyViewModel.cs" />
     <Compile Include="ViewModels\ObjectViewModel.cs" />
     <Compile Include="ViewModels\PanelViewModel.cs" />
     <Compile Include="ViewModels\PointPropertyViewModel.cs" />

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -99,6 +99,7 @@
     <Compile Include="ValueSource.cs" />
     <Compile Include="ViewModels\ArrangeModeViewModel.cs" />
     <Compile Include="ViewModels\BrushPropertyViewModel.cs" />
+    <Compile Include="ViewModels\SimpleCollectionView.cs" />
     <Compile Include="ViewModels\ConstrainedPropertyViewModel.cs" />
     <Compile Include="ViewModels\EditorViewModel.cs" />
     <Compile Include="ViewModels\EnumPropertyViewModel.cs" />


### PR DESCRIPTION
This PR:
 - Adds the APIs for retrieving assignable types to an `object` type `IPropertyInfo`.
 - Adds the APIs for creating a new instance of an arbitrary object for editing.
 - Adds a generic sort/group/filter class (`SimpleCollectionView`) that is n-tiered and should be reusable in all places we need to have a filterable experience.
 - Adds the core VM for object editing and type selection (completes #113)
 - Adds a new base window type for hiding specific elements to match VS.
 - Adds the Windows type selector window (completes #114)

Given the shifting priorities there are a few theming issues left unresolved, namely:
 - The expand button for object editing isn't sized and positioned quite correctly.
 - The sub-properties background isn't margined correctly and doesn't fill when too small.
 - Icons for assemblies/namespaces/types are left out.

These remaining theming items will have an issue created for them to be resolved later.

![2018-01-24_12-55-52](https://user-images.githubusercontent.com/156582/35348440-16d3f1b0-0106-11e8-8849-75b0fb2a242c.gif)
![2018-01-24_12-56-30](https://user-images.githubusercontent.com/156582/35348445-1804cf14-0106-11e8-856e-8a8309ac89fa.gif)
