### PR TITLE
[Mac] Centre Preview inside brush popup control.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -59,7 +59,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			this.DoConstraints (new [] {
 				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Width == c.Width - 33),
-				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Height == DefaultControlHeight + 1),
+				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Height == DefaultControlHeight),
 				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Top == c.Top + 0),
 				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Left == c.Left - 1),
 			});


### PR DESCRIPTION
Fixes https://github.com/xamarin/Xamarin.PropertyEditing/issues/359

<img width="250" alt="screen shot 2018-11-28 at 09 55 55" src="https://user-images.githubusercontent.com/271363/49143880-ea7f8300-f2f3-11e8-866e-58f2b6f2cca9.png">
