### PR TITLE
Enable the Windows standalone app to use VS icons

### DIFF
--- a/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml.cs
@@ -25,6 +25,11 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 			};
 			this.panel.EditorProvider = new MockEditorProvider ();
 			this.panel.ResourceProvider = new MockResourceProvider ();
+#if USE_VS_ICONS
+			this.panel.Resources.MergedDictionaries.Add (new ResourceDictionary {
+				Source = new Uri ("pack://application:,,,/ProppyIcons.xaml", UriKind.RelativeOrAbsolute)
+			});
+#endif
 		}
 
 		private async void Button_Click (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows.Standalone/Xamarin.PropertyEditing.Windows.Standalone.csproj
+++ b/Xamarin.PropertyEditing.Windows.Standalone/Xamarin.PropertyEditing.Windows.Standalone.csproj
@@ -33,6 +33,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="Exists('..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\ProppyIcons.xaml')">
+    <DefineConstants>$(DefineConstants);USE_VS_ICONS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -67,6 +70,13 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+  </ItemGroup>
+  <!-- Conditionally include resource file with icons when the file exists. To be replaced later with default open icons. -->
+  <ItemGroup Condition="Exists('..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\ProppyIcons.xaml')">
+    <Page Include="..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\ProppyIcons.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MockedControlButton.cs" />

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -546,41 +546,39 @@
 		</Setter>
 	</Style>
 
-	<Style x:Key="BrushChoiceIconStyle" TargetType="Path">
-		<Setter Property="Stroke" Value="{DynamicResource InputForegroundBrush}" />
-		<Setter Property="Fill" Value="{DynamicResource InputForegroundBrush}" />
-		<Setter Property="VerticalAlignment" Value="Center" />
-	</Style>
-
 	<local:BrushChoiceTemplateSelector x:Key="BrushChoiceTemplateSelector">
 		<local:BrushChoiceTemplateSelector.NoBrushTemplate>
 			<DataTemplate>
-				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
-					<Path Style="{StaticResource BrushChoiceIconStyle}" Data="{DynamicResource BrushChoiceNoBrushGeometry}" MinHeight="10" MinWidth="15"/>
+				<RadioButton Style="{DynamicResource ChoiceControlItem}" MinHeight="20" MinWidth="20"
+							 GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
+					<ContentControl ContentTemplate="{DynamicResource BrushChoiceNoBrushIcon}"/>
 				</RadioButton>
 			</DataTemplate>
 		</local:BrushChoiceTemplateSelector.NoBrushTemplate>
 		<local:BrushChoiceTemplateSelector.SolidBrushTemplate>
 			<DataTemplate>
-				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
-					<Path Style="{StaticResource BrushChoiceIconStyle}" Data="{DynamicResource BrushChoiceSolidBrushGeometry}" MinHeight="10" MinWidth="15"/>
+				<RadioButton Style="{DynamicResource ChoiceControlItem}" MinHeight="20" MinWidth="20"
+							 GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
+					<ContentControl ContentTemplate="{DynamicResource BrushChoiceSolidBrushIcon}"/>
 				</RadioButton>
 			</DataTemplate>
 		</local:BrushChoiceTemplateSelector.SolidBrushTemplate>
-		<local:BrushChoiceTemplateSelector.ResourceBrushTemplate>
-			<DataTemplate>
-				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
-					<ContentControl Content="{DynamicResource BrushChoiceResourceBrushIcon}" MinHeight="10" MinWidth="15"/>
-				</RadioButton>
-			</DataTemplate>
-		</local:BrushChoiceTemplateSelector.ResourceBrushTemplate>
 		<local:BrushChoiceTemplateSelector.MaterialDesignBrushTemplate>
 			<DataTemplate>
-				<RadioButton Style="{DynamicResource ChoiceControlItem}" GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
-					<Path Style="{StaticResource BrushChoiceIconStyle}" Data="{DynamicResource BrushChoiceMaterialDesignGeometry}" MinHeight="10" MinWidth="15"/>
+				<RadioButton Style="{DynamicResource ChoiceControlItem}" MinHeight="20" MinWidth="20"
+							 GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
+					<ContentControl ContentTemplate="{DynamicResource BrushChoiceMaterialDesignIcon}"/>
 				</RadioButton>
 			</DataTemplate>
 		</local:BrushChoiceTemplateSelector.MaterialDesignBrushTemplate>
+		<local:BrushChoiceTemplateSelector.ResourceBrushTemplate>
+			<DataTemplate>
+				<RadioButton Style="{DynamicResource ChoiceControlItem}" MinHeight="20" MinWidth="20"
+							 GroupName="{Binding Name,RelativeSource={RelativeSource FindAncestor,AncestorType=local:ChoiceControl},Mode=OneTime}">
+					<ContentControl ContentTemplate="{DynamicResource BrushChoiceResourceBrushIcon}"/>
+				</RadioButton>
+			</DataTemplate>
+		</local:BrushChoiceTemplateSelector.ResourceBrushTemplate>
 	</local:BrushChoiceTemplateSelector>
 
 	<Style TargetType="local:BrushTabbedEditorControl">


### PR DESCRIPTION
 If the icons exist in the expected `..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\ProppyIcons.xaml` path relative to the project, the resource is included and merged at runtime. This enables us to verify that the icons display in this context, which should make sure they also do so in VS. Later, we should have a proper fallback to a default set of icons.