### PR TITLE
[build] Remove touchdown from the normal restore path

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,12 +2,5 @@
 <configuration>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<add key="touchdown" value="https://msblox.pkgs.visualstudio.com/_packaging/TouchdownBuildPackages/nuget/v2" />
 	</packageSources>
-	<packageSourceCredentials>
-		<touchdown>
-			<add key="Username" value="xamarinc" />
-			<add key="ClearTextPassword" value="2jqj363qn7zilvbszcnnvyj7qrrur4u4flj33yi3esadkpbmpuxq" />
-		</touchdown>
-	</packageSourceCredentials>
 </configuration>

--- a/build/NuGet.Config
+++ b/build/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<add key="touchdown" value="https://msblox.pkgs.visualstudio.com/_packaging/TouchdownBuildPackages/nuget/v2" />
+	</packageSources>
+</configuration>


### PR DESCRIPTION
Touchdown is only needed for localization and we only run that rarely,
so remove that source from the standard NuGet.Config so we don't have
to query it as part of our normal build/restore process.