### PR TITLE
[Win] Fix scrolling in grouped mode

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -74,7 +74,13 @@
 
 	<DataTemplate x:Key="PropertyGroupTemplate">
 		<local:CategoryExpander Header="{Binding Key,Mode=OneTime}" Style="{StaticResource TreeExpanderStyle}">
-			<ItemsControl Style="{StaticResource PropertyListStyle}" ScrollViewer.CanContentScroll="False" ScrollViewer.VerticalScrollBarVisibility="Disabled"  ItemsSource="{Binding}" />
+			<ItemsControl Style="{StaticResource PropertyListStyle}" ScrollViewer.CanContentScroll="False" ScrollViewer.VerticalScrollBarVisibility="Disabled"  ItemsSource="{Binding}">
+				<ItemsControl.Template>
+					<ControlTemplate>
+						<ItemsPresenter />
+					</ControlTemplate>
+				</ItemsControl.Template>
+			</ItemsControl>
 		</local:CategoryExpander>
 	</DataTemplate>
 


### PR DESCRIPTION
Removes the scrollviewer from group child lists.

Fixes #293