### PR TITLE
Basic Windows Resources

### DIFF
--- a/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
@@ -26,7 +26,7 @@ namespace Xamarin.PropertyEditing.Tests
 			return Task.FromResult<IReadOnlyList<ResourceSource>> (new[] { SystemResourcesSource });
 		}
 
-		private static readonly ResourceSource SystemResourcesSource = new ResourceSource ("System Resources", isLocal: false);
+		internal static readonly ResourceSource SystemResourcesSource = new ResourceSource ("System Resources", isLocal: false);
 
 		private static readonly IReadOnlyList<Resource> SystemResources = new Resource[] {
 			new Resource<CommonSolidBrush> (SystemResourcesSource, "ControlTextBrush", new CommonSolidBrush (0, 0, 0)),

--- a/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
@@ -31,6 +31,7 @@ namespace Xamarin.PropertyEditing.Tests
 		private static readonly IReadOnlyList<Resource> SystemResources = new Resource[] {
 			new Resource<CommonSolidBrush> (SystemResourcesSource, "ControlTextBrush", new CommonSolidBrush (0, 0, 0)),
 			new Resource<CommonSolidBrush> (SystemResourcesSource, "HighlightBrush", new CommonSolidBrush (51, 153, 255)),
+			new Resource<CommonSolidBrush> (SystemResourcesSource, "TransparentBrush", new CommonSolidBrush (0, 0, 0, 0)),
 			new Resource<CommonColor> (SystemResourcesSource, "ControlTextColor", new CommonColor (0, 0, 0)),
 			new Resource<CommonColor> (SystemResourcesSource, "HighlightColor", new CommonColor (51, 153, 255))
 		};

--- a/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xamarin.PropertyEditing.Drawing;
+
+namespace Xamarin.PropertyEditing.Tests
+{
+	public class MockResourceProvider
+		: IResourceProvider
+	{
+		public Task<Resource> CreateResourceAsync<T> (ResourceSource source, string name, T value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Task<IReadOnlyList<Resource>> GetResourcesAsync (object target, IPropertyInfo property, CancellationToken cancelToken)
+		{
+			return Task.FromResult<IReadOnlyList<Resource>> (SystemResources.Where (r => property.Type.IsAssignableFrom (r.GetType().GetGenericArguments()[0])).ToList());
+		}
+
+		public Task<IReadOnlyList<ResourceSource>> GetResourceSourcesAsync (object target, IPropertyInfo property)
+		{
+			return Task.FromResult<IReadOnlyList<ResourceSource>> (new[] { SystemResourcesSource });
+		}
+
+		private static readonly ResourceSource SystemResourcesSource = new ResourceSource ("System Resources", isLocal: false);
+
+		private static readonly IReadOnlyList<Resource> SystemResources = new Resource[] {
+			new Resource<CommonSolidBrush> (SystemResourcesSource, "ControlTextBrush", new CommonSolidBrush (0, 0, 0)),
+			new Resource<CommonSolidBrush> (SystemResourcesSource, "HighlightBrush", new CommonSolidBrush (51, 153, 255)),
+			new Resource<CommonColor> (SystemResourcesSource, "ControlTextColor", new CommonColor (0, 0, 0)),
+			new Resource<CommonColor> (SystemResourcesSource, "HighlightColor", new CommonColor (51, 153, 255))
+		};
+	}
+}

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -154,6 +154,15 @@ namespace Xamarin.PropertyEditing.Tests
 					softType.GetProperty ("Source").SetValue (softValue, value.Source);
 				}
 			}
+
+			// Set to resource won't pass values so we will store it on the info since we just pass it back in GetValue
+			if (value.Source == ValueSource.Resource && value.ValueDescriptor is Resource) {
+				var rt = value.ValueDescriptor.GetType();
+				if (rt.IsGenericType && typeof(T).IsAssignableFrom (rt.GetGenericArguments ()[0])) {
+					var pi = rt.GetProperty ("Value");
+					value.Value = (T)pi.GetValue (value.ValueDescriptor);
+				}
+			}
 			
 			this.values[property] = softValue;
 			PropertyChanged?.Invoke (this, new EditorPropertyChangedEventArgs (property));

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -214,24 +214,6 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
-		public void CantSetValueToUnknownResource ()
-		{
-			var mockProperty = GetPropertyMock ();
-			mockProperty.SetupGet (pi => pi.CanWrite).Returns (true);
-
-			var resource = new Resource ("name");
-
-			var resourcesMock = new Mock<IResourceProvider> ();
-			resourcesMock.Setup (rp => rp.GetResourcesAsync (new object(), mockProperty.Object, It.IsAny<CancellationToken> ())).ReturnsAsync (new[] { resource });
-
-			var vm = GetViewModel (mockProperty.Object, new[] { new Mock<IObjectEditor> ().Object });
-			vm.ResourceProvider = resourcesMock.Object;
-			Assume.That (vm.SetValueResourceCommand, Is.Not.Null);
-
-			Assert.That (vm.SetValueResourceCommand.CanExecute (new Resource ("unknown")), Is.False, "Could set value to resource unknown");
-		}
-
-		[Test]
 		public void CanSetValueToResource ()
 		{
 			var mockProperty = GetPropertyMock ();

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -639,46 +639,6 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (vm.Value, Is.EqualTo (default(TValue)));
 		}
 
