### PR TITLE
Added (conditional) strong naming to builds

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -29,6 +29,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <!-- Build with strong naming if built as part of some Xamarin VSIX, normally referencing this project as a git submodule under external\Xamarin.PropertyEditing -->
+  <PropertyGroup Condition="Exists('..\..\..\xamarin.snk')">
+    <AssemblyOriginatorKeyFile>..\..\..\xamarin.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/Xamarin.PropertyEditing/Properties/AssemblyInfo.cs
+++ b/Xamarin.PropertyEditing/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,6 +6,12 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible (false)]
 [assembly: Guid ("a0b6fe73-d046-4e1c-ba9d-f20683889c5a")]
 
+#if STRONG_NAMED
+[assembly: InternalsVisibleTo ("Xamarin.PropertyEditing.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df")]
+[assembly: InternalsVisibleTo ("Xamarin.PropertyEditing.Windows, PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df")]
+[assembly: InternalsVisibleTo ("Xamarin.PropertyEditing.Mac, PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df")]
+#else
 [assembly: InternalsVisibleTo ("Xamarin.PropertyEditing.Tests")]
 [assembly: InternalsVisibleTo ("Xamarin.PropertyEditing.Windows")]
 [assembly: InternalsVisibleTo ("Xamarin.PropertyEditing.Mac")]
+#endif

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -29,6 +29,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <!-- Build with strong naming if built as part of some Xamarin VSIX, normally referencing this project as a git submodule under external/Xamarin.PropertyEditing -->
+  <PropertyGroup Condition="Exists('..\..\..\xamarin.snk')">
+    <AssemblyOriginatorKeyFile>..\..\..\xamarin.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -155,6 +161,5 @@
       <LastGenOutput>LocalizationResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Updated so if a ..\..\..\xamarin.snk file exists (which it will when we build proppy as git submodule under external/Xamarin.PropertyEditing), then we strong name the assemblies. Also updated InternalsVisibleTo to include public key when we build strong named, via ifdef.

Note that there's still one outstanding issue here, with this build error:
```Xamarin.PropertyEditing\Xamarin.PropertyEditing.Windows\Themes\PropertyEditorPanelStyle.xaml(147,25): error MC3064: Only public or internal classes can be used within markup. 'EventViewModel' type is not public or internal.```
It seems like there's some bug with InternalsVisibleTo that includes a public key not working properly from XAML files. But we can fix that (somehow) separately.