### PR TITLE
Allow for properties of type CommonColor.

### DIFF
--- a/Xamarin.PropertyEditing.Windows.Standalone/MockedSampleControlButton.cs
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MockedSampleControlButton.cs
@@ -28,6 +28,13 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 				category: "Windows Only",
 				canWrite: false);
 			MockedControl.AddProperty<CommonBrush> (this.readOnlyBrushPropertyInfo);
+
+			this.colorPropertyInfo = new MockPropertyInfo<CommonColor> (
+				name: "ColorNoBrush",
+				category: "Windows Only",
+				canWrite: true,
+				valueSources: ValueSources.Default | ValueSources.Local | ValueSources.Resource);
+			MockedControl.AddProperty<CommonColor> (this.colorPropertyInfo);
 		}
 
 		public async Task SetBrushInitialValueAsync (IObjectEditor editor, CommonBrush brush)
@@ -51,9 +58,10 @@ namespace Xamarin.PropertyEditing.Windows.Standalone
 			this.readOnlyBrushSet = true;
 		}
 
-		private IPropertyInfo brushPropertyInfo;
-		private IPropertyInfo materialDesignBrushPropertyInfo;
-		private IPropertyInfo readOnlyBrushPropertyInfo;
+		private readonly IPropertyInfo brushPropertyInfo;
+		private readonly IPropertyInfo materialDesignBrushPropertyInfo;
+		private readonly IPropertyInfo readOnlyBrushPropertyInfo;
+		private readonly IPropertyInfo colorPropertyInfo;
 		private bool brushSet = false;
 		private bool materialDesignBrushSet = false;
 		private bool readOnlyBrushSet = false;

