### PR TITLE
[Win] Fix NRE in ChoiceControl on unload

### DIFF
--- a/Xamarin.PropertyEditing.Windows/ChoiceControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ChoiceControl.cs
@@ -102,7 +102,7 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnItemContainerGeneratorOnStatusChanged (object sender, EventArgs args)
 		{
-			if (ItemContainerGenerator.Status != GeneratorStatus.ContainersGenerated)
+			if (ItemContainerGenerator.Status != GeneratorStatus.ContainersGenerated || (ItemTemplate == null && ItemTemplateSelector == null))
 				return;
 
 			// Note: this does not handle a changing items ItemsSource. It's not something that's currently required and unlikely to be.


### PR DESCRIPTION
In VS, unloading controls seems to want to unset their styles and
therefore their templates which triggers updates not seen in the
standalone app.

This fixes the container generator status change when the template is
changed to null. When it's null we don't care about the contents so
we'll just return.