### PR TITLE
Fix new object crash after reloading

### DIFF
--- a/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
@@ -16,24 +16,25 @@ namespace Xamarin.PropertyEditing.Windows
 			DataContextChanged += OnDataContextChanged;
 		}
 
+		private ObjectPropertyViewModel vm;
+
 		private void OnDataContextChanged (object sender, DependencyPropertyChangedEventArgs e)
 		{
-			var vm = e.OldValue as ObjectPropertyViewModel;
-			if (vm != null)
-				vm.TypeRequested -= OnTypeRequested;
+			if (this.vm != null)
+				this.vm.TypeRequested -= OnTypeRequested;
 
-			vm = e.NewValue as ObjectPropertyViewModel;
-			if (vm != null)
-				vm.TypeRequested += OnTypeRequested;
+			this.vm = e.NewValue as ObjectPropertyViewModel;
+			if (this.vm != null)
+				this.vm.TypeRequested += OnTypeRequested;
 		}
 
 		private void OnTypeRequested (object sender, TypeRequestedEventArgs e)
 		{
-			var vm = (ObjectPropertyViewModel)sender;
+			var vsender = (ObjectPropertyViewModel)sender;
 
 			var panel = this.FindPropertiesHost ();
 
-			ITypeInfo type = TypeSelectorWindow.RequestType (panel, vm.AssignableTypes);
+			ITypeInfo type = TypeSelectorWindow.RequestType (panel, vsender.AssignableTypes);
 			e.SelectedType = type;
 		}
 	}

--- a/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
@@ -31,7 +31,7 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			var vm = (ObjectPropertyViewModel)sender;
 
-			var panel = this.FindParent<PropertyEditorPanel> ();
+			var panel = this.FindPropertiesHost ();
 
 			ITypeInfo type = TypeSelectorWindow.RequestType (panel, vm.AssignableTypes);
 			e.SelectedType = type;

--- a/Xamarin.PropertyEditing.Windows/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyButton.cs
@@ -100,11 +100,11 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnDataContextChanged (object sender, DependencyPropertyChangedEventArgs e)
 		{
-			if (e.OldValue is PropertyViewModel pvm) {
-				pvm.PropertyChanged -= OnPropertyChanged;
-				pvm.ResourceRequested -= OnResourceRequested;
-				pvm.CreateBindingRequested -= OnCreateBindingRequested;
-				pvm.CreateResourceRequested -= OnCreateResourceRequested;
+			if (this.vm != null) {
+				this.vm.PropertyChanged -= OnPropertyChanged;
+				this.vm.ResourceRequested -= OnResourceRequested;
+				this.vm.CreateBindingRequested -= OnCreateBindingRequested;
+				this.vm.CreateResourceRequested -= OnCreateResourceRequested;
 			}
 
 			this.vm = e.NewValue as PropertyViewModel;


### PR DESCRIPTION
Fixes #378 

What's really happening is the control is loaded and then unloaded on the switch to grouped, but the VM still lives. Since `e.OldValue` turns out to be unreliable in `DataContextChanged`, we're actually keeping the control alive and attached via the VM resulting in a dead editor receiving the event to open the object editor.