### PR TITLE
Hide the name editor when the object is not nameable

### DIFF
--- a/Xamarin.PropertyEditing.Tests/MockEditorProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockEditorProvider.cs
@@ -14,11 +14,21 @@ namespace Xamarin.PropertyEditing.Tests
 			if (this.editorCache.TryGetValue (item, out IObjectEditor cachedEditor)) {
 				return Task.FromResult (cachedEditor);
 			}
-			IObjectEditor editor = (item is MockControl mockControl)
-				? (IObjectEditor)(new MockObjectEditor (mockControl))
-				: new ReflectionObjectEditor (item);
+			IObjectEditor editor = ChooseEditor (item);
 			this.editorCache.Add (item, editor);
 			return Task.FromResult (editor);
+		}
+
+		IObjectEditor ChooseEditor (object item)
+		{
+			switch (item) {
+			case MockWpfControl msc:
+				return new MockObjectEditor (msc);
+			case MockControl mc:
+				return new MockNameableEditor (mc);
+			default:
+				return new ReflectionObjectEditor (item);
+			}
 		}
 
 		public Task<object> CreateObjectAsync (ITypeInfo type)

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -7,6 +7,25 @@ using Xamarin.PropertyEditing.Tests.MockControls;
 
 namespace Xamarin.PropertyEditing.Tests
 {
+	internal class MockNameableEditor :MockObjectEditor, INameableObject
+	{
+		public string ObjectName { get; set; } = "Nameable";
+
+		public Task<string> GetNameAsync ()
+		{
+			return Task.FromResult (ObjectName);
+		}
+
+		public Task SetNameAsync (string name)
+		{
+			ObjectName = name;
+			return Task.FromResult (false);
+		}
+
+		public MockNameableEditor (MockControl control) : base (control)
+		{ }
+	}
+
 	internal class MockObjectEditor
 		: IObjectEditor, IObjectEventEditor
 	{

--- a/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 				}
 			};
 			this.panel.EditorProvider = new MockEditorProvider ();
+
 			this.panel.ResourceProvider = new MockResourceProvider ();
 		}
 

--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -107,8 +107,8 @@
 										<!-- type icon -->
 									</Border>
 
-									<TextBlock Name="nameLabel" Grid.Row="0" Grid.Column="1" Margin="0,2,0,2" Text="{x:Static prop:Resources.Name}" />
-									<local:TextBoxEx Grid.Row="0" Grid.Column="2" Margin="4,2,0,2" Text="{Binding ObjectName,Mode=TwoWay}" FocusSelectsAll="True" IsReadOnly="{Binding IsObjectNameReadOnly}" Focusable="{Binding IsObjectNameReadOnly,Converter={StaticResource OppositeBoolConverter}}" AutomationProperties.LabeledBy="{Binding ElementName=nameLabel,Mode=OneTime}" />
+									<TextBlock Visibility="{Binding IsObjectNameable, Converter={StaticResource BoolToVisibilityConverter}}" Name="nameLabel" Grid.Row="0" Grid.Column="1" Margin="0,2,0,2" Text="{x:Static prop:Resources.Name}" />
+									<local:TextBoxEx Visibility="{Binding IsObjectNameable, Converter={StaticResource BoolToVisibilityConverter}}" Grid.Row="0" Grid.Column="2" Margin="4,2,0,2" Text="{Binding ObjectName,Mode=TwoWay}" FocusSelectsAll="True" IsReadOnly="{Binding IsObjectNameReadOnly}" Focusable="{Binding IsObjectNameReadOnly,Converter={StaticResource OppositeBoolConverter}}" AutomationProperties.LabeledBy="{Binding ElementName=nameLabel,Mode=OneTime}" />
 
 									<TextBlock Name="typeLabel" Grid.Row="1" Grid.Column="1" Margin="0,4,0,4" Text="{x:Static prop:Resources.Type}" />
 									<TextBlock Grid.Row="1" Grid.Column="2" Margin="9,4,0,4" Text="{Binding TypeName}" />


### PR DESCRIPTION
This hides the name entry and label when the object is not nameable.
