### PR TITLE
Implement resource brush selection

### DIFF
--- a/Xamarin.PropertyEditing.Windows/BrushChoiceTemplateSelector.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushChoiceTemplateSelector.cs
@@ -16,6 +16,12 @@ namespace Xamarin.PropertyEditing.Windows
 			set;
 		}
 
+		public DataTemplate ResourceBrushTemplate
+		{
+			get;
+			set;
+		}
+
 		public DataTemplate MaterialDesignBrushTemplate
 		{
 			get;
@@ -31,6 +37,7 @@ namespace Xamarin.PropertyEditing.Windows
 				var choice = choiceItem.Value as string;
 				if (choice == BrushTabbedEditorControl.None) return NoBrushTemplate;
 				if (choice == BrushTabbedEditorControl.Solid) return SolidBrushTemplate;
+				if (choice == BrushTabbedEditorControl.Resource) return ResourceBrushTemplate;
 				if (choice == BrushTabbedEditorControl.MaterialDesign) return MaterialDesignBrushTemplate;
 			}
 

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -25,6 +25,7 @@ namespace Xamarin.PropertyEditing.Windows
 			this.advancedPropertyPanel = GetTemplateChild ("advancedPropertyPanel") as Expander;
 			this.solidBrushEditor = GetTemplateChild ("solidBrushEditor") as SolidBrushEditorControl;
 			this.materialDesignColorEditor = GetTemplateChild ("materialDesignColorEditor") as MaterialDesignColorEditorControl;
+			this.resourceBrushEditor = GetTemplateChild ("resourceBrushEditor") as ResourceBrushEditorControl;
 
 			if (this.brushChoice == null)
 				throw new InvalidOperationException ($"{nameof (BrushTabbedEditorControl)} is missing a child ChoiceControl named \"brushChoice\"");
@@ -34,6 +35,8 @@ namespace Xamarin.PropertyEditing.Windows
 				throw new InvalidOperationException ($"{nameof (BrushTabbedEditorControl)} is missing a child SolidBrushEditorControl named \"solidBrushEditor\"");
 			if (this.materialDesignColorEditor == null)
 				throw new InvalidOperationException ($"{nameof (BrushTabbedEditorControl)} is missing a child MaterialDesignColorEditorControl named \"materialDesignColorEditor\"");
+			if (this.resourceBrushEditor == null)
+				throw new InvalidOperationException ($"{nameof (BrushTabbedEditorControl)} is missing a child ResourceBrushEditorControl named \"resourceBrushEditor\"");
 
 			StorePreviousBrush ();
 			SelectTabFromBrush ();
@@ -54,6 +57,7 @@ namespace Xamarin.PropertyEditing.Windows
 					ViewModel.Solid.CommitLastColor ();
 					ViewModel.Solid.CommitHue ();
 					break;
+				case resource:
 				case materialDesign:
 					ViewModel.Value = ViewModel.Solid?.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));
 					break;
@@ -75,18 +79,24 @@ namespace Xamarin.PropertyEditing.Windows
 					this.brushChoice.SelectedValue = solid;
 					ShowSelectedTab ();
 					break;
+				case Key.R:
+					e.Handled = true;
+					this.brushChoice.SelectedValue = resource;
+					ShowSelectedTab ();
+					break;
 				case Key.M:
 					e.Handled = true;
 					this.brushChoice.SelectedValue = materialDesign;
 					ShowSelectedTab ();
 					break;
-					// TODO: add G, T, R for the other brush types when they are available.
+					// TODO: add G, T, etc. for the other brush types when they are available.
 				}
 			};
 		}
 
 		public static readonly string None = none;
 		public static readonly string Solid = solid;
+		public static readonly string Resource = resource;
 		public static readonly string MaterialDesign = materialDesign;
 
 		internal void FocusFirstChild ()
@@ -96,11 +106,13 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private const string none = nameof (none);
 		private const string solid = nameof (solid);
