### PR TITLE
[Core] Support nullable and unset primitives

### DIFF
--- a/Xamarin.PropertyEditing.Tests/BoolViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/BoolViewModelTests.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Tests
 {
-	class BoolViewModelTests
+	[TestFixture]
+	internal class BoolViewModelTests
 		: PropertyViewModelTests<bool, PropertyViewModel<bool>>
 	{
 		protected override bool GetRandomTestValue (Random rand)
@@ -15,6 +17,21 @@ namespace Xamarin.PropertyEditing.Tests
 		protected override PropertyViewModel<bool> GetViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
 		{
 			return new PropertyViewModel<bool> (platform, property, editors);
+		}
+	}
+
+	[TestFixture]
+	internal class NullableBoolViewModelTests
+		: PropertyViewModelTests<bool?, bool, PropertyViewModel<bool?>>
+	{
+		protected override bool? GetRandomTestValue (Random rand)
+		{
+			return (rand.Next (0, 2) == 1);
+		}
+
+		protected override PropertyViewModel<bool?> GetViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
+		{
+			return new PropertyViewModel<bool?> (platform, property, editors);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/BytePropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/BytePropertyViewModelTests.cs
@@ -7,7 +7,7 @@ namespace Xamarin.PropertyEditing.Tests
 {
 	[TestFixture]
 	internal class BytePropertyViewModelTests
-		: NumericViewModelTests<byte>
+		: NumericViewModelTests<byte, byte>
 	{
 		protected override Tuple<byte, byte> MaxMin => new Tuple<byte, byte> (byte.MaxValue, byte.MinValue);
 

--- a/Xamarin.PropertyEditing.Tests/ConstrainedPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ConstrainedPropertyViewModelTests.cs
@@ -6,9 +6,9 @@ using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Tests
 {
-	internal abstract class ConstrainedPropertyViewModelTests<T, TViewModel>
-		: PropertyViewModelTests<T, TViewModel>
-		where T : IComparable<T>
+	internal abstract class ConstrainedPropertyViewModelTests<T, TReal, TViewModel>
+		: PropertyViewModelTests<T, TReal, TViewModel>
+		where TReal : IComparable<TReal>
 		where TViewModel : ConstrainedPropertyViewModel<T>
 	{
 		[Test]

--- a/Xamarin.PropertyEditing.Tests/FloatingPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/FloatingPropertyViewModelTests.cs
@@ -7,7 +7,7 @@ namespace Xamarin.PropertyEditing.Tests
 {
 	[TestFixture]
 	internal class FloatingPropertyViewModelTests
-		: NumericViewModelTests<double>
+		: NumericViewModelTests<double, double>
 	{
 		protected override double GetRandomTestValue (Random rand)
 		{

--- a/Xamarin.PropertyEditing.Tests/IntegerPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/IntegerPropertyViewModelTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Moq;
 using NUnit.Framework;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -7,7 +8,7 @@ namespace Xamarin.PropertyEditing.Tests
 {
 	[TestFixture]
 	internal class IntegerPropertyViewModelTests
-		: NumericViewModelTests<long>
+		: NumericViewModelTests<long, long>
 	{
 		protected override Tuple<long, long> MaxMin => new Tuple<long, long> (Int64.MaxValue, Int64.MinValue);
 
@@ -45,6 +46,103 @@ namespace Xamarin.PropertyEditing.Tests
 		protected override NumericPropertyViewModel<long> GetViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
 		{
 			return new NumericPropertyViewModel<long> (platform, property, editors);
+		}
+	}
+
+	[TestFixture]
+	internal class NullableIntegerPropertyViewModelTests
+		: NumericViewModelTests<long?, long>
+	{
+		// TODO: we can handle value disagreements with null as well
+
+		[Test]
+		[Description ("Even if we say its nullable, the IPropertyInfo type and source are the actual controllers")]
+		public void ConstrainedToNonNull ()
+		{
+			var property = GetPropertyMock ();
+			// As long as IPropertyInfo Type is non-nullable AND we report supporting the Default source, we should act non-nullable
+			property.SetupGet (ip => ip.ValueSources).Returns (ValueSources.Local | ValueSources.Default);
+			property.SetupGet (ip => ip.Type).Returns (typeof(long)); // override base long?
+
+			var vm = GetViewModel (property.Object, new MockObjectEditor (property.Object));
+			Assert.That (vm.Value, Is.EqualTo (0));
+
+			vm.Value = null;
+			Assert.That (vm.Value, Is.EqualTo (0));
+		}
+
+		[Test]
+		public void NonNullableButUnset ()
+		{
+			var property = GetPropertyMock ();
+			// Even if we say we're non-nullable, if we need to support Unset (!Default), we should act nullable.
+			property.SetupGet (ip => ip.ValueSources).Returns (ValueSources.Local);
+			property.SetupGet (ip => ip.Type).Returns (typeof(long)); // override base long?
+
+			var vm = GetViewModel (property.Object, new MockObjectEditor (property.Object));
+			Assert.That (vm.Value, Is.EqualTo (null));
+
+			vm.Value = 5;
+			Assume.That (vm.Value, Is.EqualTo (5));
+
+			vm.Value = null;
+			Assert.That (vm.Value, Is.EqualTo (null));
+		}
+
+		[Test]
+		public void NullableEvenWithDefault ()
+		{
+			var property = GetPropertyMock ();
+			// If the property says its nullable, its nullable.
+			property.SetupGet (ip => ip.ValueSources).Returns (ValueSources.Local | ValueSources.Default);
+			property.SetupGet (ip => ip.Type).Returns (typeof(long?)); // override base long?
+
+			var vm = GetViewModel (property.Object, new MockObjectEditor (property.Object));
+			Assert.That (vm.Value, Is.EqualTo (null));
+
+			vm.Value = 5;
+			Assume.That (vm.Value, Is.EqualTo (5));
+
+			vm.Value = null;
+			Assert.That (vm.Value, Is.EqualTo (null));
+		}
+
+		protected override Tuple<long?, long?> MaxMin => new Tuple<long?, long?> (Int64.MaxValue, Int64.MinValue);
+
+		protected override long? GetRandomTestValue (Random rand)
+		{
+			return rand.Next ();
+		}
+
+		protected override long? GetConstrainedRandomValue (Random rand, out long? max, out long? min)
+		{
+			int value = rand.Next (2, Int32.MaxValue - 2);
+			max = rand.Next (value + 1, Int32.MaxValue);
+			min = rand.Next (0, value - 1);
+			return value;
+		}
+
+		protected override long? GetConstrainedRandomValueAboveBounds (Random rand, out long? max, out long? min)
+		{
+			int value = rand.Next (2, Int32.MaxValue - 2);
+			min = rand.Next (0, value - 1);
+			max = rand.Next ((int)min + 1, value - 1);
+
+			return value;
+		}
+
+		protected override long? GetConstrainedRandomValueBelowBounds (Random rand, out long? max, out long? min)
+		{
+			int value = rand.Next (2, Int32.MaxValue - 2);
+			max = rand.Next (value + 1, Int32.MaxValue);
+			min = rand.Next (value + 1, (int)max - 1);
+
+			return value;
+		}
+
+		protected override NumericPropertyViewModel<long?> GetViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
+		{
+			return new NumericPropertyViewModel<long?> (platform, property, editors);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/MockPropertyInfo/MockPropertyInfo.cs
+++ b/Xamarin.PropertyEditing.Tests/MockPropertyInfo/MockPropertyInfo.cs
@@ -19,6 +19,10 @@ namespace Xamarin.PropertyEditing.Tests.MockPropertyInfo
 					.Select (type => (TypeConverter)Activator.CreateInstance (type))
 					.ToArray();
 			}
+
+			if (typeof(T).IsValueType) {
+				this.nullConverter = new NullableConverter (typeof(Nullable<>).MakeGenericType (typeof(T)));
+			}
 		}
 
 		public string Name { get; }
@@ -41,6 +45,11 @@ namespace Xamarin.PropertyEditing.Tests.MockPropertyInfo
 						return true;
 					}
 				}
+			}
+
+			if (this.nullConverter != null && (fromValue != null  && this.nullConverter.CanConvertFrom (fromValue.GetType()) || this.nullConverter.CanConvertFrom (typeof(TFrom)))) {
+				toValue = this.nullConverter.ConvertFrom (fromValue);
+				return true;
 			}
 
 			if (toType == typeof(string)) {
@@ -96,5 +105,6 @@ namespace Xamarin.PropertyEditing.Tests.MockPropertyInfo
 		}
 
 		private readonly IReadOnlyList<TypeConverter> typeConverters;
+		private readonly NullableConverter nullConverter;
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/NumericTests.cs
+++ b/Xamarin.PropertyEditing.Tests/NumericTests.cs
@@ -67,6 +67,23 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
+		public void NullableInt32 ()
+		{
+			int? v = 0;
+			v = Numeric<int?>.Increment (v);
+			Assert.That (v, Is.EqualTo (1));
+			v = Numeric<int?>.Decrement (v);
+			Assert.That (v, Is.EqualTo (0));
+			v = Numeric<int?>.Decrement (v);
+			Assert.That (v, Is.EqualTo (-1));
+
+			v = Numeric<int?>.Increment (null);
+			Assert.That (v, Is.EqualTo (0));
+			v = Numeric<int?>.Decrement (null);
+			Assert.That (v, Is.EqualTo (0));
+		}
+
+		[Test]
 		public void UIn32 ()
 		{
 			uint v = 0;

--- a/Xamarin.PropertyEditing.Tests/NumericViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/NumericViewModelTests.cs
@@ -9,9 +9,9 @@ using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Tests
 {
-	internal abstract class NumericViewModelTests<T>
-		: ConstrainedPropertyViewModelTests<T, NumericPropertyViewModel<T>>
-		where T : struct, IComparable<T>
+	internal abstract class NumericViewModelTests<T, TReal>
+		: ConstrainedPropertyViewModelTests<T, TReal, NumericPropertyViewModel<T>>
+		where TReal : struct, IComparable<TReal>
 	{
 		[Test]
 		public void SelfConstrainedValuesCommands ()

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -10,8 +10,14 @@ using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Tests
 {
-	[SingleThreaded]
 	internal abstract class PropertyViewModelTests<TValue, TViewModel>
+		: PropertyViewModelTests<TValue, TValue, TViewModel>
+		where TViewModel : PropertyViewModel<TValue>
+	{
+	}
+
+	[SingleThreaded]
+	internal abstract class PropertyViewModelTests<TValue, TValueReal, TViewModel>
 		where TViewModel : PropertyViewModel<TValue>
 	{
 
@@ -707,7 +713,7 @@ namespace Xamarin.PropertyEditing.Tests
 		protected internal Mock<IPropertyInfo> GetPropertyMock (string name = null, string category = null)
 		{
 			var mock = new Mock<IPropertyInfo> ();
-			mock.SetupGet (pi => pi.Type).Returns (typeof(TValue));
+			mock.SetupGet (pi => pi.Type).Returns (typeof(TValueReal));
 			mock.SetupGet (pi => pi.Name).Returns (name);
 			mock.SetupGet (pi => pi.Category).Returns (category);
 

--- a/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
+++ b/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
@@ -97,7 +97,7 @@ namespace Xamarin.PropertyEditing.Windows
 		// We can improve on this, but it'll get us started
 		private static readonly Dictionary<Type, Type> TypeMap = new Dictionary<Type, Type> {
 			{ typeof(StringPropertyViewModel), typeof(StringEditorControl) },
-			{ typeof(PropertyViewModel<bool>), typeof(BoolEditorControl) },
+			{ typeof(PropertyViewModel<bool?>), typeof(BoolEditorControl) },
 			{ typeof(NumericPropertyViewModel<>), typeof(NumericEditorControl) },
 			{ typeof(PointPropertyViewModel), typeof(PointEditorControl) },
 			{ typeof(SizePropertyViewModel), typeof(SizeEditorControl) },

--- a/Xamarin.PropertyEditing/ISelfConstrainedPropertyInfo.cs
+++ b/Xamarin.PropertyEditing/ISelfConstrainedPropertyInfo.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 
 namespace Xamarin.PropertyEditing
 {
 	// Might want to replace constraints with a more generic interface, similar to availability
 	public interface ISelfConstrainedPropertyInfo<out T>
-		where T : IComparable<T>
 	{
 		T MaxValue { get; }
 		T MinValue { get; }

--- a/Xamarin.PropertyEditing/ViewModels/NumericPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/NumericPropertyViewModel.cs
@@ -6,7 +6,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 {
 	internal class NumericPropertyViewModel<T>
 		: ConstrainedPropertyViewModel<T>
-		where T : struct, IComparable<T>
 	{
 		public NumericPropertyViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
 			: base (platform, property, editors)
@@ -15,14 +14,14 @@ namespace Xamarin.PropertyEditing.ViewModels
 				Value = Numeric<T>.Increment (Value);
 			}, () => {
 				T value = Numeric<T>.Increment (Value);
-				return value.CompareTo (ValidateValue (value)) == 0;
+				return Compare (value, ValidateValue (value)) == 0;
 			});
 
 			this.lowerValue = new RelayCommand(() => {
 				Value = Numeric<T>.Decrement (Value);
 			}, () => {
 				T value = Numeric<T>.Decrement (Value);
-				return value.CompareTo (ValidateValue (value)) == 0;
+				return Compare (value, ValidateValue (value)) == 0;
 			});
 		}
 

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -461,11 +461,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public static readonly Dictionary<Type,Func<TargetPlatform,IPropertyInfo,IEnumerable<IObjectEditor>,PropertyViewModel>> ViewModelMap = new Dictionary<Type, Func<TargetPlatform, IPropertyInfo, IEnumerable<IObjectEditor>, PropertyViewModel>> {
 			{ typeof(string), (tp,p,e) => new StringPropertyViewModel (tp, p, e) },
-			{ typeof(bool), (tp,p,e) => new PropertyViewModel<bool> (tp, p, e) },
-			{ typeof(float), (tp,p,e) => new NumericPropertyViewModel<float> (tp, p, e) },
-			{ typeof(double), (tp,p,e) => new NumericPropertyViewModel<double> (tp, p, e) },
-			{ typeof(int), (tp,p,e) => new NumericPropertyViewModel<int> (tp, p, e) },
-			{ typeof(long), (tp,p,e) => new NumericPropertyViewModel<long> (tp, p, e) },
+			{ typeof(bool), (tp,p,e) => new PropertyViewModel<bool?> (tp, p, e) },
+			{ typeof(float), (tp,p,e) => new NumericPropertyViewModel<float?> (tp, p, e) },
+			{ typeof(double), (tp,p,e) => new NumericPropertyViewModel<double?> (tp, p, e) },
+			{ typeof(int), (tp,p,e) => new NumericPropertyViewModel<int?> (tp, p, e) },
+			{ typeof(long), (tp,p,e) => new NumericPropertyViewModel<long?> (tp, p, e) },
 			{ typeof(CommonSolidBrush), (tp,p,e) => new BrushPropertyViewModel(tp, p, e) },
 			{ typeof(CommonBrush), (tp,p,e) => new BrushPropertyViewModel(tp, p, e) },
 			{ typeof(CommonPoint), (tp,p,e) => new PointPropertyViewModel (tp, p, e) },


### PR DESCRIPTION
This adds support for nullable and unset for numeric and bools. It is likely to break Mac, but we're going to ignore that for the moment given the time constraints. It also contains a rather large breaking change in that get/set now use `Nullable<T>` instead of `T`, regardless of what the `IPropertyInfo.Type` reports.

It's possible we may be able to address this by calling with the right generic, so for the moment implementers should support both scenarios to avoid future breakage.