### PR TITLE
Remove DataType qualifier on eventsPane DataTemplate

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
                     xmlns:local="clr-namespace:Xamarin.PropertyEditing.Windows"
@@ -146,7 +146,7 @@
 							<ScrollViewer Name="eventsPane" Grid.Row="1" Visibility="Collapsed">
 								<ItemsControl ItemsSource="{Binding Events}">
 									<ItemsControl.ItemTemplate>
-										<DataTemplate DataType="{x:Type vms:EventViewModel}">
+										<DataTemplate>
 											<Grid>
 												<Grid.ColumnDefinitions>
 													<ColumnDefinition Width="0.4*" />


### PR DESCRIPTION
This effectively removes the reference to a type from a different and potentially signed assembly from XAML, and makes the build pass when the assemblies are signed. It doesn't change behavior.