-		[Test]
-		[Description ("If the target platform doesn't support distinguishing local/default, we can't clear the value")]
-		public void ClearValueDefaultNotSupported ()
-		{
-			var value = GetNonDefaultRandomTestValue ();
-
-			var mockProperty = GetPropertyMock ();
-
-			var editorMock = new Mock<IObjectEditor> ();
-			editorMock.Setup (oe => oe.GetValueAsync<TValue> (mockProperty.Object, null)).ReturnsAsync (new ValueInfo<TValue> {
-				Value = value,
-				Source = ValueSource.Local
-			});
-			mockProperty.SetupGet (pi => pi.ValueSources).Returns (ValueSources.Local);
-
-			var vm = GetViewModel (mockProperty.Object, new[] { editorMock.Object });
-
-			Assert.That (vm.ClearValueCommand.CanExecute (null), Is.False);
-		}
-
-		[Test]
-		[Description ("We only allow clearing local values")]
-		public void ClearValueNotLocalValue ()
-		{
-			var value = GetNonDefaultRandomTestValue ();
-
-			var mockProperty = GetPropertyMock ();
-			mockProperty.SetupGet (pi => pi.ValueSources).Returns (ValueSources.Default | ValueSources.Local | ValueSources.Resource);
-
-			var editorMock = new Mock<IObjectEditor> ();
-			editorMock.Setup (oe => oe.GetValueAsync<TValue> (mockProperty.Object, null)).ReturnsAsync (new ValueInfo<TValue> {
-				Value = value,
-				Source = ValueSource.Resource
-			});
-
-			var vm = GetViewModel (mockProperty.Object, new[] { editorMock.Object });
-
-			Assert.That (vm.ClearValueCommand.CanExecute (null), Is.False);
-		}
-
 		protected TValue GetNonDefaultRandomTestValue ()
 		{
 			TValue value = default (TValue);

--- a/Xamarin.PropertyEditing.Tests/ResourceSelectorViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ResourceSelectorViewModelTests.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using Moq;
+using NUnit.Framework;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Tests
+{
+	[TestFixture]
+	public class ResourceSelectorViewModelTests
+	{
+		[Test]
+		public void Resources()
+		{
+			var tests = new StringViewModelTests();
+			var mproperty = tests.GetPropertyMock ("Property");
+
+			object target = new object();
+
+			var resource = new Resource<string> (MockResourceProvider.SystemResourcesSource, "Resource", "value");
+			var mprovider = new Mock<IResourceProvider>();
+
+			mprovider.Setup (r => r.GetResourcesAsync (target, mproperty.Object, CancellationToken.None)).ReturnsAsync (new[] { resource });
+
+			var vm = new ResourceSelectorViewModel (mprovider.Object, new[] { target }, mproperty.Object);
+			Assert.That (vm.Resources, Contains.Item (resource));
+		}
+
+		[Test]
+		public void MultipleTargetResources()
+		{
+			var tests = new StringViewModelTests();
+			var mproperty = tests.GetPropertyMock ("Property");
+
+			object target = new object();
+			object target2 = new object();
+
+			var resource = new Resource<string> (MockResourceProvider.SystemResourcesSource, "Resource", "value");
+			var resource2 = new Resource<string> (MockResourceProvider.SystemResourcesSource, "Resource2", "value2");
+			var resource3 = new Resource<string> (MockResourceProvider.SystemResourcesSource, "Resource3", "value3");
+
+			var mprovider = new Mock<IResourceProvider>();
+			mprovider.Setup (r => r.GetResourcesAsync (target, mproperty.Object, CancellationToken.None)).ReturnsAsync (new[] { resource, resource3 });
+			mprovider.Setup (r => r.GetResourcesAsync (target2, mproperty.Object, CancellationToken.None)).ReturnsAsync (new[] { resource2, resource3 });
+
+			var vm = new ResourceSelectorViewModel (mprovider.Object, new[] { target, target2 }, mproperty.Object);
+			Assert.That (vm.Resources, Does.Not.Contain (resource));
+			Assert.That (vm.Resources, Does.Not.Contain (resource2));
+			Assert.That (vm.Resources, Contains.Item (resource3));
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="BoolViewModelTests.cs" />
     <Compile Include="BrushPropertyViewModelTests.cs" />
     <Compile Include="BytePropertyViewModelTests.cs" />
+    <Compile Include="MockControls\MockResourceProvider.cs" />
     <Compile Include="SimpleCollectionViewTests.cs" />
     <Compile Include="CommonColorTests.cs" />
     <Compile Include="Helpers.cs" />

--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="BrushPropertyViewModelTests.cs" />
     <Compile Include="BytePropertyViewModelTests.cs" />
     <Compile Include="MockControls\MockResourceProvider.cs" />
+    <Compile Include="ResourceSelectorViewModelTests.cs" />
     <Compile Include="SimpleCollectionViewTests.cs" />
     <Compile Include="CommonColorTests.cs" />
     <Compile Include="Helpers.cs" />

--- a/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 				}
 			};
 			this.panel.EditorProvider = new MockEditorProvider ();
+			this.panel.ResourceProvider = new MockResourceProvider ();
 		}
 
 		private async void Button_Click (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyButton.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Shapes;
+using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Windows
 {
@@ -18,6 +19,11 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			FocusableProperty.OverrideMetadata (typeof (PropertyButton), new FrameworkPropertyMetadata (false));
 			DefaultStyleKeyProperty.OverrideMetadata (typeof (PropertyButton), new FrameworkPropertyMetadata (typeof (PropertyButton)));
+		}
+
+		public PropertyButton()
+		{
+			DataContextChanged += OnDataContextChanged;
 		}
 
 		public static readonly DependencyProperty CanSetCustomExpressionProperty = DependencyProperty.Register (
@@ -107,6 +113,17 @@ namespace Xamarin.PropertyEditing.Windows
 			e.Handled = true;
 		}
 
+		private void OnDataContextChanged (object sender, DependencyPropertyChangedEventArgs e)
+		{
+			var pvm = e.OldValue as PropertyViewModel;
+			if (pvm != null)
+				pvm.ResourceRequested -= OnResourceRequested;
+
+			pvm = e.NewValue as PropertyViewModel;
+			if (pvm != null)
+				pvm.ResourceRequested += OnResourceRequested;
+		}
+
 		private void OnValueSourceChanged (ValueSource source)
 		{
 			if (this.indicator == null)
@@ -134,6 +151,12 @@ namespace Xamarin.PropertyEditing.Windows
 			}
 
 			this.indicator.SetResourceReference (Shape.FillProperty, brush);
+		}
+
+		private void OnResourceRequested (object sender, ResourceRequestedEventArgs e)
+		{
+			var vm = ((PropertyViewModel)DataContext);
+			e.Resource = ResourceSelectorWindow.RequestResource (Window.GetWindow (this), vm.ResourceProvider, vm.Editors.Select (ed => ed.Target), vm.Property);
 		}
 
 		private void OnCustomExpression (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
@@ -27,12 +27,21 @@ namespace Xamarin.PropertyEditing.Windows
 		}
 
 		public static readonly DependencyProperty EditorProviderProperty = DependencyProperty.Register (
-			nameof(EditorProvider), typeof(IEditorProvider), typeof(PropertyEditorPanel), new PropertyMetadata (default(IEditorProvider), (o, args) => ((PropertyEditorPanel)o).OnEditorProviderChanged()));
+			nameof(EditorProvider), typeof(IEditorProvider), typeof(PropertyEditorPanel), new PropertyMetadata (default(IEditorProvider), (o, args) => ((PropertyEditorPanel)o).OnProviderChanged()));
 
 		public IEditorProvider EditorProvider
 		{
 			get { return (IEditorProvider) GetValue (EditorProviderProperty); }
 			set { SetValue (EditorProviderProperty, value); }
+		}
+
+		public static readonly DependencyProperty ResourceProviderProperty = DependencyProperty.Register (
+			nameof(ResourceProvider), typeof(IResourceProvider), typeof(PropertyEditorPanel), new PropertyMetadata (default(IResourceProvider), (o, args) => ((PropertyEditorPanel)o).OnProviderChanged()));
+
+		public IResourceProvider ResourceProvider
+		{
+			get { return (IResourceProvider) GetValue (ResourceProviderProperty); }
+			set { SetValue (ResourceProviderProperty, value); }
 		}
 
 		public static readonly DependencyProperty TargetPlatformProperty = DependencyProperty.Register (
@@ -86,7 +95,7 @@ namespace Xamarin.PropertyEditing.Windows
 			this.paneSelector = (ChoiceControl) GetTemplateChild ("paneSelector");
 			this.paneSelector.SelectedValue = EditingPane.Properties;
 			this.paneSelector.SelectedItemChanged += OnPaneChanged;
-			OnEditorProviderChanged();
+			OnProviderChanged();
 
 			if (this.vm.SelectedObjects.Count > 0)
 				OnArrangeModeChanged (ArrangeMode);
@@ -142,7 +151,7 @@ namespace Xamarin.PropertyEditing.Windows
 				OnArrangeModeChanged (ArrangeMode);
 		}
 
