### PR TITLE
[Win] Auto-include resources and pass merges to subwindows

### DIFF
--- a/Xamarin.PropertyEditing.Windows.Standalone/App.xaml
+++ b/Xamarin.PropertyEditing.Windows.Standalone/App.xaml
@@ -1,13 +1,9 @@
-﻿<Application x:Class="Xamarin.PropertyEditing.Windows.Standalone.App"
+<Application x:Class="Xamarin.PropertyEditing.Windows.Standalone.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Xamarin.PropertyEditing.Windows.Standalone"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="pack://application:,,,/Xamarin.PropertyEditing.Windows;component/Themes/Resources.xaml" />
-			</ResourceDictionary.MergedDictionaries>
-		</ResourceDictionary>
+
     </Application.Resources>
 </Application>

--- a/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
@@ -31,7 +31,9 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			var vm = (ObjectPropertyViewModel)sender;
 
-			ITypeInfo type = TypeSelectorWindow.RequestType (Window.GetWindow (this), vm.AssignableTypes);
+			var panel = this.FindParent<PropertyEditorPanel> ();
+
+			ITypeInfo type = TypeSelectorWindow.RequestType (panel, vm.AssignableTypes);
 			e.SelectedType = type;
 		}
 	}

--- a/Xamarin.PropertyEditing.Windows/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyButton.cs
@@ -166,8 +166,9 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnResourceRequested (object sender, ResourceRequestedEventArgs e)
 		{
+			var panel = this.FindParent<PropertyEditorPanel> ();
 			var vm = ((PropertyViewModel)DataContext);
-			e.Resource = ResourceSelectorWindow.RequestResource (Window.GetWindow (this), vm.ResourceProvider, vm.Editors.Select (ed => ed.Target), vm.Property, e.Resource);
+			e.Resource = ResourceSelectorWindow.RequestResource (panel, vm.ResourceProvider, vm.Editors.Select (ed => ed.Target), vm.Property, e.Resource);
 		}
 
 		private void OnCustomExpression (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
@@ -21,6 +21,8 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			DefaultStyleKey = typeof(PropertyEditorPanel);
 
+			Resources.MergedDictionaries.Add (new ResourceDictionary { Source = new Uri ("pack://application:,,,/Xamarin.PropertyEditing.Windows;component/Themes/Resources.xaml") });
+
 			var selectedItems = new ObservableCollection<object> ();
 			selectedItems.CollectionChanged += OnSelectedItemsChanged;
 			SelectedItems = selectedItems;

--- a/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/ResourceSelectorWindow.xaml.cs
@@ -11,17 +11,24 @@ namespace Xamarin.PropertyEditing.Windows
 	internal partial class ResourceSelectorWindow
 		: WindowEx
 	{
-		public ResourceSelectorWindow (IResourceProvider resourceProvider, IEnumerable<object> targets, IPropertyInfo property)
+		public ResourceSelectorWindow (IEnumerable<ResourceDictionary> mergedResources, IResourceProvider resourceProvider, IEnumerable<object> targets, IPropertyInfo property)
 		{
+			Resources.MergedDictionaries.AddItems (mergedResources);
 			DataContext = new ResourceSelectorViewModel (resourceProvider, targets, property);
 			InitializeComponent ();
 		}
 
-		internal static Resource RequestResource (Window owner, IResourceProvider provider, IEnumerable<object> targets, IPropertyInfo property, Resource currentValue)
+		internal static Resource RequestResource (PropertyEditorPanel owner, IResourceProvider provider, IEnumerable<object> targets, IPropertyInfo property, Resource currentValue)
 		{
-			var w = new ResourceSelectorWindow (provider, targets, property);
-			w.list.SelectedItem = currentValue;
-			w.Owner = owner;
+			Window hostWindow = Window.GetWindow (owner);
+
+			var w = new ResourceSelectorWindow (owner.Resources.MergedDictionaries, provider, targets, property) {
+				Owner = hostWindow,
+				list = {
+					SelectedItem = currentValue
+				}
+			};
+
 			if (!w.ShowDialog () ?? false)
 				return null;
 

--- a/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/TypeSelectorWindow.xaml.cs
@@ -8,16 +8,23 @@ namespace Xamarin.PropertyEditing.Windows
 	internal partial class TypeSelectorWindow
 		: WindowEx
 	{
-		internal TypeSelectorWindow (AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
+		internal TypeSelectorWindow (IEnumerable<ResourceDictionary> mergedResources, AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
 		{
-			InitializeComponent ();
+			Resources.MergedDictionaries.AddItems (mergedResources);
 			DataContext = new TypeSelectorViewModel (assignableTypes);
+			InitializeComponent ();
 		}
 
-		internal static ITypeInfo RequestType (Window owner, AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
+		internal static ITypeInfo RequestType (PropertyEditorPanel owner, AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
 		{
-			var w = new TypeSelectorWindow (assignableTypes);
-			w.Owner = owner;
+			Window hostWindow = Window.GetWindow (owner);
+
+			var w = new TypeSelectorWindow (owner.Resources.MergedDictionaries, assignableTypes) {
+				Owner = hostWindow,
+			};
+
+			w.Resources.MergedDictionaries.AddItems (owner.Resources.MergedDictionaries);
+
 			if (!w.ShowDialog () ?? false)
 				return null;
 


### PR DESCRIPTION
Fixes #183 

Consumers should remove the manual `Resources.xaml` add they've included.