### PR TITLE
Move resource provider

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -78,7 +78,6 @@ namespace Xamarin.PropertyEditing.Mac
 		private bool isArrangeEnabled = true;
 		// when this property changes, need to create new datasource
 		private TargetPlatform targetPlatform;
-		private IResourceProvider resourceProvider;
 		private NSOutlineView propertyTable;
 		private PropertyTableDataSource dataSource;
 		private PanelViewModel viewModel;

--- a/Xamarin.PropertyEditing.Tests/BrushPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/BrushPropertyViewModelTests.cs
@@ -37,8 +37,9 @@ namespace Xamarin.PropertyEditing.Tests
 			var mockProperty = new Mock<IPropertyInfo> ();
 			mockProperty.SetupGet (pi => pi.Type).Returns (typeof (CommonBrush));
 			var mockEditor = new MockObjectEditor (mockProperty.Object);
-			var vm = new BrushPropertyViewModel (MockEditorProvider.MockPlatform, mockProperty.Object, new [] { mockEditor });
-			vm.ResourceProvider = new MockResourceProvider ();
+
+			var vm = new BrushPropertyViewModel (new TargetPlatform (new MockEditorProvider(), new MockResourceProvider()), mockProperty.Object, new [] { mockEditor });
+
 			var changed = false;
 			vm.PropertyChanged += (s, e) => {
 				if (e.PropertyName == nameof (BrushPropertyViewModel.ResourceSelector)) {
@@ -58,7 +59,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var mockProperty = new Mock<IPropertyInfo> ();
 			mockProperty.SetupGet (pi => pi.Type).Returns (typeof (CommonBrush));
 			var mockEditor = new MockObjectEditor (mockProperty.Object);
-			var vm = new BrushPropertyViewModel (MockEditorProvider.MockPlatform, mockProperty.Object, new [] { mockEditor });
+			var vm = new BrushPropertyViewModel (new TargetPlatform (new MockEditorProvider (), new MockResourceProvider()), mockProperty.Object, new [] { mockEditor });
 			
 			var changed = false;
 			vm.PropertyChanged += (s, e) => {
@@ -67,7 +68,6 @@ namespace Xamarin.PropertyEditing.Tests
 				}
 			};
 			var rs1 = vm.ResourceSelector;
-			vm.ResourceProvider = new MockResourceProvider ();
 			var rs2 = vm.ResourceSelector;
 			Assert.IsTrue (changed);
 			Assert.IsNull (rs1);

--- a/Xamarin.PropertyEditing.Tests/BrushPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/BrushPropertyViewModelTests.cs
@@ -52,26 +52,5 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.IsTrue (changed);
 			Assert.AreNotEqual (rs1, rs2);
 		}
-
-		[Test]
-		public void ChangingResourceProviderUpdatesResources ()
-		{
-			var mockProperty = new Mock<IPropertyInfo> ();
-			mockProperty.SetupGet (pi => pi.Type).Returns (typeof (CommonBrush));
-			var mockEditor = new MockObjectEditor (mockProperty.Object);
-			var vm = new BrushPropertyViewModel (new TargetPlatform (new MockEditorProvider (), new MockResourceProvider()), mockProperty.Object, new [] { mockEditor });
-			
-			var changed = false;
-			vm.PropertyChanged += (s, e) => {
-				if (e.PropertyName == nameof (BrushPropertyViewModel.ResourceSelector)) {
-					changed = true;
-				}
-			};
-			var rs1 = vm.ResourceSelector;
-			var rs2 = vm.ResourceSelector;
-			Assert.IsTrue (changed);
-			Assert.IsNull (rs1);
-			Assert.AreNotEqual (rs1, rs2);
-		}
 	}
 }

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -284,10 +284,11 @@ namespace Xamarin.PropertyEditing.Tests
 
 			var resource = new Resource ("name");
 			var vm = GetViewModel (mockProperty.Object, new[] { GetBasicEditor (mockProperty.Object) });
-			Assume.That (vm.ResourceProvider, Is.Null);
+
 			Assert.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False);
 		}
 
+		/*
 		[Test]
 		public void CanSetValueToResource ()
 		{
@@ -332,6 +333,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False, "Could set value to readonly resource");
 		}
 
+
 		[Test]
 		public void CanRequestResource()
 		{
@@ -374,7 +376,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (setChanged, Is.True);
 			Assert.That	(vm.SetValueResourceCommand.CanExecute (resource), Is.True);
 		}
-
+		*/
 		[Test]
 		public void CanRequestResourceNoProvider()
 		{
@@ -391,7 +393,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var vm = GetViewModel (mockProperty.Object, new[] { editor });
 			Assert.That (vm.RequestResourceCommand.CanExecute (null), Is.False);
 		}