-		private void OnEditorProviderChanged ()
+		private void OnProviderChanged ()
 		{
 			if (this.root == null)
 				return;
@@ -150,7 +159,14 @@ namespace Xamarin.PropertyEditing.Windows
 			if (this.vm != null)
 				this.vm.PropertyChanged -= OnVmPropertyChanged;
 
-			this.root.DataContext = this.vm = (EditorProvider != null) ? new PanelViewModel (EditorProvider, TargetPlatform) : null;
+			PanelViewModel newVm = null;
+			if (EditorProvider != null) {
+				newVm = new PanelViewModel (EditorProvider, TargetPlatform) {
+					ResourceProvider = ResourceProvider
+				};
+			}
+
+			this.root.DataContext = this.vm = newVm;
 			
 			if (this.vm != null)
 				this.vm.PropertyChanged += OnVmPropertyChanged;

--- a/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml
+++ b/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml
@@ -1,0 +1,33 @@
+<local:WindowEx x:Class="Xamarin.PropertyEditing.Windows.ResourceSelectorWindow"
+		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+		xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+		xmlns:local="clr-namespace:Xamarin.PropertyEditing.Windows"
+		xmlns:prop="clr-namespace:Xamarin.PropertyEditing.Properties;assembly=Xamarin.PropertyEditing"
+		mc:Ignorable="d" x:ClassModifier="internal" WindowStartupLocation="CenterOwner" ShowIcon="False"
+		MinWidth="300" MinHeight="400" Width="500" Height="600" ShowMinimize="False" ShowMaximize="False"
+		Background="{DynamicResource DialogBackgroundBrush}" Foreground="{DynamicResource DialogForegroundBrush}"
+		Title="{x:Static prop:Resources.SelectResourceTitle}">
+	<Grid Margin="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<local:TextBoxEx Margin="0,4,0,0" Style="{DynamicResource SearchTextBox}" MinHeight="20" Text="{Binding FilterText,UpdateSourceTrigger=PropertyChanged}" ShowClearButton="True" Hint="{x:Static prop:Resources.SearchResourcesTitle}" />
+
+		<ProgressBar Grid.Row="1" IsIndeterminate="True" Height="10" Visibility="{Binding IsLoading,Converter={StaticResource BoolToVisibilityConverter}}" />
+		<ListBox Name="list" Grid.Row="1" Margin="0,4,0,0" ItemsSource="{Binding Resources}" ItemTemplate="{DynamicResource SimpleResourcePreviewItem}" BorderThickness="1" SelectionChanged="OnListSelectionChanged" MouseDoubleClick="OnListDoubleClick" />
+
+
+		<CheckBox Grid.Row="2" HorizontalAlignment="Left" Margin="0,4,0,0" IsChecked="{Binding ShowSystemResources}" Foreground="{DynamicResource PanelGroupForegroundBrush}" Content="{x:Static prop:Resources.ShowSystemResources}" />
+
+		<StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+			<Button Name="ok" MinHeight="23" MinWidth="75" IsEnabled="False" Content="{x:Static prop:Resources.OK}" IsDefault="True" Click="OnOkClicked" />
+			<Button MinHeight="23" MinWidth="75" Margin="4,0,0,0" Content="{x:Static prop:Resources.Cancel}" IsCancel="True" />
+		</StackPanel>
+	</Grid>
+</local:WindowEx>

--- a/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	/// <summary>
+	/// Interaction logic for ResourceSelectorWindow.xaml
+	/// </summary>
+	internal partial class ResourceSelectorWindow
+		: WindowEx
+	{
+		public ResourceSelectorWindow (IResourceProvider resourceProvider, IEnumerable<object> targets, IPropertyInfo property)
+		{
+			DataContext = new ResourceSelectorViewModel (resourceProvider, targets, property);
+			InitializeComponent ();
+		}
+
+		internal static Resource RequestResource (Window owner, IResourceProvider provider, IEnumerable<object> targets, IPropertyInfo property)
+		{
+			var w = new ResourceSelectorWindow (provider, targets, property);
+			w.Owner = owner;
+			if (!w.ShowDialog () ?? false)
+				return null;
+
+			return w.list.SelectedItem as Resource;
+		}
+
+		private void OnOkClicked (object sender, RoutedEventArgs e)
+		{
+			DialogResult = true;
+		}
+
+		private void OnListSelectionChanged (object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+		{
+			this.ok.IsEnabled = (e.AddedItems.Count == 1 && e.AddedItems[0] is Resource);
+		}
+
+		private void OnListDoubleClick (object sender, MouseButtonEventArgs e)
+		{
+			if (this.list.SelectedItem == null)
+				return;
+
+			DialogResult = true;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -452,6 +452,7 @@
 	<system:Double x:Key="MenuOffset">3</system:Double>
 
 	<Rectangle x:Shared="False" x:Key="LiteralMarker" Stroke="{DynamicResource PropertyButtonBorderBrush}" Fill="{DynamicResource LiteralMarkerBrush}" Height="12" Width="12" StrokeThickness="1" />
+	<Rectangle x:Shared="False" x:Key="ResourceMarker" Stroke="{DynamicResource PropertyButtonBorderBrush}" Fill="{DynamicResource ResourceMarkerBrush}" Height="12" Width="12" StrokeThickness="1" />
 
 	<Style TargetType="local:PropertyButton">
 		<Setter Property="Background" Value="Transparent" />
@@ -466,9 +467,10 @@
 						<MenuItem x:Name="CustomExpressionItem" Header="{x:Static prop:Resources.CustomExpressionEllipsis}" Icon="{StaticResource LiteralMarker}" Visibility="{Binding TargetPlatform.SupportsCustomExpressions,Mode=OneTime,Converter={StaticResource BoolToVisibilityConverter}}" />
 						<Separator Visibility="{Binding TargetPlatform.SupportsCustomExpressions,Mode=OneTime,Converter={StaticResource BoolToVisibilityConverter}}" />
 						<MenuItem Header="{x:Static prop:Resources.Reset}" Icon="{StaticResource LiteralMarker}" Command="{Binding ClearValueCommand,Mode=OneTime}" />
-						<!--<MenuItem Header="{x:Static prop:Resources.ConvertToLocalValue}" Icon="{StaticResource LiteralMarker}" Command="{Binding ConvertToLocalValueCommand,Mode=OneTime}" />
-						<Separator />
-						<MenuItem Header="{x:Static p:Resources.LocalResource}" />
+						<!--<MenuItem Header="{x:Static prop:Resources.ConvertToLocalValue}" Icon="{StaticResource LiteralMarker}" Command="{Binding ConvertToLocalValueCommand,Mode=OneTime}" Visibility="{Binding SupportsResources,Mode=OneTime,Converter={StaticResource BoolToVisibilityConverter}}" />!-->
+						<Separator Visibility="{Binding SupportsResources,Mode=OneTime,Converter={StaticResource BoolToVisibilityConverter}}" />
+						<MenuItem Header="{x:Static prop:Resources.ResourceEllipsis}" Command="{Binding RequestResourceCommand,Mode=OneTime}" Icon="{StaticResource ResourceMarker}" Visibility="{Binding SupportsResources,Mode=OneTime,Converter={StaticResource BoolToVisibilityConverter}}" />
+						<!--<MenuItem Header="{x:Static p:Resources.LocalResource}" />
 						<MenuItem Header="{x:Static p:Resources.SystemResource}" />
 						<MenuItem Header="{x:Static p:Resources.EditResourceEllipse}" />
 						<MenuItem Header="{x:Static p:Resources.ConvertToNewResourceEllipse}" />

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -1214,7 +1214,54 @@
 	<Style TargetType="Label">
 		<Setter Property="Foreground" Value="{DynamicResource LabelForegroundBrush}"/>
 	</Style>
+
+	<Style TargetType="ListBox">
+		<Setter Property="Background" Value="{DynamicResource ListBackgroundBrush}" />
+		<Setter Property="BorderBrush" Value="{DynamicResource ListBackgroundBrush}" />
+	</Style>
 	
+	<Style TargetType="ListBoxItem">
+		<Setter Property="SnapsToDevicePixels" Value="True"/>
+		<Setter Property="Padding" Value="4,1"/>
+		<Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+		<Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+		<Setter Property="Foreground" Value="{DynamicResource ListItemForegroundBrush}" />
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="BorderBrush" Value="Transparent"/>
+		<Setter Property="BorderThickness" Value="1"/>
+		<Setter Property="FocusVisualStyle" Value="{StaticResource GenericVisualFocusStyle}"/>
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type ListBoxItem}">
+					<Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+						<ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+					</Border>
+					<ControlTemplate.Triggers>
+						<MultiTrigger>
+							<MultiTrigger.Conditions>
+								<Condition Property="IsMouseOver" Value="True"/>
+							</MultiTrigger.Conditions>
+							<Setter Property="Background" TargetName="Bd" Value="{DynamicResource ListItemMouseOverBackgroundBrush}"/>
+							<Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ListItemMouseOverBorderBrush}"/>
+							<Setter Property="TextElement.Foreground" TargetName="Bd" Value="{DynamicResource ListItemMouseOverForegroundBrush}" />
+						</MultiTrigger>
+						<MultiTrigger>
+							<MultiTrigger.Conditions>
+								<Condition Property="IsSelected" Value="True"/>
+							</MultiTrigger.Conditions>
+							<Setter Property="Background" TargetName="Bd" Value="{DynamicResource ListItemSelectedBackgroundBrush}"/>
+							<Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ListItemSelectedBorderBrush}"/>
+							<Setter Property="TextElement.Foreground" TargetName="Bd" Value="{DynamicResource ListItemSelectedForegroundBrush}" />
+						</MultiTrigger>
+						<Trigger Property="IsEnabled" Value="False">
+							<Setter Property="TextElement.Foreground" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+						</Trigger>
+					</ControlTemplate.Triggers>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
 	<Style TargetType="MenuItem">
 		<Setter Property="HorizontalContentAlignment" Value="{Binding Path=HorizontalContentAlignment, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type ItemsControl}}}"/>
 		<Setter Property="VerticalContentAlignment" Value="{Binding Path=VerticalContentAlignment, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type ItemsControl}}}"/>

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -531,21 +531,21 @@
 	<DataTemplate x:Key="SimpleResourcePreviewItem">
 		<DataTemplate.Resources>
 			<DataTemplate DataType="{x:Type drawing:CommonColor}">
-				<Rectangle>
-					<Rectangle.Fill>
+				<local:BrushBoxControl>
+					<local:BrushBoxControl.Brush>
 						<SolidColorBrush Color="{Binding Converter={StaticResource ColorConverter}}" />
-					</Rectangle.Fill>
-				</Rectangle>
+					</local:BrushBoxControl.Brush>
+				</local:BrushBoxControl>
 			</DataTemplate>
 			<DataTemplate DataType="{x:Type drawing:CommonBrush}">
-				<Rectangle Fill="{Binding Converter={StaticResource BrushConverter}}" />
+				<local:BrushBoxControl Brush="{Binding Converter={StaticResource BrushConverter}}" />
 			</DataTemplate>
 		</DataTemplate.Resources>
 		<StackPanel Orientation="Horizontal" Margin="4,2,4,2">
 			<Border Margin="4,2,0,2" BorderThickness="1" BorderBrush="{DynamicResource ControlBorderBrush}">
 				<ContentPresenter MinWidth="40" Content="{Binding Value,Mode=OneTime}" />
 			</Border>
-			<TextBlock Text="{Binding Name,Mode=OneTime}" Margin="4,0,0,0" />
+			<TextBlock VerticalAlignment="Center" Text="{Binding Name,Mode=OneTime}" Margin="4,0,0,0" />
 		</StackPanel>
 	</DataTemplate>
 

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:local="clr-namespace:Xamarin.PropertyEditing.Windows"
+					xmlns:drawing="clr-namespace:Xamarin.PropertyEditing.Drawing;assembly=Xamarin.PropertyEditing"
 					xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
 					xmlns:vm="clr-namespace:Xamarin.PropertyEditing.ViewModels;assembly=Xamarin.PropertyEditing"
 					xmlns:theme="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero"
@@ -521,6 +522,30 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<local:CommonBrushToBrushConverter x:Key="BrushConverter" />
+	<local:CommonColorToColorConverter x:Key="ColorConverter" />
+
+	<DataTemplate x:Key="SimpleResourcePreviewItem">
+		<DataTemplate.Resources>
+			<DataTemplate DataType="{x:Type drawing:CommonColor}">
+				<Rectangle>
+					<Rectangle.Fill>
+						<SolidColorBrush Color="{Binding Converter={StaticResource ColorConverter}}" />
+					</Rectangle.Fill>
+				</Rectangle>
+			</DataTemplate>
+			<DataTemplate DataType="{x:Type drawing:CommonBrush}">
+				<Rectangle Fill="{Binding Converter={StaticResource BrushConverter}}" />
+			</DataTemplate>
+		</DataTemplate.Resources>
+		<StackPanel Orientation="Horizontal" Margin="4,2,4,2">
+			<Border Margin="4,2,0,2" BorderThickness="1" BorderBrush="{DynamicResource ControlBorderBrush}">
+				<ContentPresenter MinWidth="40" Content="{Binding Value,Mode=OneTime}" />
+			</Border>
+			<TextBlock Text="{Binding Name,Mode=OneTime}" Margin="4,0,0,0" />
+		</StackPanel>
+	</DataTemplate>
 
 	<Style TargetType="local:BrushEditorControl">
 		<Setter Property="Template">

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
@@ -46,8 +46,10 @@
 	<SolidColorBrush x:Key="ListItemMouseOverForegroundBrush">#FFF1F1F1</SolidColorBrush>
 	<SolidColorBrush x:Key="MenuSeparatorBrush">#333337</SolidColorBrush>
 
-	<SolidColorBrush x:Key="LiteralMarkerBrush">#55000000</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertyMenuDotIconBorderBrush">#FF999999</SolidColorBrush>
+	<SolidColorBrush x:Key="LiteralMarkerBrush">#55000000</SolidColorBrush>
+	<SolidColorBrush x:Key="ResourceMarkerBrush">#FF8BD44A</SolidColorBrush>
+
 	<SolidColorBrush x:Key="PropertyButtonBackgroundBrush">#F2F2F6</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertyButtonBorderBrush">#717171</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertyLocalValueBrush">#F1F1F1</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
@@ -29,6 +29,8 @@
 	<SolidColorBrush x:Key="ToggleItemPressedBackgroundBrush" Color="#007ACC" />
 	<SolidColorBrush x:Key="ToggleItemPressedBorderBrush" Color="#00A7CC" />
 
+	<SolidColorBrush x:Key="ControlBorderBrush">#FF333337</SolidColorBrush>
+
 	<SolidColorBrush x:Key="MenuPopupBackgroundBrush">#1B1B1C</SolidColorBrush>
 	<SolidColorBrush x:Key="MenuPopupBorderBrush">#333337</SolidColorBrush>
 	<SolidColorBrush x:Key="ListItemForegroundBrush">#FFF1F1F1</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
@@ -50,8 +50,10 @@
 	<SolidColorBrush x:Key="ListItemMouseOverForegroundBrush">#FF1E1E1E</SolidColorBrush>
 	<SolidColorBrush x:Key="MenuSeparatorBrush">#E0E3E6</SolidColorBrush>
 
-	<SolidColorBrush x:Key="LiteralMarkerBrush">#55000000</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertyMenuDotIconBorderBrush">#FF717171</SolidColorBrush>
+	<SolidColorBrush x:Key="LiteralMarkerBrush">#55000000</SolidColorBrush>
+	<SolidColorBrush x:Key="ResourceMarkerBrush">#FF8BD44A</SolidColorBrush>
+
 	<SolidColorBrush x:Key="PropertyButtonBackgroundBrush">#F2F2F6</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertyButtonBorderBrush">#717171</SolidColorBrush>
 	<SolidColorBrush x:Key="PropertyLocalValueBrush">#1E1E1E</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
@@ -33,6 +33,8 @@
 	<SolidColorBrush x:Key="ToggleItemPressedBackgroundBrush" Color="#007ACC" />
 	<SolidColorBrush x:Key="ToggleItemPressedBorderBrush" Color="#00A7CC" />
 
+	<SolidColorBrush x:Key="ControlBorderBrush">#FFCCCEDB</SolidColorBrush>
+
 	<SolidColorBrush x:Key="MenuPopupBackgroundBrush">#F6F6F6</SolidColorBrush>
 	<SolidColorBrush x:Key="MenuPopupBorderBrush">#CCCEDB</SolidColorBrush>
 	<SolidColorBrush x:Key="ListItemForegroundBrush">#1E1E1E</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -73,6 +73,9 @@
     <Compile Include="DoubleToQuantityConverter.cs" />
     <Compile Include="MultiplyMarginConverter.cs" />
     <Compile Include="ObjectEditorControl.cs" />
+    <Compile Include="ResourceSelectorWindow.xaml.cs">
+      <DependentUpon>ResourceSelectorWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="TextBoxEx.cs" />
     <Compile Include="ToggleButtonEx.cs" />
     <Compile Include="EditorPropertySelector.cs" />
@@ -110,6 +113,10 @@
     <Compile Include="XamlHelper.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="ResourceSelectorWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Themes\Resources.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Xamarin.PropertyEditing/IObjectEditor.cs
+++ b/Xamarin.PropertyEditing/IObjectEditor.cs
@@ -78,8 +78,33 @@ namespace Xamarin.PropertyEditing
 		 * them or become invalid as a result of a prior pending change.
 		 */
 
+			
+		/// <remarks>
+		/// <para>For the <see cref="ValueSource.Default"/> or <see cref="ValueSource.Unset"/> sources, implementers should
+		/// ignore <paramref name="value"/>'s <see cref="ValueInfo{T}.Value"/> property and unset the value completely.
+		/// For XML based backings this usually means removing the attribute altogether. Implementers should not simply set
+		/// the value to its default value as this would still be a local value and override inheritance, styles, etc.</para>
+		/// <para>When <paramref name="value"/>'s <see cref="ValueInfo{T}.Source"/> is <see cref="ValueSource.Resource"/>,
+		/// the <see cref="ValueInfo{T}.ValueDescriptor"/> will be set to a <see cref="Resource"/> instance. Implementers
+		/// need not see whether the resource contains a value itself.</para>
+		/// <para>Before the returned task completes, in order:
+		/// 1. <see cref="GetValueAsync{T}(IPropertyInfo, PropertyVariation)"/> must be able to retrieve the new value.
+		/// 2. <see cref="PropertyChanged"/> should fire with the appropriate property.
+		/// For defensive purposes, consumers will not assume the <paramref name="value"/> they pass in will be the same
+		/// as the new value and as a result will re-query the value upon the assumed <see cref="PropertyChanged"/> firing.
+		/// There should not be a case where <see cref="PropertyChanged"/> is not fired when SetValueAsync is called, consumers
+		/// will do basic verification before calling. Even <see cref="ValueInfo{T}.Source"/> changes with the value staying the
+		/// same is a change in the property.
+		/// </para>
+		/// </remarks>
 		Task SetValueAsync<T> (IPropertyInfo property, ValueInfo<T> value, PropertyVariation variation = null);
 
+		/// <remarks>
+		/// <para>Implementers should strive to include the actual value of resources or bindings for <see cref="ValueInfo{T}.Value"/>
+		/// whereever possible.</para>
+		/// <para>If the platform can know the value of a property when unset, it should return that value and the <see cref="ValueSource.Default"/>
+		/// source. If the platform only knows that the value is unset, use <see cref="ValueSource.Unset"/> instead.</para>
+		/// </remarks>
 		/// <exception cref="ArgumentNullException"><paramref name="property"/> is <c>null</c>.</exception>
 		Task<ValueInfo<T>> GetValueAsync<T> (IPropertyInfo property, PropertyVariation variation = null);
 	}

