### PR TITLE
Mac color editor design review

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -30,7 +30,7 @@ namespace Xamarin.PropertyEditing.Mac
 				return;
 
 			if (!Popover.Shown)
-				Popover.Show (new CGRect (20, this.Frame.Height / 2 - 2.5, 5, 5), this, NSRectEdge.MinYEdge);
+				Popover.Show (new CGRect (26, this.Frame.Height / 2 - 2, 2, 2), this, NSRectEdge.MinYEdge);
 		}
 	}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnderlinedTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnderlinedTextField.cs
@@ -73,7 +73,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			get {
 				var size = base.IntrinsicContentSize;
-				return new CGSize (size.Width + lineWidth + 10, size.Height + lineWidth + 22);
+				return new CGSize (size.Width + lineWidth + 10, size.Height + lineWidth + 10);
 			}
 		}
 	}


### PR DESCRIPTION
@vancura asked for two small updates to the latest version.  Centering the popup over the color swatch and reducing the Tab icon padding.  These are those changes