### PR TITLE
[Mac] Initial implemention of Thickness Editor.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/ThicknessEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ThicknessEditorControl.cs
@@ -1,0 +1,72 @@
+using System;
+using AppKit;
+using CoreGraphics;
+using Xamarin.PropertyEditing.Drawing;
+using Xamarin.PropertyEditing.Mac.Resources;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class CommonThicknessEditorControl : BaseRectangleEditorControl<CommonThickness>
+	{
+		public CommonThicknessEditorControl ()
+		{
+			XLabel.Frame = new CGRect (28, 27, 50, 22);
+			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
+			XLabel.StringValue = "LEFT";
+
+			XEditor.Frame = new CGRect (4, 46, 90, 20);
+
+			YLabel.Frame = new CGRect (160, 27, 45, 22);
+			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
+			YLabel.StringValue = "TOP";
+
+			YEditor.Frame = new CGRect (132, 46, 90, 20);
+
+			WidthLabel.Frame = new CGRect (24, -6, 50, 22);
+			WidthLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
+			WidthLabel.StringValue = "RIGHT";
+
+			WidthEditor.Frame = new CGRect (4, 13, 90, 20);
+
+			HeightLabel.Frame = new CGRect (150, -6, 50, 22);
+			HeightLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
+			HeightLabel.StringValue = "BOTTOM";
+
+			HeightEditor.Frame = new CGRect (132, 13, 90, 20);
+		}
+
+		public override nint GetHeight (PropertyViewModel vm)
+		{
+			return 66;
+		}
+
+		protected override void OnInputUpdated (object sender, EventArgs e)
+		{
+			ViewModel.Value = (CommonThickness)Activator.CreateInstance (typeof (CommonThickness), HeightEditor.Value, XEditor.Value, WidthEditor.Value, YEditor.Value);
+		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			XEditor.AccessibilityEnabled = XEditor.Enabled;
+			XEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityLeftEditor, ViewModel.Property.Name);
+
+			YEditor.AccessibilityEnabled = YEditor.Enabled;
+			YEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityTopEditor, ViewModel.Property.Name);
+
+			WidthEditor.AccessibilityEnabled = WidthEditor.Enabled;
+			WidthEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityRightEditor, ViewModel.Property.Name);
+
+			HeightEditor.AccessibilityEnabled = HeightEditor.Enabled;
+			HeightEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityBottomEditor, ViewModel.Property.Name);
+		}
+
+		protected override void UpdateValue ()
+		{
+			XEditor.Value = ViewModel.Value.Left;
+			YEditor.Value = ViewModel.Value.Top;
+			WidthEditor.Value = ViewModel.Value.Right;
+			HeightEditor.Value = ViewModel.Value.Bottom;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -271,6 +271,7 @@ namespace Xamarin.PropertyEditing.Mac
 			{typeof (PropertyViewModel<Rectangle>), typeof (SystemRectangleEditorControl)},
 			{typeof (BrushPropertyViewModel), typeof (BrushEditorControl)},
 			{typeof (RatioViewModel), typeof (RatioEditorControl<CommonRatio>)},
+			{typeof (ThicknessPropertyViewModel), typeof (CommonThicknessEditorControl) },
 		};
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Resources/LocalizationResources.Designer.cs
+++ b/Xamarin.PropertyEditing.Mac/Resources/LocalizationResources.Designer.cs
@@ -202,5 +202,29 @@ namespace Xamarin.PropertyEditing.Mac.Resources {
                 return ResourceManager.GetString("ObjectNamePlaceholder", resourceCulture);
             }
         }
+        
+        internal static string AccessibilityLeftEditor {
+            get {
+                return ResourceManager.GetString("AccessibilityLeftEditor", resourceCulture);
+            }
+        }
+        
+        internal static string AccessibilityTopEditor {
+            get {
+                return ResourceManager.GetString("AccessibilityTopEditor", resourceCulture);
+            }
+        }
+        
+        internal static string AccessibilityRightEditor {
+            get {
+                return ResourceManager.GetString("AccessibilityRightEditor", resourceCulture);
+            }
+        }
+        
+        internal static string AccessibilityBottomEditor {
+            get {
+                return ResourceManager.GetString("AccessibilityBottomEditor", resourceCulture);
+            }
+        }
     }
 }

--- a/Xamarin.PropertyEditing.Mac/Resources/LocalizationResources.resx
+++ b/Xamarin.PropertyEditing.Mac/Resources/LocalizationResources.resx
@@ -102,4 +102,20 @@
   <data name="ObjectNamePlaceholder" xml:space="preserve">
     <value>No Name</value>>
   </data>
+  <data name="AccessibilityLeftEditor" xml:space="preserve">
+    <value>{0} Left Editor</value>
+    <comment>Editor for LEft Value</comment>
+  </data>
+  <data name="AccessibilityTopEditor" xml:space="preserve">
+    <value>{0} Top Editor</value>
+    <comment>Editor for Top Value</comment>
+  </data>
+  <data name="AccessibilityRightEditor" xml:space="preserve">
+    <value>{0} Right Editor</value>
+    <comment>Editor for Right Value</comment>
+  </data>
+  <data name="AccessibilityBottomEditor" xml:space="preserve">
+    <value>{0} Bottom Editor</value>
+    <comment>Editor for Bottom Value</comment>
+  </data>
 </root>

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Controls\RequestResource\ResourceTableDelegate.cs" />
     <Compile Include="Controls\RequestResource\RequestResourcePreviewPanel.cs" />
     <Compile Include="Controls\PanelHeaderEditorControl.cs" />
+    <Compile Include="Controls\ThicknessEditorControl.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\" />

--- a/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
@@ -24,7 +24,7 @@ namespace Xamarin.PropertyEditing.Tests.MockControls
 			AddProperty<CommonSize> ("Size", ReadWrite);
 			AddProperty<CommonRectangle> ("Rectangle", ReadWrite);
 			AddProperty<CommonRatio> ("Ratio", ReadWrite);
-			// AddProperty<CommonThickness> ("Thickness", ReadWrite); // Lacking support on the mac at this point in time.
+			AddProperty<CommonThickness> ("Thickness", ReadWrite);
 			AddProperty<object> ("Object", ReadWrite);
 			AddProperty<IList> ("Collection", ReadWrite);
 
@@ -39,7 +39,7 @@ namespace Xamarin.PropertyEditing.Tests.MockControls
 			AddReadOnlyProperty<CommonSize> ("ReadOnlySize", ReadOnly);
 			AddReadOnlyProperty<CommonRectangle> ("ReadOnlyRectangle", ReadOnly);
 			AddReadOnlyProperty<CommonRatio> ("ReadOnlyRatio", ReadOnly);
-			// AddReadOnlyProperty<CommonThickness> ("ReadOnlyThickness", ReadOnly);
+			AddReadOnlyProperty<CommonThickness> ("ReadOnlyThickness", ReadOnly);
 
 			AddProperty<NotImplemented> ("Uncategorized", None);
 


### PR DESCRIPTION
I've made this behave similar to how the Rectangle Editor works, so as such it does not support any images in this version to replace the  label text, just as the Point Editor doesn't support images right now. So it is consistent with what we currently have. The idea being that adding images would require asking Vaclav for extra art. Hope to come back to this closer to release to add the images into this and the Point editor.