--- a/Xamarin.PropertyEditing/IResourceProvider.cs
+++ b/Xamarin.PropertyEditing/IResourceProvider.cs
@@ -1,32 +1,32 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Xamarin.PropertyEditing
 {
-	public class Resource
-	{
-		public Resource (string name)
-		{
-			if (name == null)
-				throw new ArgumentNullException (nameof (name));
-
-			Name = name;
-		}
-
-		public string Name
-		{
-			get;
-		}
-	}
-
 	public interface IResourceProvider
 	{
 		/// <summary>
-		/// Gets the resources available to the given <paramref name="property"/>.
+		/// Gets the resources available to the given <paramref name="target"/> and <paramref name="property"/>.
 		/// </summary>
-		/// <exception cref="ArgumentNullException"><paramref name="property"/> is <c>null</c>.</exception>
-		Task<IReadOnlyList<Resource>> GetResourcesAsync (IPropertyInfo property, CancellationToken cancelToken);
+		/// <exception cref="ArgumentNullException"><paramref name="property"/> or <paramref name="target"/> is <c>null</c>.</exception>
+		/// <remarks>
+		/// <para>
+		/// Returned resources can either be of base class <see cref="Resource"/> or, whenever possible, of <see cref="Resource{T}"/>
+		/// including their relative representative value. This mean things like dynamic resources should, if possible, do a lookup
+		/// of its value relative to the <paramref name="target" /> and provide that value.
+		/// </para>
+		/// </remarks>
+		Task<IReadOnlyList<Resource>> GetResourcesAsync (object target, IPropertyInfo property, CancellationToken cancelToken);
+
+		/// <summary>
+		/// Gets resource sources relative to the provided <paramref name="target"/>.
+		/// </summary>
+		Task<IReadOnlyList<ResourceSource>> GetResourceSourcesAsync (object target, IPropertyInfo property);
+
+		/// <typeparam name="T">The representation type.</typeparam>
+		/// <param name="value">The value of the resource in it's representative form.</param>
+		Task<Resource> CreateResourceAsync<T> (ResourceSource source, string name, T value);
 	}
 }

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -502,6 +502,15 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resource….
+        /// </summary>
+        public static string ResourceEllipsis {
+            get {
+                return ResourceManager.GetString("ResourceEllipsis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to RGB.
         /// </summary>
         public static string RGB {
@@ -547,11 +556,29 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search Resources.
+        /// </summary>
+        public static string SearchResourcesTitle {
+            get {
+                return ResourceManager.GetString("SearchResourcesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select Object.
         /// </summary>
         public static string SelectObjectTitle {
             get {
                 return ResourceManager.GetString("SelectObjectTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Resource.
+        /// </summary>
+        public static string SelectResourceTitle {
+            get {
+                return ResourceManager.GetString("SelectResourceTitle", resourceCulture);
             }
         }
         
@@ -570,6 +597,15 @@ namespace Xamarin.PropertyEditing.Properties {
         public static string ShowAllAssemblies {
             get {
                 return ResourceManager.GetString("ShowAllAssemblies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Show system resources.
+        /// </summary>
+        public static string ShowSystemResources {
+            get {
+                return ResourceManager.GetString("ShowSystemResources", resourceCulture);
             }
         }
         

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -343,4 +343,16 @@
   <data name="CustomExpression" xml:space="preserve">
     <value>Custom expression</value>
   </data>
+  <data name="SearchResourcesTitle" xml:space="preserve">
+    <value>Search Resources</value>
+  </data>
+  <data name="SelectResourceTitle" xml:space="preserve">
+    <value>Select Resource</value>
+  </data>
+  <data name="ShowSystemResources" xml:space="preserve">
+    <value>_Show system resources</value>
+  </data>
+  <data name="ResourceEllipsis" xml:space="preserve">
+    <value>Resource…</value>
+  </data>
 </root>

--- a/Xamarin.PropertyEditing/Resource.cs
+++ b/Xamarin.PropertyEditing/Resource.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Xamarin.PropertyEditing
+{
+	public class Resource<T>
+		: Resource
+	{
+		public Resource (ResourceSource source, string name, T value)
+			: base (source, name)
+		{
+			Value = value;
+		}
+
+		public T Value
+		{
+			get;
+		}
+
+		public override Type RepresentationType => typeof(T);
+	}
+
+	public class Resource
+	{
+		public Resource (string name)
+		{
+			if (name == null)
+				throw new ArgumentNullException (nameof (name));
+
+			Name = name;
+		}
+
+		public Resource (ResourceSource source, string name)
+			: this (name)
+		{			
+			if (source == null)
+				throw new ArgumentNullException (nameof (source));
+
+			Source = source;
+		}
+
+		/// <summary>
+		/// Gets the source for this resource.
+		/// </summary>
+		/// <remarks>This may be <c>null</c> when the resource is a dynamic reference that is unlocatable.</remarks>
+		public ResourceSource Source
+		{
+			get;
+		}
+
+		/// <remarks>This may be <c>null</c> when the resource is a dynamic reference that is unlocatable.</remarks>
+		public virtual Type RepresentationType => null;
+
+		public string Name
+		{
+			get;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/Resource.cs
+++ b/Xamarin.PropertyEditing/Resource.cs
@@ -20,6 +20,7 @@ namespace Xamarin.PropertyEditing
 	}
 
 	public class Resource
+		: IEquatable<Resource>
 	{
 		public Resource (string name)
 		{
@@ -53,6 +54,44 @@ namespace Xamarin.PropertyEditing
 		public string Name
 		{
 			get;
+		}
+
+		public override bool Equals (object other)
+		{
+			// This does mean that a Resource<T> will match a Resource as long as its source and name are
+			// the same, but for all intents and purposes this is correct. The identification of resources
+			// is its source and name, the value is simply a helper for previews.
+			var r = other as Resource;
+			if (ReferenceEquals (null, r))
+				return false;
+			if (ReferenceEquals (this, other))
+				return true;
+
+			return r.Source == Source && r.Name == Name;
+		}
+
+		public bool Equals (Resource other)
+		{
+			return Equals ((object)other);
+		}
+
+		public override int GetHashCode ()
+		{
+			unchecked {
+				int hashCode = Source.GetHashCode();
+				hashCode = (hashCode * 397) ^ Name.GetHashCode();
+				return hashCode;
+			}
+		}
+
+		public static bool operator == (Resource left, Resource right)
+		{
+			return Equals (left, right);
+		}
+
+		public static bool operator != (Resource left, Resource right)
+		{
+			return !Equals  (left, right);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ResourceSource.cs
+++ b/Xamarin.PropertyEditing/ResourceSource.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Xamarin.PropertyEditing
+{
+	public class ResourceSource
+	{
+		public ResourceSource (string name, bool isLocal)
+		{
+			if (name == null)
+				throw new ArgumentNullException (nameof (name));
+
+			Name = name;
+			IsLocal = isLocal;
+		}
+
+		public string Name
+		{
+			get;
+		}
+
+		/// <summary>
+		/// Gets whether the source is local/relative to a target object.
+		/// </summary>
+		public bool IsLocal
+		{
+			get;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/ResourceSource.cs
+++ b/Xamarin.PropertyEditing/ResourceSource.cs
@@ -2,7 +2,8 @@ using System;
 
 namespace Xamarin.PropertyEditing
 {
-	public class ResourceSource
+	public sealed class ResourceSource
+		: IEquatable<ResourceSource>
 	{
 		public ResourceSource (string name, bool isLocal)
 		{
@@ -24,6 +25,47 @@ namespace Xamarin.PropertyEditing
 		public bool IsLocal
 		{
 			get;
+		}
+
+		public bool Equals (ResourceSource other)
+		{
+			if (ReferenceEquals (other, null))
+				return false;
+			if (ReferenceEquals (other, this))
+				return true;
+
+			return IsLocal == other.IsLocal && Name == other.Name;
+		}
+
+		public override bool Equals (object obj)
+		{
+			if (ReferenceEquals (obj, null))
+				return false;
+			if (ReferenceEquals (obj, this))
+				return true;
+			if (obj.GetType() != GetType())
+				return false;
+
+			return Equals ((ResourceSource)obj);
+		}
+
+		public override int GetHashCode ()
+		{
+			unchecked {
+				int hashCode = Name.GetHashCode();
+				hashCode = (hashCode * 397) ^ IsLocal.GetHashCode();
+				return hashCode;
+			}
+		}
+
+		public static bool operator == (ResourceSource left, ResourceSource right)
+		{
+			return Equals (left, right);
+		}
+
+		public static bool operator != (ResourceSource left, ResourceSource right)
+		{
+			return !Equals (left, right);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ValueSource.cs
+++ b/Xamarin.PropertyEditing/ValueSource.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 
 namespace Xamarin.PropertyEditing
 {
 	public enum ValueSource
 	{
 		/// <summary>
-		/// Property is at its unset value, which is not the same as the default value of the property type.
+		/// Value is the property's default value, which is not the same as the default value of the property type.
 		/// </summary>
 		Default = 0,
 		Local = 1,
@@ -14,7 +14,16 @@ namespace Xamarin.PropertyEditing
 		Style = 4,
 		Inherited = 5,
 		DefaultStyle = 6,
+
+		/// <summary>
+		/// The property's value comes from multiple sources.
+		/// </summary>
 		Unknown = 7,
+
+		/// <summary>
+		/// The property's value is unset but its unset value isn't known.
+		/// </summary>
+		Unset = 8,
 	}
 
 	[Flags]

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -28,6 +28,20 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
 
+		public IResourceProvider ResourceProvider
+		{
+			get { return this.resourceProvider; }
+			set
+			{
+				if (this.resourceProvider == value)
+					return;
+
+				this.resourceProvider = value;
+				UpdateResourceProvider();
+				OnPropertyChanged();
+			}
+		}
+
 		/// <remarks>Consumers should check for <see cref="INotifyCollectionChanged"/> and hook appropriately.</remarks>
 		public IReadOnlyList<EditorViewModel> Properties => this.editors;
 
@@ -200,6 +214,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		{
 		}
 
+		private IResourceProvider resourceProvider;
 		private INameableObject nameable;
 		private bool nameReadOnly;
 		private bool eventsEnabled;
@@ -404,12 +419,26 @@ namespace Xamarin.PropertyEditing.ViewModels
 			return newEditors;
 		}
 
+		private void UpdateResourceProvider()
+		{
+			foreach (PropertyViewModel vm in this.editors) {
+				vm.ResourceProvider = this.resourceProvider;
+			}
+		}
+
 		private void OnObjectEditorPropertiesChanged (object sender, NotifyCollectionChangedEventArgs e)
 		{
 			UpdateMembers();
 		}
 
 		private PropertyViewModel GetViewModel (IPropertyInfo property)
+		{
+			var vm = GetViewModelCore (property);
+			vm.ResourceProvider = ResourceProvider;
+			return vm;
+		}
+
+		private PropertyViewModel GetViewModelCore (IPropertyInfo property)
 		{
 			Type[] interfaces = property.GetType ().GetInterfaces ();
 

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -125,7 +125,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 					}
 
 					await Task.WhenAll (setValues);
-					await UpdateCurrentValueAsync ();
+					// Implementers should raise PropertyChanged during the set task
+					// which will bring the update under the async work request.
 				} catch (Exception ex) {
 					AggregateException aggregate = ex as AggregateException;
 					if (aggregate != null) {

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -141,7 +141,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private bool CanSetValueToResource (Resource resource)
 		{
-			return (resource != null && SupportsResources);
+			return (ResourceProvider != null && resource != null && SupportsResources);
 		}
 
 		private void OnSetValueToResource (Resource resource)
@@ -157,15 +157,17 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private void OnClearValue ()
 		{
+			ValueSource clearSource = (Property.ValueSources.HasFlag (ValueSources.Default)) ? ValueSource.Default : ValueSource.Unset;
+
 			SetValue (new ValueInfo<TValue> {
-				Source = ValueSource.Default,
+				Source = clearSource,
 				Value = default(TValue)
 			});
 		}
 
 		private bool CanClearValue ()
 		{
-			return (Property.ValueSources.HasFlag (ValueSources.Local) && Property.ValueSources.HasFlag (ValueSources.Default) && ValueSource == ValueSource.Local);
+			return (ValueSource != ValueSource.Default && ValueSource != ValueSource.Unknown);
 		}
 	}
 

--- a/Xamarin.PropertyEditing/ViewModels/ResourceRequestedEventArgs.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ResourceRequestedEventArgs.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Xamarin.PropertyEditing.ViewModels
+{
+	internal class ResourceRequestedEventArgs
+		: EventArgs
+	{
+		public Resource Resource
+		{
+			get;
+			set;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/ViewModels/ResourceSelectorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ResourceSelectorViewModel.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.PropertyEditing.ViewModels
+{
+	internal class ResourceSelectorViewModel
+		: NotifyingObject
+	{
+		public ResourceSelectorViewModel (IResourceProvider provider, IEnumerable<object> targets, IPropertyInfo property)
+		{
+			if (provider == null)
+				throw new ArgumentNullException (nameof (provider));
+			if (targets == null)
+				throw new ArgumentNullException (nameof (targets));
+			if (property == null)
+				throw new ArgumentNullException (nameof (property));
+
+			Provider = provider;
+			this.targets = targets.ToArray();
+			Property = property;
+			UpdateResources();
+
+			this.resourcesView = new SimpleCollectionView (this.resources, new SimpleCollectionViewOptions {
+				DisplaySelector = (o) => ((Resource)o).Name
+			});
+		}
+
+		public IPropertyInfo Property
+		{
+			get;
+		}
+
+		public IResourceProvider Provider
+		{
+			get;
+		}
+
+		public IEnumerable Resources => this.resourcesView;
+
+		public bool IsLoading
+		{
+			get { return this.isLoading; }
+			set
+			{
+				if (this.isLoading == value)
+					return;
+
+				this.isLoading = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public bool ShowSystemResources
+		{
+			get {  return this.showSystemResources; }
+			set
+			{
+				if (this.showSystemResources == value)
+					return;
+
+				this.showSystemResources = value;
+				OnPropertyChanged();
+				UpdateResourceFilter();
+			}
+		}
+
+		public string FilterText
+		{
+			get { return this.filterText; }
+			set
+			{
+				if (this.filterText == value)
+					return;
+
+				this.filterText = value;
+				OnPropertyChanged();
+				UpdateResourceFilter();
+			}
+		}
+
+		private readonly ObservableCollectionEx<Resource> resources = new ObservableCollectionEx<Resource>();
+		private readonly SimpleCollectionView resourcesView;
+		private bool showSystemResources = true, isLoading;
+		private string filterText;
+		private readonly object[] targets;
+
+		private void UpdateResourceFilter()
+		{
+			if (String.IsNullOrWhiteSpace (FilterText) && ShowSystemResources) {
+				this.resourcesView.Options.Filter = null;
+				return;
+			}
+
+			this.resourcesView.Options.Filter = ResourceFilter;
+		}
+
+		private bool ResourceFilter (object item)
+		{
+			var r = (Resource)item;
+			if (!String.IsNullOrWhiteSpace (FilterText) && !r.Name.StartsWith (FilterText, StringComparison.OrdinalIgnoreCase))
+				return false;
+			if (!ShowSystemResources && !r.Source.IsLocal)
+				return false;
+
+			return true;
+		}
+
+		private async void UpdateResources ()
+		{
+			await UpdateResourcesAsync();
+		}
+
+		private async Task UpdateResourcesAsync()
+		{
+			this.resources.Clear();
+
+			if (Provider != null) {
+				try {
+					HashSet<Resource> joinedResources = null;
+					var tasks = new HashSet<Task<IReadOnlyList<Resource>>> (this.targets.Select (t => Provider.GetResourcesAsync (t, Property, CancellationToken.None)));
+					do {
+						var task = await Task.WhenAny (tasks);
+						tasks.Remove (task);
+
+						if (joinedResources == null)
+							joinedResources = new HashSet<Resource> (task.Result);
+						else
+							joinedResources.IntersectWith (task.Result);
+					} while (tasks.Count > 0);
+
+					this.resources.AddItems (joinedResources);
+					IsLoading = false;
+				} catch (OperationCanceledException) {
+					return;
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -94,11 +94,14 @@
     <Compile Include="Reflection\ReflectionEventInfo.cs" />
     <Compile Include="Reflection\ReflectionObjectEditor.cs" />
     <Compile Include="Reflection\ReflectionPropertyInfo.cs" />
+    <Compile Include="Resource.cs" />
+    <Compile Include="ResourceSource.cs" />
     <Compile Include="TargetPlatform.cs" />
     <Compile Include="ValueInfo.cs" />
     <Compile Include="ValueSource.cs" />
     <Compile Include="ViewModels\ArrangeModeViewModel.cs" />
     <Compile Include="ViewModels\BrushPropertyViewModel.cs" />
+    <Compile Include="ViewModels\ResourceRequestedEventArgs.cs" />
     <Compile Include="ViewModels\SimpleCollectionView.cs" />
     <Compile Include="ViewModels\ConstrainedPropertyViewModel.cs" />
     <Compile Include="ViewModels\EditorViewModel.cs" />

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -102,6 +102,7 @@
     <Compile Include="ViewModels\ArrangeModeViewModel.cs" />
     <Compile Include="ViewModels\BrushPropertyViewModel.cs" />
     <Compile Include="ViewModels\ResourceRequestedEventArgs.cs" />
+    <Compile Include="ViewModels\ResourceSelectorViewModel.cs" />
     <Compile Include="ViewModels\SimpleCollectionView.cs" />
     <Compile Include="ViewModels\ConstrainedPropertyViewModel.cs" />
     <Compile Include="ViewModels\EditorViewModel.cs" />


### PR DESCRIPTION
This PR:
 - Flushes out the resources API
 - Adds basic brush preview templates (useful for the brush editor)
 - Adds documentation and clarifies some SetValue behavior
 - Adds the basis for a resource selector window

While we don't yet have a design for a resource selector window, the basics of one largely won't change from the internals perspective. As such this adds a basic one based on the type selector window that we can adjust once we have designs. The complete experience of the standin helps to test and make sure the rest of the internals are working as expected.

![2018-01-30_15-49-24](https://user-images.githubusercontent.com/156582/35590778-d983a362-05d5-11e8-895d-45cb3cd4547e.gif)
