### PR TITLE
Ignore packages dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ obj
 /TestResult.xml
 /out
 .vs
+packages


### PR DESCRIPTION
This is helpful in particular on the mac when not building side-by-side with the designer repo.