-
+		/*
 		[Test]
 		[Description ("RequestResourceCommand's CanExecuteChanged should fire when SetValueResourceCommand's does")]
 		public void CanRequestResourceSetValueChanges()
@@ -419,7 +421,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assume.That (setChanged, Is.True);
 			Assert.That (requestChanged, Is.True);
 		}
-
+	
 		[Test]
 		public void SetValueToResource ()
 		{
@@ -509,7 +511,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Local));
 			Assert.That (changed, Is.True, "CanExecuteChanged didn't fire"); // Converitng to local should make the command unexecutable because its now already local
 		}
-
+*/
 		[Test]
 		public async Task ConvertToLocalValueAlreadyLocal ()
 		{
@@ -1051,7 +1053,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (changed, Is.True, "CanExecuteChanged did not fire");
 			Assert.That (vm.NavigateToValueSourceCommand.CanExecute (null), Is.True, "Navigate not enabled once value source became valid");
 		}
-
+		/*
 		[Test]
 		public void CanCreateResource ()
 		{
@@ -1153,7 +1155,7 @@ namespace Xamarin.PropertyEditing.Tests
 			vm.RequestCreateResourceCommand.Execute (null);
 			Assert.That (requested, Is.True, "CreateResourceRequested did not fire");
 		}
-
+*/
 		protected TViewModel GetViewModel (IPropertyInfo property, IObjectEditor editor)
 		{
 			return GetViewModel (property, new[] { editor });

--- a/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PropertyViewModelTests.cs
@@ -288,7 +288,6 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False);
 		}
 
-		/*
 		[Test]
 		public void CanSetValueToResource ()
 		{
@@ -303,12 +302,11 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourcesMock = new Mock<IResourceProvider> ();
 			resourcesMock.Setup (rp => rp.GetResourcesAsync (editor.Target, mockProperty.Object, It.IsAny<CancellationToken> ())).ReturnsAsync (new[] { resource });
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False);
 
 			bool changed = false;
 			vm.SetValueResourceCommand.CanExecuteChanged += (o,e) => changed = true;
-			vm.ResourceProvider = resourcesMock.Object;
 			Assume.That (changed, Is.True);
 			Assume.That (vm.SetValueResourceCommand, Is.Not.Null);
 			Assert.That (vm.SetValueResourceCommand.CanExecute (resource), Is.True, "Could not set value to resource");
@@ -326,8 +324,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourcesMock = new Mock<IResourceProvider> ();
 			resourcesMock.Setup (rp => rp.GetResourcesAsync (editor.Target, mockProperty.Object, It.IsAny<CancellationToken> ())).ReturnsAsync (new[] { resource });
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourcesMock.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.SetValueResourceCommand, Is.Not.Null);
 
 			Assert.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False, "Could set value to readonly resource");
@@ -343,8 +340,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 			var resourcesMock = new Mock<IResourceProvider>();
 
-			var vm = GetViewModel (mockProperty.Object, new[] { GetBasicEditor (mockProperty.Object) });
-			vm.ResourceProvider = resourcesMock.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { GetBasicEditor (mockProperty.Object) });
 
 			Assert.That (vm.RequestResourceCommand.CanExecute (null), Is.True);
 		}
@@ -363,7 +359,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourcesMock = new Mock<IResourceProvider> ();
 			resourcesMock.Setup (rp => rp.GetResourcesAsync (editor.Target, mockProperty.Object, It.IsAny<CancellationToken> ())).ReturnsAsync (new[] { resource });
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False);
 
 			bool setChanged = false;
@@ -371,12 +367,10 @@ namespace Xamarin.PropertyEditing.Tests
 
 			Assume.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False);
 
-			vm.ResourceProvider = resourcesMock.Object;
-
 			Assert.That (setChanged, Is.True);
 			Assert.That	(vm.SetValueResourceCommand.CanExecute (resource), Is.True);
 		}
-		*/
+		
 		[Test]
 		public void CanRequestResourceNoProvider()
 		{
@@ -393,7 +387,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var vm = GetViewModel (mockProperty.Object, new[] { editor });
 			Assert.That (vm.RequestResourceCommand.CanExecute (null), Is.False);
 		}
