### PR TITLE
Fix brush editor reuse

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnderlinedTabViewController.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnderlinedTabViewController.cs
@@ -8,28 +8,16 @@ namespace Xamarin.PropertyEditing.Mac
 		: NotifyingTabViewController<TViewModel>
 		where TViewModel : NotifyingObject
 	{
-		public override void AddTabViewItem (NSTabViewItem item)
+		public override void AddTabViewItem (NSTabViewItem tabViewItem)
 		{
-			base.AddTabViewItem (item);
+			base.AddTabViewItem (tabViewItem);
+			this.tabStack.AddView (GetView (tabViewItem), NSStackViewGravity.Leading);
+		}
 
-			NSView tabView;
-			if (item.Image != null) {
-				tabView = new UnderlinedImageView (item.Image.Name) {
-					Selected = this.tabStack.Views.Length == SelectedTabViewItemIndex,
-					ToolTip = item.ToolTip
-				};
-			} else {
-				tabView = new UnderlinedTextField {
-					BackgroundColor = NSColor.Clear,
-					Editable = false,
-					Bezeled = false,
-					StringValue = item.Label,
-					Selected = this.tabStack.Views.Length == SelectedTabViewItemIndex,
-					ToolTip = item.ToolTip
-				};
-			}
-
-			this.tabStack.AddView (tabView, NSStackViewGravity.Leading);
+		public override void InsertTabViewItem (NSTabViewItem tabViewItem, nint index)
+		{
+			base.InsertTabViewItem (tabViewItem, index);
+			this.tabStack.InsertView (GetView (tabViewItem), (nuint)index, NSStackViewGravity.Leading);
 		}
 
 		public override void RemoveTabViewItem (NSTabViewItem tabViewItem)
@@ -42,13 +30,6 @@ namespace Xamarin.PropertyEditing.Mac
 			base.RemoveTabViewItem (tabViewItem);
 		}
 
-		private NSStackView outerStack;
-		private NSStackView innerStack;
-		private NSStackView tabStack = new NSStackView () {
-			Spacing = 2f,
-		};
-
-		private NSEdgeInsets edgeInsets = new NSEdgeInsets (0, 0, 0, 0);
 		public NSEdgeInsets EdgeInsets {
 			get => this.edgeInsets;
 			set {
@@ -98,6 +79,36 @@ namespace Xamarin.PropertyEditing.Mac
 			this.innerStack.AddView (this.tabStack, NSStackViewGravity.Leading);
 			this.innerStack.AddView (TabView, NSStackViewGravity.Bottom);
 			View = this.outerStack;
+		}
+
+		private NSStackView outerStack;
+		private NSStackView innerStack;
+		private NSStackView tabStack = new NSStackView () {
+			Spacing = 2f,
+		};
+
+		private NSEdgeInsets edgeInsets = new NSEdgeInsets (0, 0, 0, 0);
+
+		private NSView GetView (NSTabViewItem item)
+		{
+			NSView tabView;
+			if (item.Image != null) {
+				tabView = new UnderlinedImageView (item.Image.Name) {
+					Selected = this.tabStack.Views.Length == SelectedTabViewItemIndex,
+					ToolTip = item.ToolTip
+				};
+			} else {
+				tabView = new UnderlinedTextField {
+					BackgroundColor = NSColor.Clear,
+					Editable = false,
+					Bezeled = false,
+					StringValue = item.Label,
+					Selected = this.tabStack.Views.Length == SelectedTabViewItemIndex,
+					ToolTip = item.ToolTip
+				};
+			}
+
+			return tabView;
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/IReadOnlyOrderedDictionary.cs
+++ b/Xamarin.PropertyEditing/IReadOnlyOrderedDictionary.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Cadenza.Collections
+{
+	internal interface IReadOnlyOrderedDictionary<TKey, TValue>
+		: IReadOnlyDictionary<TKey, TValue>
+	{
+		KeyValuePair<TKey, TValue> this[int index] { get; }
+
+		int IndexOf (TKey key);
+	}
+}

--- a/Xamarin.PropertyEditing/OrderedDictionary.cs
+++ b/Xamarin.PropertyEditing/OrderedDictionary.cs
@@ -34,7 +34,7 @@ using System.Collections.ObjectModel;
 namespace Cadenza.Collections
 {
 	internal class OrderedDictionary<TKey, TValue>
-		: IDictionary<TKey, TValue>, IList<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>
+		: IDictionary<TKey, TValue>, IList<KeyValuePair<TKey, TValue>>, IReadOnlyOrderedDictionary<TKey, TValue>
 	{
 		public OrderedDictionary ()
 			: this (0)
@@ -125,6 +125,11 @@ namespace Cadenza.Collections
 		public TValue this[int index]
 		{
 			get { return this.dict[this.keyOrder[index]]; }
+		}
+
+		KeyValuePair<TKey, TValue> IReadOnlyOrderedDictionary<TKey, TValue>.this[int index]
+		{
+			get { return new KeyValuePair<TKey, TValue> (this.keyOrder[index], this[index]); }
 		}
 
 		KeyValuePair<TKey, TValue> IList<KeyValuePair<TKey, TValue>>.this[int index]

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -45,7 +45,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			RequestCurrentValueUpdate ();
 		}
 
-		public IReadOnlyDictionary<string, CommonBrushType> BrushTypes
+		public IReadOnlyOrderedDictionary<string, CommonBrushType> BrushTypes
 		{
 			get;
 		}

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -166,6 +166,7 @@
     <Compile Include="ViewModels\TypeSelectorViewModel.cs" />
     <Compile Include="ViewModels\RatioViewModel.cs" />
     <Compile Include="Drawing\CommonRatio.cs" />
+    <Compile Include="IReadOnlyOrderedDictionary.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Themes\BaseThemeManager.cs" />


### PR DESCRIPTION
This fixes visual and performance issues when the brush editor is used/reused inline:

- Tabs are no longer destroyed and rebuilt every time a tab is removed
- Tabs are no longer destroyed and rebuilt every time a tab is added

This has the side-effect of no longer destroying the actual active brush type editor itself.