+		private const string resource = nameof (resource);
 		private const string materialDesign = nameof (materialDesign);
 
 		private ChoiceControl brushChoice;
 		private Expander advancedPropertyPanel;
 		private SolidBrushEditorControl solidBrushEditor;
+		private ResourceBrushEditorControl resourceBrushEditor;
 		private MaterialDesignColorEditorControl materialDesignColorEditor;
 
 		private BrushPropertyViewModel ViewModel => DataContext as BrushPropertyViewModel;
@@ -127,7 +139,17 @@ namespace Xamarin.PropertyEditing.Windows
 				ShowSelectedTab ();
 				break;
 			case CommonSolidBrush _:
-				this.brushChoice.SelectedValue = solid;
+				switch (ViewModel.ValueSource) {
+				case ValueSource.Local:
+					this.brushChoice.SelectedValue = solid;
+					break;
+				case ValueSource.Resource:
+					this.brushChoice.SelectedValue = resource;
+					break;
+				default:
+					this.brushChoice.SelectedValue = solid;
+					break;
+				}
 				ShowSelectedTab ();
 				break;
 			}
@@ -140,16 +162,25 @@ namespace Xamarin.PropertyEditing.Windows
 				this.advancedPropertyPanel.Visibility = Visibility.Collapsed;
 				this.solidBrushEditor.Visibility = Visibility.Collapsed;
 				this.materialDesignColorEditor.Visibility = Visibility.Collapsed;
+				this.resourceBrushEditor.Visibility = Visibility.Collapsed;
 				break;
 			case solid:
 				this.advancedPropertyPanel.Visibility = Visibility.Visible;
 				this.solidBrushEditor.Visibility = Visibility.Visible;
 				this.materialDesignColorEditor.Visibility = Visibility.Collapsed;
+				this.resourceBrushEditor.Visibility = Visibility.Collapsed;
 				break;
 			case materialDesign:
 				this.advancedPropertyPanel.Visibility = Visibility.Visible;
 				this.solidBrushEditor.Visibility = Visibility.Collapsed;
 				this.materialDesignColorEditor.Visibility = Visibility.Visible;
+				this.resourceBrushEditor.Visibility = Visibility.Collapsed;
+				break;
+			case resource:
+				this.advancedPropertyPanel.Visibility = Visibility.Collapsed;
+				this.solidBrushEditor.Visibility = Visibility.Collapsed;
+				this.materialDesignColorEditor.Visibility = Visibility.Collapsed;
+				this.resourceBrushEditor.Visibility = Visibility.Visible;
 				break;
 			}
 		}

--- a/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushTabbedEditorControl.cs
@@ -58,6 +58,7 @@ namespace Xamarin.PropertyEditing.Windows
 					ViewModel.Solid.CommitHue ();
 					break;
 				case resource:
+					break;
 				case materialDesign:
 					ViewModel.Value = ViewModel.Solid?.PreviousSolidBrush ?? new CommonSolidBrush (new CommonColor (0, 0, 0));
 					break;

