### PR TITLE
Improve designer integrated build

### DIFF
--- a/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
+++ b/Xamarin.PropertyEditing.Tests/Xamarin.PropertyEditing.Tests.csproj
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
+  <Choose>
+    <When Condition="Exists('..\..\..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')">
+      <PropertyGroup>
+        <NunitImportPath>..\..\..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props</NunitImportPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <NunitImportPath>..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props</NunitImportPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(NunitImportPath)" Condition="Exists($(NunitImportPath))" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -136,6 +148,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists($(NunitImportPath))" Text="$([System.String]::Format('$(ErrorText)', $(NunitImportPath)))" />
   </Target>
 </Project>

--- a/Xamarin.PropertyEditing.Windows.Standalone/Xamarin.PropertyEditing.Windows.Standalone.csproj
+++ b/Xamarin.PropertyEditing.Windows.Standalone/Xamarin.PropertyEditing.Windows.Standalone.csproj
@@ -33,9 +33,21 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="Exists('..\..\designer\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml')">
+  <PropertyGroup Condition="Exists('..\..\designer\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml') OR Exists('..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml')">
     <DefineConstants>$(DefineConstants);USE_VS_ICONS</DefineConstants>
   </PropertyGroup>
+  <Choose>
+    <When Condition="Exists('..\..\designer\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml')">
+      <PropertyGroup>
+        <ProppyIconPath>..\..\designer\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml</ProppyIconPath>
+      </PropertyGroup>
+    </When>
+    <When Condition="Exists('..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml')">
+      <PropertyGroup>
+        <ProppyIconPath>..\..\..\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml</ProppyIconPath>
+      </PropertyGroup>
+    </When>
+  </Choose>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -72,8 +84,8 @@
     </Compile>
   </ItemGroup>
   <!-- Conditionally include resource file with icons when the file exists. To be replaced later with default open icons. -->
-  <ItemGroup Condition="Exists('..\..\designer\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml')">
-    <Page Include="..\..\designer\Xamarin.Designer.VisualStudio\src\VisualStudio.Designer\Resources\ProppyIcons.xaml">
+  <ItemGroup Condition="Exists($(ProppyIconPath))">
+    <Page Include="$(ProppyIconPath)">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
This fixes the inclusion of the Nunit prop file and of the icons file in the case where PropertyEditing is a submodule of the designer repo, and keeping the side-by-side configuration working.