### PR TITLE
Fix constraints for combinable

### DIFF
--- a/Xamarin.PropertyEditing.Tests/CombinablePredefinedViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/CombinablePredefinedViewModelTests.cs
@@ -200,7 +200,6 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
-		[Ignore ("There's either a bug in the test or in Moq, but the callbacks seem to be causing NREs even empty")]
 		public void SetFlagsMultipleValues ()
 		{
 			FlagsTestEnum value = FlagsTestEnum.Flag2 | FlagsTestEnum.Flag3;
@@ -249,7 +248,8 @@ namespace Xamarin.PropertyEditing.Tests
 						Source = ValueSource.Local
 					});
 					editorMock.Raise (oe => oe.PropertyChanged += null, new EditorPropertyChangedEventArgs (p.Object));
-				});
+				})
+				.Returns (Task.FromResult (true));
 
 			ValueInfo<IReadOnlyList<int>> setValue2 = null;
 			editorMock2.Setup (oe => oe.SetValueAsync (p.Object, It.IsAny<ValueInfo<IReadOnlyList<int>>> (), null))
@@ -266,7 +266,8 @@ namespace Xamarin.PropertyEditing.Tests
 						Source = ValueSource.Local
 					});
 					editorMock2.Raise (oe => oe.PropertyChanged += null, new EditorPropertyChangedEventArgs (p.Object));
-				});
+				})
+				.Returns (Task.FromResult (true));
 
 			var vm = GetViewModel (p.Object, new [] { editorMock.Object, editorMock2.Object });
 			Assume.That (vm.Choices.Count, Is.EqualTo (7));
@@ -288,7 +289,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assume.That (flag5Choice.Value, Is.EqualTo ((int)FlagsTestEnum.Flag5));
 			Assume.That (flag5Choice.IsFlagged.HasValue, Is.False);
 
-			vm.Choices[1].IsFlagged = true;
+			flag1Choice.IsFlagged = true;
 
 			Assert.That (setValue, Is.Not.Null, "Did not call setvalue");
 			CollectionAssert.AreEquivalent (new[] { (int)FlagsTestEnum.Flag1, (int)FlagsTestEnum.Flag2, (int)FlagsTestEnum.Flag3 }, setValue.Value);


### PR DESCRIPTION
This PR:
 - Fixes constraints to work on combinable values
 - Fixes a broken test to not NRE. That test fails and it's my intention to leave it failing until I can fix it. It is specifically related to multi-selection which is currently disabled in our consumers.