### PR TITLE
[Mac] Remove hard coded colour on Arrange By label.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -113,7 +113,6 @@ namespace Xamarin.PropertyEditing.Mac
 				Bezeled = false,
 				Editable = false,
 				StringValue = LocalizationResources.ArrangeByLabel,
-				TextColor = NSColor.Black,
 				TranslatesAutoresizingMaskIntoConstraints = false,
 			};
 
@@ -203,7 +202,7 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 		}
 
-		void ThemeManager_ThemeChanged (object sender, EventArgs e)
+		private void ThemeManager_ThemeChanged (object sender, EventArgs e)
 		{
 			UpdateTheme ();
 		}
@@ -227,7 +226,7 @@ namespace Xamarin.PropertyEditing.Mac
 			((PropertyTableDelegate)this.propertyTable.Delegate).UpdateExpansions (this.propertyTable);
 		}
 
-		void UpdateTheme ()
+		private void UpdateTheme ()
 		{
 			Appearance = ThemeManager.CurrentAppearance;
 		}
@@ -238,7 +237,7 @@ namespace Xamarin.PropertyEditing.Mac
 				this.propertyArrangeMode.Select (new NSString (this.viewModel.ArrangeMode.ToString ()));
 		}
 
-		class FirstResponderOutlineView : NSOutlineView
+		private class FirstResponderOutlineView : NSOutlineView
 		{
 			[Export ("validateProposedFirstResponder:forEvent:")]
 			public bool validateProposedFirstResponder (NSResponder responder, NSEvent ev)


### PR DESCRIPTION
This is what was throwing me when theme changing. So Themes ARE changing correctly, but this hardcoded colour made it appear that it wasn't

Some slight accessor changes to make the code more to standard, while I was there.