### PR TITLE
[Core] Ignore raw value changes from direct input

### DIFF
--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -454,6 +454,32 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
+		public async Task ValueNotChangedForSameValueDifferentSource ()
+		{
+			var value = GetNonDefaultRandomTestValue ();
+
+			var mockProperty = GetPropertyMock ();
+
+			var editor = new MockObjectEditor (mockProperty.Object);
+			await editor.SetValueAsync (mockProperty.Object, new ValueInfo<TValue> {
+				Source = ValueSource.Resource,
+				Value = value
+			});
+
+			var vm = GetViewModel (mockProperty.Object, new[] { editor });
+			Assume.That (vm.Value, Is.EqualTo (value));
+
+			bool changed = false;
+			vm.PropertyChanged += (sender, args) => {
+				changed = true;
+			};
+
+			vm.Value = value;
+
+			Assert.That (changed, Is.False, "PropertyChanged raised when value set to same value");
+		}
+
+		[Test]
 		public void ValueChanged ()
 		{
 			var value = GetNonDefaultRandomTestValue ();

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -35,12 +35,20 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public ValueSource ValueSource => this.value != null ? this.value.Source : ValueSource.Default;
 
+		/// <remarks>
+		/// This is only meant for use from the UI. Other value setting mechanisms (like, converting resources to local, or setting to a resource) should
+		/// use bespoke value setting mechanisms as this property switches the value source to local and only if the value itself has changed.
+		/// </remarks>
 		public TValue Value
 		{
 			get { return (this.value != null) ? this.value.Value : default(TValue); }
 			set
 			{
 				value = CoerceValue (value);
+
+				if (Equals (value, Value))
+					return;
+
 				SetValue (new ValueInfo<TValue> {
 					Source = ValueSource.Local,
 					Value = value


### PR DESCRIPTION
And mark .Value as for direct input only. Any other method of changing
the value needs its own path. Fixes #255