-		/*
+		
 		[Test]
 		[Description ("RequestResourceCommand's CanExecuteChanged should fire when SetValueResourceCommand's does")]
 		public void CanRequestResourceSetValueChanges()
@@ -407,7 +401,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourcesMock = new Mock<IResourceProvider> ();
 			resourcesMock.Setup (rp => rp.GetResourcesAsync (editor.Target, mockProperty.Object, It.IsAny<CancellationToken> ())).ReturnsAsync (new[] { resource });
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.SetValueResourceCommand.CanExecute (resource), Is.False);
 			Assume.That (vm.RequestResourceCommand.CanExecute (null), Is.False);
 
@@ -415,8 +409,6 @@ namespace Xamarin.PropertyEditing.Tests
 			vm.SetValueResourceCommand.CanExecuteChanged += (o,e) => setChanged = true;
 			bool requestChanged = false;
 			vm.RequestResourceCommand.CanExecuteChanged += (o, e) => requestChanged = true;
-
-			vm.ResourceProvider = resourcesMock.Object;
 
 			Assume.That (setChanged, Is.True);
 			Assert.That (requestChanged, Is.True);
@@ -443,8 +435,7 @@ namespace Xamarin.PropertyEditing.Tests
 				return default(TValue);
 			};
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourcesMock.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.Value, Is.EqualTo (default(TValue)));
 
 			vm.SetValueResourceCommand.Execute (resource);
@@ -470,9 +461,8 @@ namespace Xamarin.PropertyEditing.Tests
 				Value = value
 			});
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourcesMock.Object;
-
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
+			
 			Assert.That (vm.Value, Is.EqualTo (value));
 			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Resource));
 		}
@@ -496,8 +486,7 @@ namespace Xamarin.PropertyEditing.Tests
 				Value = value
 			});
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourcesMock.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourcesMock.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.Value, Is.EqualTo (value));
 			Assume.That (vm.ValueSource, Is.EqualTo (ValueSource.Resource));
 
@@ -511,7 +500,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (vm.ValueSource, Is.EqualTo (ValueSource.Local));
 			Assert.That (changed, Is.True, "CanExecuteChanged didn't fire"); // Converitng to local should make the command unexecutable because its now already local
 		}
-*/
+
 		[Test]
 		public async Task ConvertToLocalValueAlreadyLocal ()
 		{
@@ -1053,7 +1042,7 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (changed, Is.True, "CanExecuteChanged did not fire");
 			Assert.That (vm.NavigateToValueSourceCommand.CanExecute (null), Is.True, "Navigate not enabled once value source became valid");
 		}
-		/*
+
 		[Test]
 		public void CanCreateResource ()
 		{
@@ -1064,8 +1053,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourceProvider = new Mock<IResourceProvider> ();
 			resourceProvider.SetupGet (rp => rp.CanCreateResources).Returns (true);
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourceProvider.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourceProvider.Object), mockProperty.Object, new[] { editor });
 			Assert.That (vm.CanCreateResources, Is.True);
 		}
 
@@ -1085,8 +1073,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourceProvider = new Mock<IResourceProvider> ();
 			resourceProvider.SetupGet (rp => rp.CanCreateResources).Returns (true);
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourceProvider.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourceProvider.Object), mockProperty.Object, new[] { editor });
 			Assert.That (vm.RequestCreateResourceCommand.CanExecute (null), Is.True, "Can't create resources");
 		}
 
@@ -1112,8 +1099,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourceProvider = new Mock<IResourceProvider> ();
 			resourceProvider.SetupGet (rp => rp.CanCreateResources).Returns (true);
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourceProvider.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourceProvider.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.RequestCreateResourceCommand.CanExecute (null), Is.True, "Can't create resources initially");
 
 			bool changed = false;
@@ -1143,8 +1129,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var resourceProvider = new Mock<IResourceProvider> ();
 			resourceProvider.SetupGet (rp => rp.CanCreateResources).Returns (true);
 
-			var vm = GetViewModel (mockProperty.Object, new[] { editor });
-			vm.ResourceProvider = resourceProvider.Object;
+			var vm = GetViewModel (new TargetPlatform (new MockEditorProvider (), resourceProvider.Object), mockProperty.Object, new[] { editor });
 			Assume.That (vm.RequestCreateResourceCommand.CanExecute (null), Is.True, "Can't create resources");
 
 			bool requested = false;
@@ -1155,7 +1140,7 @@ namespace Xamarin.PropertyEditing.Tests
 			vm.RequestCreateResourceCommand.Execute (null);
 			Assert.That (requested, Is.True, "CreateResourceRequested did not fire");
 		}
-*/
+
 		protected TViewModel GetViewModel (IPropertyInfo property, IObjectEditor editor)
 		{
 			return GetViewModel (property, new[] { editor });

--- a/Xamarin.PropertyEditing.Windows/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyButton.cs
@@ -157,7 +157,7 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			var panel = this.FindPropertiesHost();
 			var pvm = (PropertyViewModel) DataContext;
-			e.Resource = ResourceSelectorWindow.RequestResource (panel, pvm.ResourceProvider, pvm.Editors.Select (ed => ed.Target), pvm.Property, e.Resource);
+			e.Resource = ResourceSelectorWindow.RequestResource (panel, pvm.TargetPlatform.ResourceProvider, pvm.Editors.Select (ed => ed.Target), pvm.Property, e.Resource);
 		}
 
 		private void OnCreateResourceRequested (object sender, CreateResourceRequestedEventArgs e)
