### PR TITLE
Validation/Coerce

### DIFF
--- a/Xamarin.PropertyEditing.Tests/CombinablePredefinedViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/CombinablePredefinedViewModelTests.cs
@@ -390,6 +390,13 @@ namespace Xamarin.PropertyEditing.Tests
 			// impl swaps flag1 back on, now o1 is flag1; o2 is flag1|flag2
 
 			flag1choice.IsFlagged = false;
+
+			var setValue = await editor.GetValueAsync<IReadOnlyList<int>> (p.Object);
+			var setValue2 = await editor2.GetValueAsync<IReadOnlyList<int>> (p.Object);
+
+			CollectionAssert.AreEquivalent (new[] { (int)FlagsTestEnum.Flag1 }, setValue.Value);
+			CollectionAssert.AreEquivalent (new[] { (int)FlagsTestEnum.Flag1, (int)FlagsTestEnum.Flag2 }, setValue2.Value);
+
 			Assert.That (flag1choice.IsFlagged, Is.True);
 			Assert.That (flag2choice.IsFlagged, Is.Null);
 		}

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -177,6 +177,19 @@ namespace Xamarin.PropertyEditing.Tests
 					softType.GetProperty ("Value").SetValue (softValue, v);
 					softType.GetProperty ("Source").SetValue (softValue, value.Source);
 				}
+
+				if (typeof(T).Name == "IReadOnlyList`1") {
+					var list = (IReadOnlyList<int>) value.Value;
+					int iv = 0;
+					foreach (int flag in list) {
+						iv |= flag;
+					}
+
+					softValue = new ValueInfo<int> {
+						Value = iv,
+						Source = value.Source
+					};
+				}
 			}
 
 			// Set to resource won't pass values so we will store it on the info since we just pass it back in GetValue
@@ -197,6 +210,8 @@ namespace Xamarin.PropertyEditing.Tests
 			if (variation != null)
 				throw new NotSupportedException (); // TODO
 
