### PR TITLE
Added strong naming of mac assembly

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -43,6 +43,12 @@
     <LinkMode></LinkMode>
     <XamMacArch></XamMacArch>
   </PropertyGroup>
+  <!-- Build with strong naming if built as part of some Xamarin VSIX, normally referencing this project as a git submodule under external\Xamarin.PropertyEditing -->
+  <PropertyGroup Condition="Exists('../../../xamarin.snk')">
+    <AssemblyOriginatorKeyFile>../../../xamarin.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <DefineConstants>$(DefineConstants);STRONG_NAMED</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
If a xamarin.snk key file is found, sign the mac assembly the same
as we do on Windows.