### PR TITLE
Handle manual setting of the material color foreground color

### DIFF
--- a/Xamarin.PropertyEditing.Windows/BrushBoxControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushBoxControl.cs
@@ -39,12 +39,23 @@ namespace Xamarin.PropertyEditing.Windows
 		public static readonly DependencyProperty LabelProperty =
 			DependencyProperty.Register (
 				nameof (Label), typeof (string), typeof (BrushBoxControl),
-				new PropertyMetadata (""));
+				new PropertyMetadata (null));
 
 		public string Label
 		{
 			get => (string)GetValue (LabelProperty);
 			set => SetValue (LabelProperty, value);
+		}
+
+		public static readonly DependencyProperty LightForegroundThresholdProperty =
+			DependencyProperty.Register (
+				nameof (LightForegroundThreshold), typeof (double), typeof (BrushBoxControl),
+				new PropertyMetadata (0.667));
+
+		public double LightForegroundThreshold
+		{
+			get => (double)GetValue (LightForegroundThresholdProperty);
+			set => SetValue (LightForegroundThresholdProperty, value);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/BrushToDarknessConverter.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushToDarknessConverter.cs
@@ -7,16 +7,16 @@ using Xamarin.PropertyEditing.Drawing;
 
 namespace Xamarin.PropertyEditing.Windows
 {
-	[ValueConversion (typeof (CommonColor), typeof (Darkness))]
-	internal class BrushToDarknessConverter : MarkupExtension, IValueConverter
+	internal class BrushToDarknessConverter : MarkupExtension, IMultiValueConverter
 	{
-		public object Convert (object value, Type targetType, object parameter, CultureInfo culture)
+		public object Convert (object[] values, Type targetType, object parameter, CultureInfo culture)
 		{
-			if (!(value is SolidColorBrush brush)) return Darkness.Unknown;
-			return brush.Color.ToCommonColor ().Lightness > 0.667 ? Darkness.Light : Darkness.Dark;
+			if (values.Length == 0 || !(values[0] is SolidColorBrush brush)) return Darkness.Unknown;
+			var threshold = (values.Length > 1 && values[1] is double doubleParameter) ? doubleParameter : 0.667;
+			return brush.Color.ToCommonColor ().Lightness >= threshold ? Darkness.Light : Darkness.Dark;
 		}
 
-		public object ConvertBack (object value, Type targetType, object parameter, CultureInfo culture)
+		public object[] ConvertBack (object value, Type[] targetTypes, object parameter, CultureInfo culture)
 			=> throw new NotImplementedException ();
 
 		public override object ProvideValue (IServiceProvider serviceProvider) => this;

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -1229,7 +1229,8 @@
 												BorderThickness="0"
 												ToolTip="{Binding Label}" AutomationProperties.Name="{Binding Label}" AutomationProperties.HelpText="{Binding Label}"
 												GroupName="MaterialDesignAccentOrNormal">
-												<local:BrushBoxControl Label="{Binding Label}" FontSize="10">
+												<local:BrushBoxControl Label="{Binding Label}" FontSize="10"
+																	   LightForegroundThreshold="{Binding Path=DataContext.NormalColorScriptureLightnessThreshold, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ChoiceControl}}}">
 													<local:BrushBoxControl.Brush>
 														<SolidColorBrush Color="{Binding Converter={local:CommonColorToColorConverter}}"/>
 													</local:BrushBoxControl.Brush>
@@ -1256,7 +1257,8 @@
 												BorderThickness="0"
 												ToolTip="{Binding Label}" AutomationProperties.Name="{Binding Label}" AutomationProperties.HelpText="{Binding Label}"
 												GroupName="MaterialDesignAccentOrNormal">
-												<local:BrushBoxControl Label="{Binding Label}" FontSize="10">
+												<local:BrushBoxControl Label="{Binding Label}" FontSize="10"
+																	   LightForegroundThreshold="{Binding Path=DataContext.AccentColorScriptureLightnessThreshold, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:ChoiceControl}}}">
 													<local:BrushBoxControl.Brush>
 														<SolidColorBrush Color="{Binding Converter={local:CommonColorToColorConverter}}"/>
 													</local:BrushBoxControl.Brush>
@@ -1318,18 +1320,33 @@
 								   Height="{Binding Height, RelativeSource={RelativeSource TemplatedParent}}"/>
 					</Grid>
 					<ControlTemplate.Triggers>
-						<DataTrigger Binding="{Binding Brush, RelativeSource={RelativeSource Self}, Converter={local:BrushToDarknessConverter}}"
-									 Value="Dark">
+						<DataTrigger Value="Dark">
+							<DataTrigger.Binding>
+								<MultiBinding Converter="{local:BrushToDarknessConverter}">
+									<Binding Path="Brush" RelativeSource="{RelativeSource Self}"/>
+									<Binding Path="LightForegroundThreshold" RelativeSource="{RelativeSource Self}"/>
+								</MultiBinding>
+							</DataTrigger.Binding>
 							<Setter TargetName="label" Property="Foreground" Value="#FFFFFFFF"/>
 							<Setter TargetName="labelOutline" Property="Foreground" Value="Transparent"/>
 						</DataTrigger>
-						<DataTrigger Binding="{Binding Brush, RelativeSource={RelativeSource Self}, Converter={local:BrushToDarknessConverter}}"
-									 Value="Light">
+						<DataTrigger Value="Light">
+							<DataTrigger.Binding>
+								<MultiBinding Converter="{local:BrushToDarknessConverter}">
+									<Binding Path="Brush" RelativeSource="{RelativeSource Self}"/>
+									<Binding Path="LightForegroundThreshold" RelativeSource="{RelativeSource Self}"/>
+								</MultiBinding>
+							</DataTrigger.Binding>
 							<Setter TargetName="label" Property="Foreground" Value="#FF000000"/>
 							<Setter TargetName="labelOutline" Property="Foreground" Value="Transparent"/>
 						</DataTrigger>
-						<DataTrigger Binding="{Binding Brush, RelativeSource={RelativeSource Self}, Converter={local:BrushToDarknessConverter}}"
-									 Value="Unknown">
+						<DataTrigger Value="Unknown">
+							<DataTrigger.Binding>
+								<MultiBinding Converter="{local:BrushToDarknessConverter}">
+									<Binding Path="Brush" RelativeSource="{RelativeSource Self}"/>
+									<Binding Path="LightForegroundThreshold" RelativeSource="{RelativeSource Self}"/>
+								</MultiBinding>
+							</DataTrigger.Binding>
 							<Setter TargetName="label" Property="Foreground" Value="#FF000000"/>
 							<Setter TargetName="labelOutline" Property="Foreground" Value="#FFFFFFFF"/>
 						</DataTrigger>

--- a/Xamarin.PropertyEditing/ViewModels/MaterialColorScale.cs
+++ b/Xamarin.PropertyEditing/ViewModels/MaterialColorScale.cs
@@ -17,6 +17,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 		public IReadOnlyList<CommonColor> Colors { get; set; }
 		// At which index in the scale the rendering should switch to use a light color for the color label
 		public int LightScriptureIndex { get; set; }
+		public double LightScriptureLightnessThreshold => Colors == null ? 0.667 :
+			Colors.Count <= LightScriptureIndex ? 0 : Colors[LightScriptureIndex].Lightness + 0.001;
 		public bool IsAccent { get; set; }
 		public string Name { get; set; }
 

--- a/Xamarin.PropertyEditing/ViewModels/MaterialDesignColorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/MaterialDesignColorViewModel.cs
@@ -134,8 +134,10 @@ namespace Xamarin.PropertyEditing.ViewModels
 			.Where (palette => !palette.IsAccent);
 
 		public IEnumerable<CommonColor?> AccentColorScale => GetScale (ColorName, true);
+		public double AccentColorScriptureLightnessThreshold => FindPalette (ColorName, true).LightScriptureLightnessThreshold;
 
 		public IEnumerable<CommonColor?> NormalColorScale => GetScale (ColorName, false);
+		public double NormalColorScriptureLightnessThreshold => FindPalette (ColorName, false).LightScriptureLightnessThreshold;
 
 		private string colorName;
 		private CommonColor? normalColor = null;


### PR DESCRIPTION
The threshold for switching from white to black text over a Material Design color used to be based on a brightness threshold. With this change, the switch is based on manual metadata for each palette, which ensures that the text is always readable, even on colors that give bad contrast with white text even for low brightness, such as yellow.

![image](https://user-images.githubusercontent.com/1165609/36508300-2ef825ba-1711-11e8-830c-7fd3dbe9e37f.png)
