### PR TITLE
Remove struct constraint on mac predefined values editor

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -13,7 +13,6 @@ using Xamarin.PropertyEditing.Mac.Resources;
 namespace Xamarin.PropertyEditing.Mac
 {
 	internal class PredefinedValuesEditor<T> : PropertyEditorControl<PredefinedValuesViewModel<T>>
-		where T : struct
 	{
 		public PredefinedValuesEditor ()
 		{


### PR DESCRIPTION
The struct constraint is breaking enumerations described with strings.