@@ -165,7 +165,7 @@ namespace Xamarin.PropertyEditing.Windows
 			var panel = this.FindPropertiesHost();
 			var pvm = (PropertyViewModel) DataContext;
 
-			var result = CreateResourceWindow.CreateResource (panel, pvm.ResourceProvider, pvm.Editors.Select (oe => oe.Target), pvm.Property);
+			var result = CreateResourceWindow.CreateResource (panel, pvm.TargetPlatform.ResourceProvider, pvm.Editors.Select (oe => oe.Target), pvm.Property);
 			e.Source = result.Item1;
 			e.Name = result.Item2;
 		}

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -72,10 +72,10 @@ namespace Xamarin.PropertyEditing.ViewModels
 				if (this.resourceSelector != null)
 					return this.resourceSelector;
 
-				if (ResourceProvider == null || Editors == null)
+				if (TargetPlatform.ResourceProvider == null || Editors == null)
 					return null;
 
-				return this.resourceSelector = new ResourceSelectorViewModel (ResourceProvider, Editors.Select (ed => ed.Target), Property);
+				return this.resourceSelector = new ResourceSelectorViewModel (TargetPlatform.ResourceProvider, Editors.Select (ed => ed.Target), Property);
 			}
 		}
 		
@@ -154,7 +154,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		protected override void OnPropertyChanged ([CallerMemberName] string propertyName = null)
 		{
 			base.OnPropertyChanged (propertyName);
-			if (propertyName == nameof (PropertyViewModel.ResourceProvider)) {
+			if (propertyName == nameof (TargetPlatform)) {
 				ResetResourceSelector ();
 			}
 		}

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -271,7 +271,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private bool CanSetValueToResource (Resource resource)
 		{
-			return (ResourceProvider != null && resource != null && SupportsResources);
+			return (TargetPlatform.ResourceProvider != null && resource != null && SupportsResources);
 		}
 
 		private void OnSetValueToResource (Resource resource)
@@ -329,7 +329,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private bool CanCreateResource ()
 		{
-			return SupportsResources && ResourceProvider != null && !MultipleValues;
+			return SupportsResources && TargetPlatform.ResourceProvider != null && !MultipleValues;
 		}
 
 		private async void OnCreateResource ()
@@ -338,7 +338,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			if (e.Source == null)
 				return;
 
-			Resource resource =  await ResourceProvider.CreateResourceAsync (e.Source, e.Name, Value);
+			Resource resource =  await TargetPlatform.ResourceProvider.CreateResourceAsync (e.Source, e.Name, Value);
 			OnSetValueToResource (resource);
 		}
 
@@ -413,7 +413,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		public bool CanCreateResources
 		{
-			get { return SupportsResources && (ResourceProvider?.CanCreateResources ?? false); }
+			get { return SupportsResources && (TargetPlatform.ResourceProvider?.CanCreateResources ?? false); }
 		}
 
 		public bool SupportsBindings
@@ -425,22 +425,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 		{
 			get;
 			set;
-		}
-
-		public IResourceProvider ResourceProvider
-		{
-			get { return this.resourceProvider; }
-			set
-			{
-				if (this.resourceProvider == value)
-					return;
-
-				this.resourceProvider = value;
-				OnPropertyChanged ();
-
-				if (SetValueResourceCommand is RelayCommand<Resource> r)
-					r.ChangeCanExecute();
-			}
 		}
 
 		public ICommand SetValueResourceCommand
@@ -658,7 +642,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 		private bool CanRequestResource ()
 		{
-			return SupportsResources && ResourceProvider != null && SetValueResourceCommand != null;
+			return SupportsResources && TargetPlatform.ResourceProvider != null && SetValueResourceCommand != null;
 		}
 
 		private void OnRequestResource ()

--- a/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyViewModel.cs
@@ -281,6 +281,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			
 			SetValue (new ValueInfo<TValue> {
 				Source = ValueSource.Resource,
+				Value = Value,
 				SourceDescriptor = resource
 			});
 		}


### PR DESCRIPTION
Now that ResourceProvider is in the platform remove it from PropertyViewModel and fix up the references. This fixes the runtime problems that slipped in with the bindings related changes.