--- a/Xamarin.PropertyEditing/Drawing/CommonBrushType.cs
+++ b/Xamarin.PropertyEditing/Drawing/CommonBrushType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Xamarin.PropertyEditing.Drawing
 {
 	public enum CommonBrushType

--- a/Xamarin.PropertyEditing/Drawing/CommonColor.cs
+++ b/Xamarin.PropertyEditing/Drawing/CommonColor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Xamarin.PropertyEditing.Drawing
 {
@@ -6,6 +7,7 @@ namespace Xamarin.PropertyEditing.Drawing
 	/// Describes a color.
 	/// </summary>
 	[Serializable]
+	[TypeConverter(typeof(CommonColorToCommonBrushConverter))]
 	public struct CommonColor : IEquatable<CommonColor>
 	{
 		public CommonColor (byte r, byte g, byte b, byte a = 255, string label = null)

--- a/Xamarin.PropertyEditing/Drawing/CommonColorToCommonBrushConverter.cs
+++ b/Xamarin.PropertyEditing/Drawing/CommonColorToCommonBrushConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Xamarin.PropertyEditing.Drawing
+{
+	internal class CommonColorToCommonBrushConverter : TypeConverter
+	{
+		public override bool CanConvertTo (ITypeDescriptorContext context, Type destinationType)
+			=> typeof(CommonBrush) == destinationType ? true : base.CanConvertTo (context, destinationType);
+
+		public override object ConvertTo (ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			if (typeof (CommonBrush).IsAssignableFrom (destinationType) && value is CommonColor color) {
+				return new CommonSolidBrush (color);
+			}
+			return base.ConvertTo (context, culture, value, destinationType);
+		}
+
+		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
+			=> sourceType == typeof (CommonColor) ? true : base.CanConvertFrom (context, sourceType);
+
+		public override object ConvertFrom (ITypeDescriptorContext context, CultureInfo culture, object value)
+			=> value is CommonColor color ? new CommonSolidBrush(color) : base.ConvertFrom (context, culture, value);
+	}
+}

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -12,10 +12,12 @@ namespace Xamarin.PropertyEditing.ViewModels
 {
 	internal class BrushPropertyViewModel : PropertyViewModel<CommonBrush>
 	{
-		public BrushPropertyViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors)
+		public BrushPropertyViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors,
+		                               IEnumerable<CommonBrushType> allowedBrushTypes = null)
 			: base (platform, property, editors)
 		{
-			if (property.Type.IsAssignableFrom (typeof (CommonSolidBrush))) {
+			if (property.Type.IsAssignableFrom (typeof (CommonSolidBrush))
+				|| property.Type.IsAssignableFrom (typeof (CommonColor))) {
 				Solid = new SolidBrushViewModel (this,
 					property is IColorSpaced colorSpacedPropertyInfo ? colorSpacedPropertyInfo.ColorSpaces :  null);
 				if (platform.SupportsMaterialDesign) {
@@ -23,14 +25,19 @@ namespace Xamarin.PropertyEditing.ViewModels
 				}
 			}
 
-			// TODO: we actually need to localize this for platforms really, "brush" doesn't make sense for some
-			var types = new OrderedDictionary<string, CommonBrushType> {
-				{ Resources.NoBrush, CommonBrushType.NoBrush },
-				{ Resources.SolidBrush, CommonBrushType.Solid },
-				{ Resources.ResourceBrush, CommonBrushType.Resource }
+			allowedBrushTypes = allowedBrushTypes ?? new[] {
+				CommonBrushType.NoBrush, CommonBrushType.Solid, CommonBrushType.MaterialDesign,
+				CommonBrushType.Gradient, CommonBrushType.Tile, CommonBrushType.Resource
 			};
 
-			if (platform.SupportsMaterialDesign) {
+			// TODO: we actually need to localize this for platforms really, "brush" doesn't make sense for some
+			var types = new OrderedDictionary<string, CommonBrushType> ();
+
+			if (allowedBrushTypes.Contains (CommonBrushType.NoBrush)) types.Add (Resources.NoBrush, CommonBrushType.NoBrush);
+			if (allowedBrushTypes.Contains (CommonBrushType.Solid)) types.Add (Resources.SolidBrush, CommonBrushType.Solid);
+			if (allowedBrushTypes.Contains (CommonBrushType.Resource)) types.Add (Resources.ResourceBrush, CommonBrushType.Resource);
+
+			if (platform.SupportsMaterialDesign && allowedBrushTypes.Contains (CommonBrushType.MaterialDesign)) {
 				types.Insert (2, Resources.MaterialDesignColorBrush, CommonBrushType.MaterialDesign);
 			}
 
@@ -171,8 +178,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 				break;
 			case CommonBrushType.Solid:
 				Value = Solid?.PreviousSolidBrush ?? new CommonSolidBrush (CommonColor.Black);
-				Solid.CommitLastColor ();
-				Solid.CommitHue ();
+				Solid?.CommitLastColor ();
+				Solid?.CommitHue ();
 				break;
 			case CommonBrushType.MaterialDesign:
 				MaterialDesign.SetToClosest ();

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -454,14 +454,15 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private Task busyTask;
 
-		private static readonly Dictionary<Type,Func<TargetPlatform,IPropertyInfo,IEnumerable<IObjectEditor>,PropertyViewModel>> ViewModelMap = new Dictionary<Type, Func<TargetPlatform, IPropertyInfo, IEnumerable<IObjectEditor>, PropertyViewModel>> {
+		private static readonly Dictionary<Type, Func<TargetPlatform, IPropertyInfo, IEnumerable<IObjectEditor>, PropertyViewModel>> ViewModelMap = new Dictionary<Type, Func<TargetPlatform, IPropertyInfo, IEnumerable<IObjectEditor>, PropertyViewModel>> {
 			{ typeof(string), (tp,p,e) => new StringPropertyViewModel (tp, p, e) },
 			{ typeof(bool), (tp,p,e) => new PropertyViewModel<bool?> (tp, p, e) },
 			{ typeof(float), (tp,p,e) => new NumericPropertyViewModel<float?> (tp, p, e) },
 			{ typeof(double), (tp,p,e) => new NumericPropertyViewModel<double?> (tp, p, e) },
 			{ typeof(int), (tp,p,e) => new NumericPropertyViewModel<int?> (tp, p, e) },
 			{ typeof(long), (tp,p,e) => new NumericPropertyViewModel<long?> (tp, p, e) },
-			{ typeof(CommonSolidBrush), (tp,p,e) => new BrushPropertyViewModel(tp, p, e) },
+			{ typeof(CommonSolidBrush), (tp,p,e) => new BrushPropertyViewModel(tp, p, e, new[] {CommonBrushType.NoBrush, CommonBrushType.Solid, CommonBrushType.MaterialDesign, CommonBrushType.Resource }) },
+			{ typeof(CommonColor), (tp,p,e) => new BrushPropertyViewModel(tp, p, e, new[] {CommonBrushType.NoBrush, CommonBrushType.Solid, CommonBrushType.MaterialDesign, CommonBrushType.Resource }) },
 			{ typeof(CommonBrush), (tp,p,e) => new BrushPropertyViewModel(tp, p, e) },
 			{ typeof(CommonPoint), (tp,p,e) => new PointPropertyViewModel (tp, p, e) },
 			{ typeof(CommonSize), (tp,p,e) => new SizePropertyViewModel (tp, p, e) },

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Drawing\CommonBrushType.cs" />
     <Compile Include="Drawing\CommonColor.cs" />
     <Compile Include="Drawing\CommonColorInterpolationMode.cs" />
+    <Compile Include="Drawing\CommonColorToCommonBrushConverter.cs" />
     <Compile Include="Drawing\CommonGradientBrush.cs" />
     <Compile Include="Drawing\CommonGradientSpreadMethod.cs" />
     <Compile Include="Drawing\CommonGradientStop.cs" />


### PR DESCRIPTION
It also introduces the ability to filter what brush types can be used, property by property.

I had to introduce some type converter extensibility when resolving resource values that didn't feel 100% right when I wrote it: I wish we could do that without adding a burden to the editor author, but couldn't find a better way. If I missed one, please do tell, and I'll happily change that part.