### PR TITLE
Handle multiselection without crashing

### DIFF
--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -172,9 +172,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private bool SetCurrentValue (ValueInfo<TValue> newValue)
 		{
-			if (!this.isNullable && newValue.Value == null) {
+			if (!this.isNullable && newValue != null && newValue.Value == null)
 				newValue.Value = DefaultValue;
-			}
 
 			if (this.value == newValue)
 				return false;


### PR DESCRIPTION
This avoids a crash with multiple selected non nullable properties.  I'm not certain this is the correct way to handle that case.