### PR TITLE
Add test cases for empty editor lists and null ValueInfo<T> values

### DIFF
--- a/Xamarin.PropertyEditing.Tests/BytePropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/BytePropertyViewModelTests.cs
@@ -36,7 +36,7 @@ namespace Xamarin.PropertyEditing.Tests
 		protected override byte GetConstrainedRandomValueBelowBounds (Random rand, out byte max, out byte min)
 		{
 			var value = (byte)rand.Next (2, byte.MaxValue - 2);
-			max = (byte)rand.Next (value + 1, byte.MaxValue);
+			max = (byte)rand.Next (value + 2, byte.MaxValue);
 			min = (byte)rand.Next (value + 1, (byte)(max - 1));
 
 			return value;

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -141,6 +141,61 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
+		public void MultipleValuesNull ()
+		{
+			TValue value = GetNonDefaultRandomTestValue ();
+			TValue otherValue = GetRandomTestValue ();
+
+			var basicEditor = GetBasicEditor ();
+			var prop = basicEditor.Properties.First ();
+			var editor = new Mock<IObjectEditor> ();
+			editor.SetupGet (o => o.Target).Returns (new TestClass ());
+			editor.SetupGet (oe => oe.Properties).Returns (new [] { prop });
+			editor.Setup (oe => oe.GetValueAsync<TValue> (prop, null)).ReturnsAsync ((ValueInfo<TValue>)null);
+			var e2 = new Mock<IObjectEditor> ();
+			e2.SetupGet (o => o.Target).Returns (new TestClass ());
+			e2.SetupGet (oe => oe.Properties).Returns (new [] { prop });
+			e2.Setup (oe => oe.GetValueAsync<TValue> (prop, null)).ReturnsAsync ((ValueInfo<TValue>)null);
+			var vm = GetViewModel (basicEditor.Properties.First (), new [] { e2.Object, editor.Object });
+
+			Assert.That (vm.Value, Is.EqualTo (default (TValue)));
+			Assert.That (vm.MultipleValues, Is.False);
+		}
+
+		[Test]
+		public void MultipleValuesOneNull ()
+		{
+			TValue value = GetNonDefaultRandomTestValue ();
+
+			var basicEditor = GetBasicEditor (value);
+			var prop = basicEditor.Properties.First ();
+			var editor = new Mock<IObjectEditor> ();
+			editor.SetupGet (o => o.Target).Returns (new TestClass ());
+			editor.SetupGet (oe => oe.Properties).Returns (new [] { prop });
+			editor.Setup (oe => oe.GetValueAsync<TValue> (prop, null)).ReturnsAsync ((ValueInfo<TValue>)null);
+			var vm = GetViewModel (basicEditor.Properties.First (), new [] { basicEditor, editor.Object });
+
+			Assert.That (vm.Value, Is.EqualTo (default (TValue)));
+			Assert.That (vm.MultipleValues, Is.True);
+		}
+
+		[Test]
+		public void EmptyEditorList ()
+		{
+			TValue value = GetNonDefaultRandomTestValue ();
+
+			var vm = GetBasicTestModel (value);
+			var editor = vm.Editors.First ();
+			var prop = editor.Properties.First ();
+
+			Assume.That (vm.Value, Is.EqualTo (value));
+			vm.Editors.Remove (vm.Editors.First ());
+
+			Assert.That (vm.Value, Is.EqualTo (default (TValue)));
+			Assert.That (vm.MultipleValues, Is.False);
+		}
+
+		[Test]
 		public void MultipleValuesDontMatchButSourcesDo ()
 		{
 			TValue value = GetNonDefaultRandomTestValue ();
@@ -1054,7 +1109,7 @@ namespace Xamarin.PropertyEditing.Tests
 			mock.SetupGet (pi => pi.Type).Returns (typeof(TValueReal));
 			mock.SetupGet (pi => pi.Name).Returns (name);
 			mock.SetupGet (pi => pi.Category).Returns (category);
-
+			mock.SetupGet (pi => pi.ValueSources).Returns (ValueSources.Default | ValueSources.Local);
 			AugmentPropertyMock (mock);
 
 			return mock;

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -143,9 +143,6 @@ namespace Xamarin.PropertyEditing.Tests
 		[Test]
 		public void MultipleValuesNull ()
 		{
-			TValue value = GetNonDefaultRandomTestValue ();
-			TValue otherValue = GetRandomTestValue ();
-
 			var basicEditor = GetBasicEditor ();
 			var prop = basicEditor.Properties.First ();
 			var editor = new Mock<IObjectEditor> ();
@@ -185,9 +182,6 @@ namespace Xamarin.PropertyEditing.Tests
 			TValue value = GetNonDefaultRandomTestValue ();
 
 			var vm = GetBasicTestModel (value);
-			var editor = vm.Editors.First ();
-			var prop = editor.Properties.First ();
-
 			Assume.That (vm.Value, Is.EqualTo (value));
 			vm.Editors.Remove (vm.Editors.First ());
 
@@ -1109,7 +1103,6 @@ namespace Xamarin.PropertyEditing.Tests
 			mock.SetupGet (pi => pi.Type).Returns (typeof(TValueReal));
 			mock.SetupGet (pi => pi.Name).Returns (name);
 			mock.SetupGet (pi => pi.Category).Returns (category);
-			mock.SetupGet (pi => pi.ValueSources).Returns (ValueSources.Default | ValueSources.Local);
 			AugmentPropertyMock (mock);
 
 			return mock;

--- a/Xamarin.PropertyEditing/ViewModels/CombinablePropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/CombinablePropertyViewModel.cs
@@ -84,7 +84,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 				ValueInfo<IReadOnlyList<TValue>>[] values = await Task.WhenAll (Editors.Select (ed => ed.GetValueAsync<IReadOnlyList<TValue>> (Property, Variation)).ToArray ());
 				foreach (ValueInfo<IReadOnlyList<TValue>> valueInfo in values) {
-					if (valueInfo.Value == null || valueInfo.Source == ValueSource.Unset) {
+					if (valueInfo == null || valueInfo.Value == null || valueInfo.Source == ValueSource.Unset) {
 						foreach (var kvp in this.predefinedValues.PredefinedValues) {
 							newValues[kvp.Key] = null;
 						}

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -129,6 +129,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 					if (currentValue == null)
 						currentValue = valueInfo;
 					else {
+						if (valueInfo == null) {
+							currentValue.Value = default (TValue);
+							disagree = true;
+							continue;
+						}
+
 						if (currentValue.Source != valueInfo.Source) {
 							currentValue.Source = ValueSource.Default;
 							disagree = true;


### PR DESCRIPTION
the ValueSources change is causing test failures in:
* NullableBoolViewModelTests
* NullableIntegerPropertyViewModelTests

I haven't had a chance to look into it yet beyond seeing that the model is no longer considered nullable.