--- a/Xamarin.PropertyEditing.Windows/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyButton.cs
@@ -167,7 +167,7 @@ namespace Xamarin.PropertyEditing.Windows
 		private void OnResourceRequested (object sender, ResourceRequestedEventArgs e)
 		{
 			var vm = ((PropertyViewModel)DataContext);
-			e.Resource = ResourceSelectorWindow.RequestResource (Window.GetWindow (this), vm.ResourceProvider, vm.Editors.Select (ed => ed.Target), vm.Property);
+			e.Resource = ResourceSelectorWindow.RequestResource (Window.GetWindow (this), vm.ResourceProvider, vm.Editors.Select (ed => ed.Target), vm.Property, e.Resource);
 		}
 
 		private void OnCustomExpression (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/ResourceBrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ResourceBrushEditorControl.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using Xamarin.PropertyEditing.Drawing;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	class ResourceBrushEditorControl : PropertyEditorControl
+	{
+		static ResourceBrushEditorControl ()
+		{
+			DefaultStyleKeyProperty.OverrideMetadata (typeof (ResourceBrushEditorControl), new FrameworkPropertyMetadata (typeof (ResourceBrushEditorControl)));
+		}
+
+		ListBox resourceList;
+
+		BrushPropertyViewModel ViewModel => DataContext as BrushPropertyViewModel;
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml.cs
@@ -17,9 +17,10 @@ namespace Xamarin.PropertyEditing.Windows
 			InitializeComponent ();
 		}
 
-		internal static Resource RequestResource (Window owner, IResourceProvider provider, IEnumerable<object> targets, IPropertyInfo property)
+		internal static Resource RequestResource (Window owner, IResourceProvider provider, IEnumerable<object> targets, IPropertyInfo property, Resource currentValue)
 		{
 			var w = new ResourceSelectorWindow (provider, targets, property);
+			w.list.SelectedItem = currentValue;
 			w.Owner = owner;
 			if (!w.ShowDialog () ?? false)
 				return null;

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -551,6 +551,13 @@
 				</RadioButton>
 			</DataTemplate>
 		</local:BrushChoiceTemplateSelector.SolidBrushTemplate>
+		<local:BrushChoiceTemplateSelector.ResourceBrushTemplate>
+			<DataTemplate>
+				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
+					<ContentControl Content="{DynamicResource BrushChoiceResourceBrushIcon}" MinHeight="10" MinWidth="15"/>
+				</RadioButton>
+			</DataTemplate>
+		</local:BrushChoiceTemplateSelector.ResourceBrushTemplate>
 		<local:BrushChoiceTemplateSelector.MaterialDesignBrushTemplate>
 			<DataTemplate>
 				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
@@ -571,8 +578,10 @@
 									<local:ChoiceItem Value="{x:Static local:BrushTabbedEditorControl.None}" Name="noBrushTab" Tooltip="{x:Static prop:Resources.NoBrush}"/>
 									<local:ChoiceItem Value="{x:Static local:BrushTabbedEditorControl.Solid}" Name="solidColorTab" Tooltip="{x:Static prop:Resources.SolidBrush}"/>
 									<local:ChoiceItem Value="{x:Static local:BrushTabbedEditorControl.MaterialDesign}" Name="materialDesignTab" Tooltip="{x:Static prop:Resources.MaterialDesignColorBrush}"/>
+									<local:ChoiceItem Value="{x:Static local:BrushTabbedEditorControl.Resource}" Name="resourceColorTab" Tooltip="{x:Static prop:Resources.ResourceBrush}"/>
 								</local:ChoiceControl>
 								<local:SolidBrushEditorControl x:Name="solidBrushEditor"/>
+								<local:ResourceBrushEditorControl x:Name="resourceBrushEditor"/>
 								<local:MaterialDesignColorEditorControl x:Name="materialDesignColorEditor" Visibility="Collapsed"/>
 							</StackPanel>
 						</Border>
@@ -596,7 +605,32 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
-	
+	<Style TargetType="local:ResourceBrushEditorControl">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="local:ResourceBrushEditorControl">
+					<StackPanel Orientation="Vertical">
+						<ListBox Height="100" Name="resourceList" Grid.Row="1" Margin="0,4,0,0" SelectedItem="{Binding Resource}" ItemsSource="{Binding ResourceSelector.Resources}" HorizontalContentAlignment="Stretch" BorderThickness="1" >
+							<ListBox.ItemTemplate>
+								<DataTemplate>
+									<Grid Margin="12,0,12,0">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="100" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Grid.Column="1" Text="{Binding Name,Mode=OneTime}" VerticalAlignment="Center" />
+										<ContentPresenter Grid.Column="2" Content="{Binding Value,Mode=OneTime}" Style="{DynamicResource ComplexResourcePreview}" />
+									</Grid>
+								</DataTemplate>
+							</ListBox.ItemTemplate>
+						</ListBox>
+					</StackPanel>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
 	<Style TargetType="local:SolidBrushEditorControl">
 		<Setter Property="Template">
 			<Setter.Value>

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -81,6 +81,7 @@
     <Compile Include="MaterialDesignColorEditorControl.cs" />
     <Compile Include="MultiplyMarginConverter.cs" />
     <Compile Include="ObjectEditorControl.cs" />
+    <Compile Include="ResourceBrushEditorControl.cs" />
     <Compile Include="ResourceSelectorWindow.xaml.cs">
       <DependentUpon>ResourceSelectorWindow.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -736,6 +736,15 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Brush from resource.
+        /// </summary>
+        public static string ResourceBrush {
+            get {
+                return ResourceManager.GetString("ResourceBrush", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Resource….
         /// </summary>
         public static string ResourceEllipsis {

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -313,6 +313,10 @@
     <value>Solid color brush</value>
     <comment>Solid color brush help text</comment>
   </data>
+  <data name="ResourceBrush" xml:space="preserve">
+    <value>Brush from resource</value>
+    <comment>Brush from resource help text</comment>
+  </data>
   <data name="Opacity" xml:space="preserve">
     <value>Opacity</value>
   </data>

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -36,6 +36,21 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
+		public Resource Resource
+		{
+			get => this.value?.ValueDescriptor as Resource;
+			set {
+				if (Resource == value)
+					return;
+
+				if (value == null)
+					return;
+
+				if (SetValueResourceCommand.CanExecute (value))
+					SetValueResourceCommand.Execute (value);
+			}
+		}
+
 		public string CustomExpression
 		{
 			get { return this.value?.CustomExpression; }
@@ -142,6 +157,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			OnPropertyChanged (nameof (Value));
 			OnPropertyChanged (nameof (ValueSource));
 			OnPropertyChanged (nameof (CustomExpression));
+			OnPropertyChanged (nameof (Resource));
 
 			((RelayCommand) ClearValueCommand)?.ChangeCanExecute ();
 

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -18,6 +16,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		{
 			SetValueResourceCommand = new RelayCommand<Resource> (OnSetValueToResource, CanSetValueToResource);
 			ClearValueCommand = new RelayCommand (OnClearValue, CanClearValue);
+
 			RequestCurrentValueUpdate();
 		}
 
@@ -113,6 +112,13 @@ namespace Xamarin.PropertyEditing.ViewModels
 				// The public setter for Value is a local set for binding
 				SetCurrentValue (currentValue);
 			}
+		}
+
+		protected override ResourceRequestedEventArgs CreateRequestResourceArgs ()
+		{
+			var args = base.CreateRequestResourceArgs ();
+			args.Resource = Resource;
+			return args;
 		}
 
 		protected async Task SetValueAsync (ValueInfo<TValue> newValue)
@@ -417,6 +423,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
+		protected virtual ResourceRequestedEventArgs CreateRequestResourceArgs ()
+		{
+			return new ResourceRequestedEventArgs ();
+		}
+
 		private bool CanRequestResource ()
 		{
 			return SupportsResources && ResourceProvider != null && SetValueResourceCommand != null;
@@ -424,7 +435,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private void OnRequestResource ()
 		{
-			var e = new ResourceRequestedEventArgs();
+			var e = CreateRequestResourceArgs ();
 			ResourceRequested?.Invoke (this, e);
 			if (e.Resource == null)
 				return;


### PR DESCRIPTION
This is a PR to fix #173

It add a resource selector tab for the brush editor and a few model related changes to allow binding the selected resource.  It's currently based off the material design branch to make tracking that simpler.

![image](https://user-images.githubusercontent.com/24063/36222629-8d484d28-1187-11e8-9758-ed0116062d6a.png)


- [x] Implement selector tab
- [ ] Review resource template
- [ ] Add view model related tests
- [ ] Add Icon for resource tab