+			Type tType = typeof(T);
+
 			object value;
 			if (this.values.TryGetValue (property, out value)) {
 				var info = value as ValueInfo<T>;
@@ -209,9 +224,28 @@ namespace Xamarin.PropertyEditing.Tests
 					};
 				} else if (value == null || value is T) {
 					return new ValueInfo<T> {
-						Value = (T)value,
+						Value = (T) value,
 						Source = ValueSource.Local
 					};
+				} else if (tType.Name == "IReadOnlyList`1") {
+					// start with just supporting ints for now
+					var predefined = (IReadOnlyDictionary<string, int>)property.GetType().GetProperty(nameof(IHavePredefinedValues<int>.PredefinedValues)).GetValue(property);
+
+					var values = new List<int> ();
+					// mock should store as combined value only
+					var underlyingInfo = (ValueInfo<int>)value;
+					foreach (int v in predefined.Values) {
+						if (v == 0 && underlyingInfo.Value != 0)
+							continue;
+
+						if ((underlyingInfo.Value & v) == v)
+							values.Add (v);
+					}
+
+					return (ValueInfo<T>)Convert.ChangeType(new ValueInfo<IReadOnlyList<int>> {
+						Value = values,
+						Source = underlyingInfo.Source
+					}, typeof(ValueInfo<T>));
 				} else {
 					ValueSource source = ValueSource.Local;
 					Type valueType = value.GetType ();

--- a/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
+++ b/Xamarin.PropertyEditing.Tests/MockObjectEditor.cs
@@ -231,20 +231,26 @@ namespace Xamarin.PropertyEditing.Tests
 					// start with just supporting ints for now
 					var predefined = (IReadOnlyDictionary<string, int>)property.GetType().GetProperty(nameof(IHavePredefinedValues<int>.PredefinedValues)).GetValue(property);
 
-					var values = new List<int> ();
-					// mock should store as combined value only
-					var underlyingInfo = (ValueInfo<int>)value;
+					var underlyingInfo = value as ValueInfo<int>;
+
+					int realValue;
+					if (value is int i) {
+						realValue = i;
+					} else
+						realValue = ((ValueInfo<int>) value).Value;
+
+					var flags = new List<int> ();
 					foreach (int v in predefined.Values) {
-						if (v == 0 && underlyingInfo.Value != 0)
+						if (v == 0 && realValue != 0)
 							continue;
 
-						if ((underlyingInfo.Value & v) == v)
-							values.Add (v);
+						if ((realValue & v) == v)
+							flags.Add (v);
 					}
 
 					return (ValueInfo<T>)Convert.ChangeType(new ValueInfo<IReadOnlyList<int>> {
-						Value = values,
-						Source = underlyingInfo.Source
+						Value = flags,
+						Source = underlyingInfo?.Source ?? ValueSource.Local
 					}, typeof(ValueInfo<T>));
 				} else {
 					ValueSource source = ValueSource.Local;

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -755,8 +755,8 @@ namespace Xamarin.PropertyEditing.Tests
 			var value2 = GetRandomTestValue (value);
 
 			var mockProperty = GetPropertyMock ();
-			var validator = mockProperty.As<IValidator<TValue>> ();
-			validator.Setup (v => v.ValidateValue (value)).Returns (value2);
+			var validator = mockProperty.As<ICoerce<TValue>> ();
+			validator.Setup (v => v.CoerceValue (value)).Returns (value2);
 
 			var editor = new Mock<IObjectEditor> ();
 			editor.SetupGet (oe => oe.Properties).Returns (new[] { mockProperty.Object });

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -749,14 +749,14 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
-		public void ConstrainedProperty ()
+		public void CoercedProperty ()
 		{
 			var value = GetNonDefaultRandomTestValue ();
 			var value2 = GetRandomTestValue (value);
 
 			var mockProperty = GetPropertyMock ();
-			var validator = mockProperty.As<ICoerce<TValue>> ();
-			validator.Setup (v => v.CoerceValue (value)).Returns (value2);
+			var coerce = mockProperty.As<ICoerce<TValue>> ();
+			coerce.Setup (v => v.CoerceValue (value)).Returns (value2);
 
 			var editor = new Mock<IObjectEditor> ();
 			editor.SetupGet (oe => oe.Properties).Returns (new[] { mockProperty.Object });
@@ -765,6 +765,36 @@ namespace Xamarin.PropertyEditing.Tests
 			var vm = GetViewModel (mockProperty.Object, editor.Object);
 			vm.Value = value;
 			Assert.That (vm.Value, Is.EqualTo (value2));
+		}
+
+		[Test]
+		public async Task ValidatedProperty ()
+		{
+			var value = GetNonDefaultRandomTestValue ();
+			var value2 = GetRandomTestValue (value);
+
+			var mockProperty = GetPropertyMock ();
+			var validator = mockProperty.As<IValidator<TValue>> ();
+			validator.Setup (v => v.IsValid (It.IsAny<TValue> ())).Returns ((TValue v) => !Equals (v, value));
+
+			var editor = new MockObjectEditor (mockProperty.Object);
+			await editor.SetValueAsync (mockProperty.Object, new ValueInfo<TValue> {
+				Value = value2,
+				Source = ValueSource.Local
+			});
+
+			var vm = GetViewModel (mockProperty.Object, editor);
+			Assume.That (vm.Value, Is.EqualTo (value2));
+
+			bool changed = false;
+			vm.PropertyChanged += (sender, args) => {
+				if (args.PropertyName == nameof(PropertyViewModel<TValue>.Value))
+					changed = true;
+			};
+
+			vm.Value = value;
+			Assert.That (vm.Value, Is.EqualTo (value2));
+			Assert.That (changed, Is.True);
 		}
 
 		protected TViewModel GetViewModel (IPropertyInfo property, IObjectEditor editor)

--- a/Xamarin.PropertyEditing/ICoerce.cs
+++ b/Xamarin.PropertyEditing/ICoerce.cs
@@ -1,0 +1,7 @@
+namespace Xamarin.PropertyEditing
+{
+	public interface ICoerce<T>
+	{
+		T CoerceValue (T value);
+	}
+}

--- a/Xamarin.PropertyEditing/IValidator.cs
+++ b/Xamarin.PropertyEditing/IValidator.cs
@@ -1,7 +1,7 @@
 namespace Xamarin.PropertyEditing
 {
-	public interface IValidator<T>
+	public interface IValidator<in T>
 	{
-		T ValidateValue (T value);
+		bool IsValid (T value);
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/CombinablePropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/CombinablePropertyViewModel.cs
@@ -160,8 +160,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 							if (!this.validator.IsValid (values)) {
 								// Some combinables simply don't have a valid "none", but if we're going from indeterminate we still need to
 								// update the value, so we'll flip the changed value to true in that case so we don't go right back to indeterminate
-								if (values.Count == 0)
+								if (values.Count == 0) {
 									changedChoice.IsFlagged = true;
+									// We're explicitly triggering a change and need the update here so we need to update our snapshot.
+									currentChoices = Choices.ToDictionary (c => c, c => c.IsFlagged);
+								}
 
 								continue;
 							}

--- a/Xamarin.PropertyEditing/ViewModels/CombinablePropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/CombinablePropertyViewModel.cs
@@ -134,6 +134,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			using (await AsyncWork.RequestAsyncWork (this)) {
 				try {
+					// Snapshot current choices so we don't catch updates mid-push for multi-editors
+					var currentChoices = Choices.ToDictionary (c => c, c => c.IsFlagged);
+
 					foreach (IObjectEditor editor in Editors) {
 						ValueInfo<IReadOnlyList<TValue>> value = await editor.GetValueAsync<IReadOnlyList<TValue>> (Property, Variation);
 						HashSet<TValue> current;
@@ -142,14 +145,14 @@ namespace Xamarin.PropertyEditing.ViewModels
 						else
 							current = new HashSet<TValue> (value.Value);
 
-						foreach (var choice in Choices) {
-							if (!choice.IsFlagged.HasValue)
+						foreach (var choice in currentChoices) {
+							if (!choice.Value.HasValue)
 								continue;
 
-							if (choice.IsFlagged.Value)
-								current.Add (choice.Value);
+							if (choice.Value.Value)
+								current.Add (choice.Key.Value);
 							else
-								current.Remove (choice.Value);
+								current.Remove (choice.Key.Value);
 						}
 
 						IReadOnlyList<TValue> values = current.ToArray ();

--- a/Xamarin.PropertyEditing/ViewModels/ConstrainedPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ConstrainedPropertyViewModel.cs
@@ -57,7 +57,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		protected override T ValidateValue (T validationValue)
+		protected override T CoerceValue (T validationValue)
 		{
 			if (IsConstrained) {
 				if (Compare (validationValue, MaximumValue) > 0)
@@ -66,7 +66,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 					validationValue = MinimumValue;
 			}
 
-			return base.ValidateValue (validationValue);
+			return base.CoerceValue (validationValue);
 		}
 
 		protected int Compare (T left, T right)

--- a/Xamarin.PropertyEditing/ViewModels/NumericPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/NumericPropertyViewModel.cs
@@ -14,14 +14,14 @@ namespace Xamarin.PropertyEditing.ViewModels
 				Value = Numeric<T>.Increment (Value);
 			}, () => {
 				T value = Numeric<T>.Increment (Value);
-				return Compare (value, ValidateValue (value)) == 0;
+				return Compare (value, CoerceValue (value)) == 0;
 			});
 
 			this.lowerValue = new RelayCommand(() => {
 				Value = Numeric<T>.Decrement (Value);
 			}, () => {
 				T value = Numeric<T>.Decrement (Value);
-				return Compare (value, ValidateValue (value)) == 0;
+				return Compare (value, CoerceValue (value)) == 0;
 			});
 		}
 

--- a/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
@@ -43,10 +43,10 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public bool IsConstrainedToPredefined => this.predefinedValues.IsConstrainedToPredefined;
 
-		protected override TValue ValidateValue (TValue validationValue)
+		protected override TValue CoerceValue (TValue validationValue)
 		{
 			if (!IsConstrainedToPredefined || IsValueDefined (validationValue))
-				return base.ValidateValue (validationValue);
+				return base.CoerceValue (validationValue);
 
 			return Value;
 		}

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -24,6 +24,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			: base (platform, property, editors)
 		{
 			this.coerce = property as ICoerce<TValue>;
+			this.validator = property as IValidator<TValue>;
 			this.isNullable = (!property.ValueSources.HasFlag (ValueSources.Default) || property.Type.Name == NullableName);
 
 			SetValueResourceCommand = new RelayCommand<Resource> (OnSetValueToResource, CanSetValueToResource);
@@ -153,6 +154,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			SetError (null);
 
+			// We may need to be more careful about value sources here
+			if (this.validator != null && !this.validator.IsValid (newValue.Value)) {
+				SignalValueChange(); // Ensure UI refresh its own value
+				return;
+			}
+
 			using (await AsyncWork.RequestAsyncWork (this)) {
 				try {
 					Task[] setValues = new Task[Editors.Count];
@@ -177,9 +184,18 @@ namespace Xamarin.PropertyEditing.ViewModels
 		}
 
 		private readonly ICoerce<TValue> coerce;
+		private readonly IValidator<TValue> validator;
 		private const string NullableName = "Nullable`1";
 		private bool isNullable;
 		private ValueInfo<TValue> value;
+
+		private void SignalValueChange ()
+		{
+			OnPropertyChanged (nameof (Value));
+			OnPropertyChanged (nameof (ValueSource));
+			OnPropertyChanged (nameof (CustomExpression));
+			OnPropertyChanged (nameof (Resource));
+		}
 
 		private bool SetCurrentValue (ValueInfo<TValue> newValue)
 		{
@@ -191,10 +207,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			this.value = newValue;
 			OnValueChanged ();
-			OnPropertyChanged (nameof (Value));
-			OnPropertyChanged (nameof (ValueSource));
-			OnPropertyChanged (nameof (CustomExpression));
-			OnPropertyChanged (nameof (Resource));
+			SignalValueChange();
 
 			((RelayCommand) ClearValueCommand)?.ChangeCanExecute ();
 

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -39,7 +39,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			get { return (this.value != null) ? this.value.Value : default(TValue); }
 			set
 			{
-				value = ValidateValue (value);
+				value = CoerceValue (value);
 				SetValue (new ValueInfo<TValue> {
 					Source = ValueSource.Local,
 					Value = value
@@ -79,7 +79,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		protected virtual TValue ValidateValue (TValue validationValue)
+		protected virtual TValue CoerceValue (TValue validationValue)
 		{
 			if (!this.isNullable && validationValue == null) {
 				validationValue = DefaultValue;

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -23,7 +23,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		public PropertyViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
 			: base (platform, property, editors)
 		{
-			this.validator = property as IValidator<TValue>;
+			this.coerce = property as ICoerce<TValue>;
 			this.isNullable = (!property.ValueSources.HasFlag (ValueSources.Default) || property.Type.Name == NullableName);
 
 			SetValueResourceCommand = new RelayCommand<Resource> (OnSetValueToResource, CanSetValueToResource);
@@ -85,8 +85,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 				validationValue = DefaultValue;
 			}
 
-			if (this.validator != null)
-				validationValue = this.validator.ValidateValue (validationValue);
+			if (this.coerce != null)
+				validationValue = this.coerce.CoerceValue (validationValue);
 
 			return validationValue;
 		}
@@ -176,7 +176,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		private readonly IValidator<TValue> validator;
+		private readonly ICoerce<TValue> coerce;
 		private const string NullableName = "Nullable`1";
 		private bool isNullable;
 		private ValueInfo<TValue> value;

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -75,7 +75,7 @@
     <Compile Include="IAvailabilityConstraint.cs" />
     <Compile Include="IClampedPropertyInfo.cs" />
     <Compile Include="IColorSpaced.cs" />
-    <Compile Include="IValidator.cs" />
+    <Compile Include="ICoerce.cs" />
     <Compile Include="IEditorProvider.cs" />
     <Compile Include="IObjectEventEditor.cs" />
     <Compile Include="IEventInfo.cs" />
@@ -86,6 +86,7 @@
     <Compile Include="IResourceProvider.cs" />
     <Compile Include="ISelfConstrainedPropertyInfo.cs" />
     <Compile Include="ITypeInfo.cs" />
+    <Compile Include="IValidator.cs" />
     <Compile Include="MultiAvailabilityConstraint.cs" />
     <Compile Include="NotifyingObject.cs" />
     <Compile Include="Numeric.cs" />


### PR DESCRIPTION
This PR:
 - Renames the previous validation to coercion as that's what it is
 - Adds validation support at a base level and special none handling for flags
 - Fixes previous failing behavior for flags multi-select