### PR TITLE
[Mac]Fix vertical alignment of labels in resource lists.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BaseEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseEditorControl.cs
@@ -11,31 +11,27 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal abstract class BaseEditorControl : NSView
 	{
-		IEnumerable errorList;
-		const int DefaultActioButtonSize = 16;
+		private IEnumerable errorList;
+		private const int DefaultActioButtonSize = 16;
 
 		public event EventHandler ActionButtonClicked;
-		NSButton actionButton;
-		public NSButton ActionButton
-		{
-			get { return actionButton; }
-		}
 
-		PropertyButton propertyButton;
-		public PropertyButton PropertyButton
-		{
-			get { return propertyButton; }
-		}
+		private NSButton actionButton;
+		public NSButton ActionButton => this.actionButton;
+
+		private PropertyButton propertyButton;
+		public PropertyButton PropertyButton => this.propertyButton;
+
 
 		public BaseEditorControl ()
 		{
-			propertyButton = new PropertyButton {
+			this.propertyButton = new PropertyButton {
 				TranslatesAutoresizingMaskIntoConstraints = false
 			};
 
-			AddSubview (propertyButton);
+			AddSubview (this.propertyButton);
 
-			actionButton = new NSButton {
+			this.actionButton = new NSButton {
 				Bordered = false,
 				Enabled = false,
 				ImageScaling = NSImageScale.AxesIndependently,
@@ -46,19 +42,19 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 
 #if DESIGNER_DEBUG
-			actionButton.Image = PropertyEditorPanel.ThemeManager.GetImageForTheme ("action-warning-16");
+			this.actionButton.Image = PropertyEditorPanel.ThemeManager.GetImageForTheme ("action-warning-16");
 #endif
 
-			actionButton.Activated += (object sender, EventArgs e) => {
-				if (errorList != null) {
-					var Container = new ErrorMessageView (errorList);
+			this.actionButton.Activated += (object sender, EventArgs e) => {
+				if (this.errorList != null) {
+					var Container = new ErrorMessageView (this.errorList);
 
 					var errorMessagePopUp = new NSPopover {
 						Behavior = NSPopoverBehavior.Semitransient,
 						ContentViewController = new NSViewController (null, null) { View = Container },
 					};
 
-					errorMessagePopUp.Show (default (CGRect), actionButton, NSRectEdge.MinYEdge);
+					errorMessagePopUp.Show (default (CGRect), this.actionButton, NSRectEdge.MinYEdge);
 				}
 
 				NotifyActionButtonClicked ();
@@ -66,15 +62,16 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (actionButton);
 
-			this.DoConstraints (new[] {
-				propertyButton.ConstraintTo (this, (ab, c) => ab.Width == PropertyButton.DefaultSize),
-				propertyButton.ConstraintTo (this, (ab, c) => ab.Height == PropertyButton.DefaultSize),
-				propertyButton.ConstraintTo (this, (ab, c) => ab.Top == c.Top + 1),
-				propertyButton.ConstraintTo (this, (ab, c) => ab.Left == c.Right - 33),
-				actionButton.ConstraintTo (this, (eb, c) => eb.Width == DefaultActioButtonSize),
-				actionButton.ConstraintTo (this, (eb, c) => eb.Height == DefaultActioButtonSize),
-				actionButton.ConstraintTo (propertyButton, (eb, ab) => eb.Left == ab.Left + PropertyButton.DefaultSize),
-				actionButton.ConstraintTo (this, (eb, c) => eb.Top == c.Top + 3), // TODO: Better centering based on the icon height
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.propertyButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 1f),
+				NSLayoutConstraint.Create (this.propertyButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Right, 1f, -33f),
+				NSLayoutConstraint.Create (this.propertyButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, PropertyButton.DefaultSize),
+				NSLayoutConstraint.Create (this.propertyButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyButton.DefaultSize),
+
+				NSLayoutConstraint.Create (this.actionButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 3f), // TODO: Better centering based on the icon height
+				NSLayoutConstraint.Create (this.actionButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.propertyButton,  NSLayoutAttribute.Left, 1f, 20f),
+				NSLayoutConstraint.Create (this.actionButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, DefaultActioButtonSize),
+				NSLayoutConstraint.Create (this.actionButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultActioButtonSize),
 			});
 
 			PropertyEditorPanel.ThemeManager.ThemeChanged += ThemeManager_ThemeChanged;
@@ -99,13 +96,13 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected void SetErrors (IEnumerable errors)
 		{
-			errorList = errors;
+			this.errorList = errors;
 
-			actionButton.Enabled = errors != null;
-			actionButton.Hidden = !actionButton.Enabled;
+			this.actionButton.Enabled = errors != null;
+			this.actionButton.Hidden = !this.actionButton.Enabled;
 
 			// Using NSImageName.Caution for now, we can change this later at the designers behest
-			actionButton.Image = actionButton.Enabled ? PropertyEditorPanel.ThemeManager.GetImageForTheme ("action-warning-16") : null;
+			this.actionButton.Image = this.actionButton.Enabled ? PropertyEditorPanel.ThemeManager.GetImageForTheme ("action-warning-16") : null;
 		}
 
 		void NotifyActionButtonClicked ()

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -40,11 +40,12 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (YLabel);
 			AddSubview (YEditor);
 
-			this.DoConstraints (new[] {
-				XEditor.ConstraintTo (this, (xe, c) => xe.Width == 90),
-				XEditor.ConstraintTo (this, (xe, c) => xe.Height == DefaultControlHeight),
-				YEditor.ConstraintTo (this, (ye, c) => ye.Width == 90),
-				YEditor.ConstraintTo (this, (ye, c) => ye.Height == DefaultControlHeight),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 			});
 
 			UpdateTheme ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -17,25 +17,23 @@ namespace Xamarin.PropertyEditing.Mac
 		public override NSView FirstKeyView => XEditor;
 		public override NSView LastKeyView => YEditor.DecrementButton;
 
-		public BasePointEditorControl ()
+		protected BasePointEditorControl ()
 		{
 			XLabel = new UnfocusableTextField ();
 
-			XEditor = new NumericSpinEditor<T> ();
-			XEditor.BackgroundColor = NSColor.Clear;
-			XEditor.Value = 0.0f;
+			XEditor = new NumericSpinEditor<T> {
+				BackgroundColor = NSColor.Clear,
+				Value = 0.0f
+			};
 			XEditor.ValueChanged += OnInputUpdated;
-
-			XLabel.AccessibilityElement = false;
 
 			YLabel = new UnfocusableTextField ();
 
-			YEditor = new NumericSpinEditor<T> ();
-			YEditor.BackgroundColor = NSColor.Clear;
-			YEditor.Value = 0.0f;
+			YEditor = new NumericSpinEditor<T> {
+				BackgroundColor = NSColor.Clear,
+				Value = 0.0f
+			};
 			YEditor.ValueChanged += OnInputUpdated;
-
-			YLabel.AccessibilityElement = false;
 
 			AddSubview (XLabel);
 			AddSubview (XEditor);
@@ -43,7 +41,6 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (YEditor);
 
 			this.DoConstraints (new[] {
-				XEditor.ConstraintTo (this, (xe, c) => xe.Left == xe.Left - 1),
 				XEditor.ConstraintTo (this, (xe, c) => xe.Width == 90),
 				XEditor.ConstraintTo (this, (xe, c) => xe.Height == DefaultControlHeight),
 				YEditor.ConstraintTo (this, (ye, c) => ye.Width == 90),

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -23,7 +23,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public override NSView FirstKeyView => XEditor;
 		public override NSView LastKeyView => HeightEditor.DecrementButton;
 
-		public BaseRectangleEditorControl ()
+		protected BaseRectangleEditorControl ()
 		{
 			XLabel = new UnfocusableTextField ();
 			XEditor = new NumericSpinEditor<T> ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -58,15 +58,18 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (HeightLabel);
 			AddSubview (HeightEditor);
 
-			this.DoConstraints (new[] {
-				XEditor.ConstraintTo (this, (xe, c) => xe.Width == 90),
-				XEditor.ConstraintTo (this, (xe, c) => xe.Height == DefaultControlHeight),
-				YEditor.ConstraintTo (this, (ye, c) => ye.Width == 90),
-				YEditor.ConstraintTo (this, (ye, c) => ye.Height == DefaultControlHeight),
-				WidthEditor.ConstraintTo (this, (we, c) => we.Width == 90),
-				WidthEditor.ConstraintTo (this, (we, c) => we.Height == DefaultControlHeight),
-				HeightEditor.ConstraintTo (this, (he, c) => he.Width == 90),
-				HeightEditor.ConstraintTo (this, (he, c) => he.Height == DefaultControlHeight),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 			});
 
 			UpdateTheme ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -35,9 +35,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (BooleanEditor);
 
-			this.DoConstraints (new[] {
-				BooleanEditor.ConstraintTo (this, (be, c) => be.Width == c.Width - 50),
-				BooleanEditor.ConstraintTo (this, (be, c) => be.Top == c.Top + 6),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (BooleanEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 6f),
+				NSLayoutConstraint.Create (BooleanEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -50f),
 			});
 
 			UpdateTheme ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -35,7 +35,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (BooleanEditor);
 
-            this.DoConstraints (new[] {
+			this.DoConstraints (new[] {
 				BooleanEditor.ConstraintTo (this, (be, c) => be.Width == c.Width - 50),
 				BooleanEditor.ConstraintTo (this, (be, c) => be.Top == c.Top + 6),
 			});

--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -61,7 +61,6 @@ namespace Xamarin.PropertyEditing.Mac
 				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Width == c.Width - 33),
 				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Height == DefaultControlHeight),
 				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Top == c.Top + 0),
-				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Left == c.Left - 1),
 			});
 
 			AddSubview (this.popUpButton);

--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -57,13 +57,13 @@ namespace Xamarin.PropertyEditing.Mac
 			this.popupButtonList = new NSMenu ();
 			this.popUpButton.Menu = this.popupButtonList;
 
-			this.DoConstraints (new [] {
-				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Width == c.Width - 33),
-				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Height == DefaultControlHeight),
-				this.popUpButton.ConstraintTo (this, (pub, c) => pub.Top == c.Top + 0),
-			});
-
 			AddSubview (this.popUpButton);
+
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -33f),
+				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight + 1),
+			});
 
 			UpdateTheme ();
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/ConstraintExtensions.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ConstraintExtensions.cs
@@ -45,10 +45,12 @@ namespace Xamarin.PropertyEditing.Mac
 
 			if (mainExpression.Right.NodeType == ExpressionType.Constant) {
 				var c = Convert.ToSingle (((ConstantExpression)mainExpression.Right).Value);
+				// Console.WriteLine ("NSLayoutConstraint.Create ({0}, NSLayoutAttribute.{1}, NSLayoutRelation.{2}, {3},  NSLayoutAttribute.{4}, {5}f, {6}f),", view1, propLeft, relation, null, propRight, 1, c);
 				return NSLayoutConstraint.Create (view1, propLeft, relation, null, NSLayoutAttribute.NoAttribute, 1, c);
 			}
 			else if (mainExpression.Right is MemberExpression) {
 				propRight = (NSLayoutAttribute)Enum.Parse (typeof (NSLayoutAttribute), ((MemberExpression)mainExpression.Right).Member.Name);
+				// Console.WriteLine ("NSLayoutConstraint.Create ({0}, NSLayoutAttribute.{1}, NSLayoutRelation.{2}, {3},  NSLayoutAttribute.{4}, {5}f, {6}f),", view1, propLeft, relation, view2, propRight, 1, 0);
 				return NSLayoutConstraint.Create (view1, propLeft, relation, view2, propRight, 1, 0);
 			}
 
@@ -84,8 +86,8 @@ namespace Xamarin.PropertyEditing.Mac
 				var member = (MemberExpression)(addNode.Right is MemberExpression ? addNode.Right : addNode.Left);
 				propRight = (NSLayoutAttribute)Enum.Parse (typeof (NSLayoutAttribute), member.Member.Name);
 			}
-
-			// Console.WriteLine ("NSLayoutConstraint.Create ({0}, {1}, {2}, {3}, {4}, {5}, {6});", view1, propLeft, relation, view2, propRight, multiplier, constant);
+		
+			// Console.WriteLine ("NSLayoutConstraint.Create ({0}, NSLayoutAttribute.{1}, NSLayoutRelation.{2}, {3},  NSLayoutAttribute.{4}, {5}f, {6}f),", view1, propLeft, relation, view2, propRight, multiplier, constant);
 
 			return NSLayoutConstraint.Create (view1, propLeft, relation, view2, propRight, multiplier, constant);
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/ConstraintExtensions.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ConstraintExtensions.cs
@@ -85,7 +85,7 @@ namespace Xamarin.PropertyEditing.Mac
 				propRight = (NSLayoutAttribute)Enum.Parse (typeof (NSLayoutAttribute), member.Member.Name);
 			}
 
-			//Console.WriteLine ("v1.{0} {1} v2.{2} * {3} + {4}", propLeft, relation, propRight, multiplier, constant);
+			// Console.WriteLine ("NSLayoutConstraint.Create ({0}, {1}, {2}, {3}, {4}, {5}, {6});", view1, propLeft, relation, view2, propRight, multiplier, constant);
 
 			return NSLayoutConstraint.Create (view1, propLeft, relation, view2, propRight, multiplier, constant);
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/BasePopOverControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/BasePopOverControl.cs
@@ -26,10 +26,10 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (iconView);
 
-			var viewTitle = new UnfocusableTextField () {
+			var viewTitle = new UnfocusableTextField {
+				Font = NSFont.BoldSystemFontOfSize (11),
 				StringValue = title,
 				TranslatesAutoresizingMaskIntoConstraints = false,
-				Font = NSFont.BoldSystemFontOfSize (11)
 			};
 
 			AddSubview (viewTitle);
@@ -40,7 +40,7 @@ namespace Xamarin.PropertyEditing.Mac
 				iconView.ConstraintTo (this, (iv, c) => iv.Width == DefaultIconButtonSize),
 				iconView.ConstraintTo (this, (iv, c) => iv.Height == DefaultIconButtonSize),
 
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Top == c.Top + 10),
+				viewTitle.ConstraintTo (this, (vt, c) => vt.Top == c.Top + 8),
 				viewTitle.ConstraintTo (this, (vt, c) => vt.Left == c.Left + 38),
 				viewTitle.ConstraintTo (this, (vt, c) => vt.Width == 120),
 				viewTitle.ConstraintTo (this, (vt, c) => vt.Height == 24),

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/BasePopOverControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/BasePopOverControl.cs
@@ -34,16 +34,17 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (viewTitle);
 
-			this.DoConstraints (new[] {
-				iconView.ConstraintTo (this, (iv, c) => iv.Top == c.Top + 5),
-				iconView.ConstraintTo (this, (iv, c) => iv.Left == c.Left + 5),
-				iconView.ConstraintTo (this, (iv, c) => iv.Width == DefaultIconButtonSize),
-				iconView.ConstraintTo (this, (iv, c) => iv.Height == DefaultIconButtonSize),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 5f),
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 5f),
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, DefaultIconButtonSize),
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultIconButtonSize),
 
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Top == c.Top + 8),
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Left == c.Left + 38),
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Width == 120),
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Height == 24),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 7f),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Left, NSLayoutRelation.Equal, iconView,  NSLayoutAttribute.Right, 1f, 5f),
+				//NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 38f),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 120),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 			});
 
 			Appearance = PropertyEditorPanel.ThemeManager.CurrentAppearance;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/ColorComponentEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/ColorComponentEditor.cs
@@ -49,7 +49,6 @@ namespace Xamarin.PropertyEditing.Mac
 				Label = new UnfocusableTextField {
 					StringValue = $"{editor.Name}:",
 					Alignment = NSTextAlignment.Right,
-					BackgroundColor = NSColor.Clear,
 					ToolTip = editor.ToolTip
 				},
 				Editor = new ComponentSpinEditor (editor) {
@@ -116,14 +115,12 @@ namespace Xamarin.PropertyEditing.Mac
 			this.hexLabel = new UnfocusableTextField {
 				StringValue = "#:",
 				Alignment = NSTextAlignment.Right,
-				BackgroundColor = NSColor.Clear,
 				ToolTip = Properties.Resources.HexValue
 			};
 			AddSubview (this.hexLabel);
 
 			this.hexEditor = new NSTextField {
 				Alignment = NSTextAlignment.Right,
-				BackgroundColor = NSColor.Clear
 			};
 			AddSubview (this.hexEditor);
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialBrushEditorViewController.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialBrushEditorViewController.cs
@@ -66,19 +66,12 @@ namespace Xamarin.PropertyEditing.Mac
 				Orientation = NSUserInterfaceLayoutOrientation.Horizontal
 			};
 
-			var alphaLabel = new NSTextField {
-				Bordered = false,
-				Editable = false,
-				Selectable = false,
-				ControlSize = NSControlSize.Small,
-				Font = NSFont.FromFontName (PropertyEditorControl.DefaultFontName, PropertyEditorControl.DefaultPropertyLabelFontSize),
-				AccessibilityElement = false,
+			var alphaLabel = new UnfocusableTextField {
 				StringValue = $"{Properties.Resources.Alpha}:",
 				Alignment = NSTextAlignment.Left,
-				BackgroundColor = NSColor.Clear,
 			};
-			alphaLabel.Cell.UsesSingleLineMode = true;
 			alphaLabel.Cell.LineBreakMode = NSLineBreakMode.Clipping;
+
 			alphaStack.AddView (alphaLabel, NSStackViewGravity.Trailing);
 			alphaStack.AddView (alphaSpinEditor, NSStackViewGravity.Trailing);
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
@@ -215,19 +215,19 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (incrementButton);
 			AddSubview (decrementButton);
 
-			this.DoConstraints (new[] {
-				numericEditor.ConstraintTo (this, (n, c) => n.Width == c.Width - (stepperWidth + stepperSpace + 1)),
-				numericEditor.ConstraintTo (this, (n, c) => n.Height == PropertyEditorControl.DefaultControlHeight - 3),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.numericEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -(stepperWidth + stepperSpace + 1)),
+				NSLayoutConstraint.Create (this.numericEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight - 3),
 
-				incrementButton.ConstraintTo (numericEditor, (s, n) => s.Left == n.Right + stepperSpace),
-				incrementButton.ConstraintTo (numericEditor, (s, n) => s.Top == n.Top),
-				incrementButton.ConstraintTo (numericEditor, (s, n) => s.Width == stepperWidth),
-				incrementButton.ConstraintTo (numericEditor, (s, n) => s.Height == stepperTopHeight),
+				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Right, 1f, stepperSpace),
+				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, stepperWidth),
+				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, stepperTopHeight),
 
-				decrementButton.ConstraintTo (numericEditor, (s, n) => s.Left == n.Right + stepperSpace),
-				decrementButton.ConstraintTo (numericEditor, (s, n) => s.Top == n.Top + stepperTopHeight),
-				decrementButton.ConstraintTo (numericEditor, (s, n) => s.Width == stepperWidth),
-				decrementButton.ConstraintTo (numericEditor, (s, n) => s.Height == stepperBotHeight),
+				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Top, 1f, stepperTopHeight),
+				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Right, 1f, stepperSpace),
+				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, stepperWidth),
+				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, stepperBotHeight),
 			});
 
 			PropertyEditorPanel.ThemeManager.ThemeChanged += ThemeManager_ThemeChanged;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/ResourceOutlineViewDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/ResourceOutlineViewDelegate.cs
@@ -37,7 +37,6 @@ namespace Xamarin.PropertyEditing.Mac
 					var utf = (UnfocusableTextField)outlineView.MakeView (labelIdentifier, this);
 					if (utf == null) {
 						utf = new UnfocusableTextField {
-							BackgroundColor = NSColor.Clear,
 							Identifier = labelIdentifier,
 						};
 					}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
@@ -33,6 +33,11 @@ namespace Xamarin.PropertyEditing.Mac
 			internal set { this.label.StringValue = value; }
 		}
 
+		public NSColor TextColor {
+			get { return this.label.TextColor; }
+			internal set { this.label.TextColor = value; }
+		}
+
 		public UnfocusableTextField ()
 		{
 			SetDefaultTextProperties ();

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
@@ -1,35 +1,100 @@
 ﻿using System;
-using System.Collections;
-using System.ComponentModel;
 using AppKit;
 using CoreGraphics;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	class UnfocusableTextField : NSTextField
+	internal class UnfocusableTextField : NSView
 	{
-		public UnfocusableTextField () : base ()
+		private NSTextField label;
+
+		public NSTextAlignment Alignment {
+			get { return this.label.Alignment; }
+			internal set { this.label.Alignment = value; }
+		}
+
+		public NSColor BackgroundColor {
+			get { return this.label.BackgroundColor; }
+			internal set { this.label.BackgroundColor = value; }
+		}
+
+		public NSTextFieldCell Cell {
+			get { return this.label.Cell; }
+			internal set { this.label.Cell = value; }
+		}
+
+		public NSFont Font {
+			get { return this.label.Font; }
+			internal set { this.label.Font = value; }
+		}
+
+		public string StringValue {
+			get { return this.label.StringValue; }
+			internal set { this.label.StringValue = value; }
+		}
+
+		public UnfocusableTextField ()
 		{
-			SetDefaultProperties ();
+			SetDefaultTextProperties ();
+			SetTheming ();
 		}
 
 		public UnfocusableTextField (CGRect frameRect, string text) : base (frameRect)
 		{
+			SetDefaultTextProperties ();
+			SetTheming ();
+
 			StringValue = text;
-			SetDefaultProperties ();
 		}
 
-		void SetDefaultProperties ()
+		protected override void Dispose (bool disposing)
 		{
-			AccessibilityElement = false;
-			Bordered = false;
-			Cell.LineBreakMode = NSLineBreakMode.TruncatingTail;
-			Cell.UsesSingleLineMode = true;
-			ControlSize = NSControlSize.Small;
-			Editable = false;
-			Font = NSFont.FromFontName (PropertyEditorControl.DefaultFontName, PropertyEditorControl.DefaultPropertyLabelFontSize);
-			Selectable = false;
-			BackgroundColor = NSColor.Clear;
+			if (disposing) {
+				PropertyEditorPanel.ThemeManager.ThemeChanged -= ThemeManager_ThemeChanged;
+			}
+		}
+
+		private void SetDefaultTextProperties ()
+		{
+			this.label = new NSTextField {
+				AccessibilityElement = false,
+				BackgroundColor = NSColor.Clear,
+				Bordered = false,
+				Cell = {
+					LineBreakMode = NSLineBreakMode.TruncatingTail,
+					UsesSingleLineMode = true,
+				},
+				ControlSize = NSControlSize.Small,
+				Editable = false,
+				Font = NSFont.FromFontName (PropertyEditorControl.DefaultFontName, PropertyEditorControl.DefaultPropertyLabelFontSize),
+				Selectable = false,
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
+
+			AddSubview (this.label);
+
+			AddConstraints (new[] {
+				NSLayoutConstraint.Create (this, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this.label, NSLayoutAttribute.CenterY, 1f, 0f),
+				NSLayoutConstraint.Create (this, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this.label, NSLayoutAttribute.Leading, 1f, 0f),
+				NSLayoutConstraint.Create (this, NSLayoutAttribute.Trailing, NSLayoutRelation.Equal, this.label, NSLayoutAttribute.Trailing, 1f, 0f)
+			});
+		}
+
+		private void SetTheming ()
+		{
+			PropertyEditorPanel.ThemeManager.ThemeChanged += ThemeManager_ThemeChanged;
+
+			UpdateTheme ();
+		}
+
+		private void ThemeManager_ThemeChanged (object sender, EventArgs e)
+		{
+			UpdateTheme ();
+		}
+
+		protected void UpdateTheme ()
+		{
+			Appearance = PropertyEditorPanel.ThemeManager.CurrentAppearance;
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CustomExpressionView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CustomExpressionView.cs
@@ -23,23 +23,23 @@ namespace Xamarin.PropertyEditing.Mac
 				TranslatesAutoresizingMaskIntoConstraints = false,
 			};
 
-			vmType = viewModel.GetType ();
-			customExpressionPropertyInfo = vmType.GetProperty (CustomExpressionPropertyString);
-			var value = customExpressionPropertyInfo.GetValue (viewModel);
+			this.vmType = viewModel.GetType ();
+			this.customExpressionPropertyInfo = vmType.GetProperty (CustomExpressionPropertyString);
+			var value = this.customExpressionPropertyInfo.GetValue (viewModel);
 			if (value != null)
 				customExpressionField.StringValue = (string)value;
 
 			customExpressionField.Activated += (sender, e) => {
-				customExpressionPropertyInfo.SetValue (viewModel, customExpressionField.StringValue);
+				this.customExpressionPropertyInfo.SetValue (viewModel, customExpressionField.StringValue);
 			};
 
 			AddSubview (customExpressionField);
 
-			this.DoConstraints (new[] {
-				customExpressionField.ConstraintTo (this, (s, c) => s.Top == c.Top + 37),
-				customExpressionField.ConstraintTo (this, (s, c) => s.Left == c.Left + 38),
-				customExpressionField.ConstraintTo (this, (s, c) => s.Width == c.Width - 57),
-				customExpressionField.ConstraintTo (this, (s, c) => s.Height == 24),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (customExpressionField, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 37f),
+				NSLayoutConstraint.Create (customExpressionField, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 38f),
+				NSLayoutConstraint.Create (customExpressionField, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -57f),
+				NSLayoutConstraint.Create (customExpressionField, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 			});
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -11,10 +11,11 @@ namespace Xamarin.PropertyEditing.Mac
 			EditorView = editorView;
 
 			AddSubview (this.label);
+
 			this.AddConstraints (new[] {
-				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 4f),
+				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 0f),
 				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, Mac.Layout.GoldenRatioLeft, 0f),
-				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 0f),
+				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 			});
 
 			if (EditorView != null) {

--- a/Xamarin.PropertyEditing.Mac/Controls/ErrorMessageView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ErrorMessageView.cs
@@ -11,7 +11,7 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		const int DefaultIconButtonSize = 24;
 
-		NSTextField ErrorMessages;
+		private NSTextField errorMessages;
 
 		public ErrorMessageView (IEnumerable errors)
 		{
@@ -33,31 +33,34 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (viewTitle);
 
-			ErrorMessages = new NSTextField {
+			this.errorMessages = new NSTextField {
 				BackgroundColor = NSColor.Clear,
 				Editable = false,
 				TranslatesAutoresizingMaskIntoConstraints = false,
 			};
-			ErrorMessages.Cell.Wraps = true;
+			this.errorMessages.Cell.Wraps = true;
 
 			foreach (var error in errors) {
-				ErrorMessages.StringValue += error + "\n";
+				this.errorMessages.StringValue += error + "\n";
 			}
 
-			AddSubview (ErrorMessages);
+			AddSubview (this.errorMessages);
 
-			this.DoConstraints (new[] {
-				iconView.ConstraintTo (this, (iv, c) => iv.Top == c.Top + 5),
-				iconView.ConstraintTo (this, (iv, c) => iv.Left == c.Left + 5),
-				iconView.ConstraintTo (this, (iv, c) => iv.Width == DefaultIconButtonSize),
-				iconView.ConstraintTo (this, (iv, c) => iv.Height == DefaultIconButtonSize),
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Top == c.Top + 7),
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Width == 120),
-				viewTitle.ConstraintTo (this, (vt, c) => vt.Height == 24),
-				ErrorMessages.ConstraintTo (this, (s, c) => s.Top == c.Top + 35),
-				ErrorMessages.ConstraintTo (this, (s, c) => s.Left == c.Left + 5),
-				ErrorMessages.ConstraintTo (this, (s, c) => s.Width == c.Width - 10),
-				ErrorMessages.ConstraintTo (this, (s, c) => s.Height == c.Height - 40),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 5f),
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 5f),
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, DefaultIconButtonSize),
+				NSLayoutConstraint.Create (iconView, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultIconButtonSize),
+
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 7f),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Left, NSLayoutRelation.Equal, iconView,  NSLayoutAttribute.Right, 1f, 5f),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 120),
+				NSLayoutConstraint.Create (viewTitle, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
+
+				NSLayoutConstraint.Create (this.errorMessages, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 35f),
+				NSLayoutConstraint.Create (this.errorMessages, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 5f),
+				NSLayoutConstraint.Create (this.errorMessages, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -10f),
+				NSLayoutConstraint.Create (this.errorMessages, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Height, 1f, -40f),
 			});
 
 			this.Appearance = PropertyEditorPanel.ThemeManager.CurrentAppearance;

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -38,9 +38,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 			AddSubview (NumericEditor);
 
-			this.DoConstraints ( new[] {
-				NumericEditor.ConstraintTo (this, (n, c) => n.Top == c.Top + 1),
-				NumericEditor.ConstraintTo (this, (n, c) => n.Width == c.Width - 32),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (NumericEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 1f),
+				NSLayoutConstraint.Create (NumericEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -32f),
 			});
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -41,7 +41,6 @@ namespace Xamarin.PropertyEditing.Mac
 			this.DoConstraints ( new[] {
 				NumericEditor.ConstraintTo (this, (n, c) => n.Top == c.Top + 1),
 				NumericEditor.ConstraintTo (this, (n, c) => n.Width == c.Width - 32),
-				NumericEditor.ConstraintTo (this, (n, c) => n.Left == c.Left - 1),
 			});
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
@@ -53,14 +53,14 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.propertyIcon);
 
 			this.AddConstraints (new[] {
-
 				NSLayoutConstraint.Create (this.propertyIcon, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1, 32),
 				NSLayoutConstraint.Create (this.propertyIcon, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1, 32),
 				NSLayoutConstraint.Create (this.propertyIcon, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 5),
 				NSLayoutConstraint.Create (this.propertyIcon, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1, 32),
 
-				NSLayoutConstraint.Create (this.objectNameLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 5),
+				NSLayoutConstraint.Create (this.objectNameLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 0),
 				NSLayoutConstraint.Create (this.objectNameLabel, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, Mac.Layout.GoldenRatioLeft, 0f),
+				NSLayoutConstraint.Create (this.objectNameLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 
 				NSLayoutConstraint.Create (this.propertyObjectName, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this.objectNameLabel, NSLayoutAttribute.CenterY, 1, 0),
 				NSLayoutConstraint.Create (this.propertyObjectName, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.objectNameLabel, NSLayoutAttribute.Right, 1, 4.5f),
@@ -68,10 +68,12 @@ namespace Xamarin.PropertyEditing.Mac
 
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.propertyObjectName, NSLayoutAttribute.Bottom, 1, 5),
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, Mac.Layout.GoldenRatioLeft, 0f),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 
 				NSLayoutConstraint.Create (this.typeDisplay, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Top, 1, 0),
 				NSLayoutConstraint.Create (this.typeDisplay, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this.propertyObjectName, NSLayoutAttribute.Width, 1, 0),
-				NSLayoutConstraint.Create (this.typeDisplay, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Right, 1, 4)
+				NSLayoutConstraint.Create (this.typeDisplay, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Right, 1, 4),
+				NSLayoutConstraint.Create (this.typeDisplay, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 			});
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
@@ -12,13 +12,13 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public PointEditorControl ()
 		{
-			XLabel.Frame = new CGRect (34, -10, 25, 22);
+			XLabel.Frame = new CGRect (34, -5, 25, 22);
 			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			XLabel.StringValue = "X"; // TODO Localise
 
 			XEditor.Frame = new CGRect (0, 13, 90, 20);
 
-			YLabel.Frame = new CGRect (166, -10, 25, 22);
+			YLabel.Frame = new CGRect (166, -5, 25, 22);
 			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			YLabel.StringValue = "Y"; // TODO Localise
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -95,10 +95,9 @@ namespace Xamarin.PropertyEditing.Mac
 					AddSubview (this.popUpButton);
 
 					this.DoConstraints (new[] {
-						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Width == c.Width - 34),
+						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Width == c.Width - 33),
 						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Height == DefaultControlHeight + 1),
 						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Top == pub.Top + 0),
-						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Left == pub.Left + 1),
 					});
 
 					this.firstKeyView = this.popUpButton;
@@ -117,7 +116,7 @@ namespace Xamarin.PropertyEditing.Mac
 						this.comboBox.ConstraintTo (this, (cb, c) => cb.Width == c.Width - 34),
 						this.comboBox.ConstraintTo (this, (cb, c) => cb.Height == DefaultControlHeight),
 						this.comboBox.ConstraintTo (this, (cb, c) => cb.Top == cb.Top + 0),
-						this.comboBox.ConstraintTo (this, (cb, c) => cb.Left == cb.Left - 1),
+						this.comboBox.ConstraintTo (this, (cb, c) => cb.Left == cb.Left + 0),
 					});
 
 					this.firstKeyView = this.comboBox;

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -88,16 +88,16 @@ namespace Xamarin.PropertyEditing.Mac
 			if (!this.dataPopulated) {
 				if (ViewModel.IsConstrainedToPredefined) {
 					this.popupButtonList.RemoveAllItems ();
-					foreach (string item in ViewModel.PossibleValues) {
+					foreach (var item in ViewModel.PossibleValues) {
 						this.popupButtonList.AddItem (new NSMenuItem (item));
 					}
 
 					AddSubview (this.popUpButton);
 
-					this.DoConstraints (new[] {
-						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Width == c.Width - 33),
-						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Height == DefaultControlHeight + 1),
-						this.popUpButton.ConstraintTo (this, (pub, c) => pub.Top == pub.Top + 0),
+					this.AddConstraints (new[] {
+						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
+						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -33f),
+						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight + 1),
 					});
 
 					this.firstKeyView = this.popUpButton;
@@ -112,11 +112,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 					AddSubview (this.comboBox);
 
-					this.DoConstraints (new[] {
-						this.comboBox.ConstraintTo (this, (cb, c) => cb.Width == c.Width - 34),
-						this.comboBox.ConstraintTo (this, (cb, c) => cb.Height == DefaultControlHeight),
-						this.comboBox.ConstraintTo (this, (cb, c) => cb.Top == cb.Top + 0),
-						this.comboBox.ConstraintTo (this, (cb, c) => cb.Left == cb.Left + 0),
+					this.AddConstraints (new[] {
+						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 0f),
+						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 0f),
+						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -34f),
+						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 					});
 
 					this.firstKeyView = this.comboBox;
@@ -144,8 +144,8 @@ namespace Xamarin.PropertyEditing.Mac
 				this.popUpButton.AccessibilityEnabled = this.popUpButton.Enabled;
 				this.popUpButton.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityCombobox, ViewModel.Property.Name);
 			} else {
-				comboBox.AccessibilityEnabled = comboBox.Enabled;
-				comboBox.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityCombobox, ViewModel.Property.Name);
+				this.comboBox.AccessibilityEnabled = this.comboBox.Enabled;
+				this.comboBox.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityCombobox, ViewModel.Property.Name);
 			}
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -33,7 +33,6 @@ namespace Xamarin.PropertyEditing.Mac
 
 			this.DoConstraints (new[] {
 				this.ratioEditor.ConstraintTo (this, (re, c) => re.Top == c.Top - 2),
-				this.ratioEditor.ConstraintTo (this, (re, c) => re.Left == c.Left - 1),
 				this.ratioEditor.ConstraintTo (this, (re, c) => re.Width == c.Width - 32),
 				this.ratioEditor.ConstraintTo (this, (re, c) => re.Height == DefaultControlHeight),
 			});

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -31,10 +31,10 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 			AddSubview (this.ratioEditor);
 
-			this.DoConstraints (new[] {
-				this.ratioEditor.ConstraintTo (this, (re, c) => re.Top == c.Top - 2),
-				this.ratioEditor.ConstraintTo (this, (re, c) => re.Width == c.Width - 32),
-				this.ratioEditor.ConstraintTo (this, (re, c) => re.Height == DefaultControlHeight),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.ratioEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, -2f),
+				NSLayoutConstraint.Create (this.ratioEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -32f),
+				NSLayoutConstraint.Create (this.ratioEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 			});
 
 			UpdateTheme ();

--- a/Xamarin.PropertyEditing.Mac/Controls/RectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RectangleEditorControl.cs
@@ -9,28 +9,28 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal abstract class RectangleEditorControl<T>: BaseRectangleEditorControl<T>
 	{
-		public RectangleEditorControl ()
+		protected RectangleEditorControl ()
 		{
 			// TODO localize
-			XLabel.Frame = new CGRect (34, 23, 25, 22);
+			XLabel.Frame = new CGRect (34, 28, 25, 22);
 			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			XLabel.StringValue = "X";
 
-			XEditor.Frame = new CGRect (-1, 46, 90, 20);
+			XEditor.Frame = new CGRect (0, 46, 90, 20);
 
-			YLabel.Frame = new CGRect (166, 23, 25, 22);
+			YLabel.Frame = new CGRect (166, 28, 25, 22);
 			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			YLabel.StringValue = "Y";
 
 			YEditor.Frame = new CGRect (132, 46, 90, 20);
 
-			WidthLabel.Frame = new CGRect (20, -10, 50, 22);
+			WidthLabel.Frame = new CGRect (20, -5, 50, 22);
 			WidthLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			WidthLabel.StringValue = "WIDTH";
 
-			WidthEditor.Frame = new CGRect (-1, 13, 90, 20);
+			WidthEditor.Frame = new CGRect (0, 13, 90, 20);
 
-			HeightLabel.Frame = new CGRect (150, -10, 50, 22);
+			HeightLabel.Frame = new CGRect (150, -5, 50, 22);
 			HeightLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			HeightLabel.StringValue = "HEIGHT";
 

--- a/Xamarin.PropertyEditing.Mac/Controls/RequestResource/RequestResourcePanel.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RequestResource/RequestResourcePanel.cs
@@ -118,9 +118,9 @@ namespace Xamarin.PropertyEditing.Mac
 			this.previewPanel = new RequestResourcePreviewPanel (new CGRect (Frame.Width - FrameWidthThird, 0, FrameWidthThird, Frame.Height));
 			AddSubview (this.previewPanel);
 
-			this.DoConstraints (new NSLayoutConstraint[] {
-				this.tableContainer.ConstraintTo (this, (t, c) => t.Width == c.Width - 190),
-				this.tableContainer.ConstraintTo (this, (t, c) => t.Height == c.Height),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.tableContainer, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -190f),
+				NSLayoutConstraint.Create (this.tableContainer, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Height, 1f, 0f),
 			});
 
 			ReloadData ();

--- a/Xamarin.PropertyEditing.Mac/Controls/RequestResource/RequestResourcePreviewPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RequestResource/RequestResourcePreviewPanel.cs
@@ -8,33 +8,28 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal class RequestResourcePreviewPanel : NSView
 	{
-		private NSTextField noPreviewAvailable;
+		private UnfocusableTextField noPreviewAvailable;
 		private NSView previewView;
 
 		private Resource selectedResource;
-		public Resource SelectedResource
-		{
-			internal get
-			{
-				return selectedResource;
-			}
+		public Resource SelectedResource {
+			internal get { return this.selectedResource; }
 
-			set
-			{
-				if (selectedResource != value) {
-					selectedResource = value;
+			set {
+				if (this.selectedResource != value) {
+					this.selectedResource = value;
 
-					if (selectedResource != null) {
+					if (this.selectedResource != null) {
 						// Let's find the next View
-						var pView = GetPreviewView (selectedResource);
+						var pView = GetPreviewView (this.selectedResource);
 
 						if (pView == null) {
 							ShowNoPreviewText ();
 						} else {
-							noPreviewAvailable.Hidden = true;
-							previewView.Hidden = false;
+							this.noPreviewAvailable.Hidden = true;
+							this.previewView.Hidden = false;
 
-							switch (selectedResource) {
+							switch (this.selectedResource) {
 								case Resource<CommonColor> colour:
 									if (pView is CommonBrushView cc) {
 										cc.Brush = new CommonSolidBrush (colour.Value);
@@ -55,11 +50,11 @@ namespace Xamarin.PropertyEditing.Mac
 							}
 
 							// Only 1 subview allowed (must be a better way to handle this??)
-							if (previewView.Subviews.Count () > 0) {
-								previewView.Subviews[0].RemoveFromSuperview ();
+							if (this.previewView.Subviews.Count () > 0) {
+								this.previewView.Subviews[0].RemoveFromSuperview ();
 							}
 							// Free up anything from the previous view
-							previewView.AddSubview (pView);
+							this.previewView.AddSubview (pView);
 						}
 					} else {
 						ShowNoPreviewText ();
@@ -70,8 +65,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private void ShowNoPreviewText ()
 		{
-			noPreviewAvailable.Hidden = false;
-			previewView.Hidden = true;
+			this.noPreviewAvailable.Hidden = false;
+			this.previewView.Hidden = true;
 		}
 
 		public RequestResourcePreviewPanel (CGRect frame) : base (frame)
@@ -80,17 +75,17 @@ namespace Xamarin.PropertyEditing.Mac
 			var FrameWidthHalf = (Frame.Width - 32) / 2;
 			var FrameWidthThird = (Frame.Width - 32) / 3;
 
-			noPreviewAvailable = new UnfocusableTextField {
-				BackgroundColor = NSColor.Clear,
+			this.noPreviewAvailable = new UnfocusableTextField {
 				StringValue = Properties.Resources.NoPreviewAvailable,
 				Frame = new CGRect (50, FrameHeightHalf, 150, 50),
 			};
 
-			AddSubview (noPreviewAvailable);
+			AddSubview (this.noPreviewAvailable);
 
-			previewView = new NSView (new CGRect (20, 0, frame.Width - 30, frame.Height));
-			previewView.Hidden = true; // Hidden until a resource is selected and a preview is available for it.
-			AddSubview (previewView);
+			this.previewView = new NSView (new CGRect (20, 0, frame.Width - 30, frame.Height)) {
+				Hidden = true // Hidden until a resource is selected and a preview is available for it.
+			};
+			AddSubview (this.previewView);
 		}
 
 		NSView GetPreviewView (Resource resource)
@@ -120,7 +115,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			var view = (NSView)Activator.CreateInstance (previewRenderType);
 			view.Identifier = previewRenderType.Name;
-			view.Frame = new CGRect (0, 0, previewView.Frame.Width, previewView.Frame.Height);
+			view.Frame = new CGRect (0, 0, this.previewView.Frame.Width, this.previewView.Frame.Height);
 
 			return view;
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/RequestResource/ResourceTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RequestResource/ResourceTableDelegate.cs
@@ -54,7 +54,6 @@ namespace Xamarin.PropertyEditing.Mac
 					if (typeView == null) {
 						typeView = new UnfocusableTextField {
 							Identifier = typeIdentifier,
-							BackgroundColor = NSColor.Clear,
 						};
 					}
 
@@ -65,7 +64,6 @@ namespace Xamarin.PropertyEditing.Mac
 					var nameView = (UnfocusableTextField)tableView.MakeView (nameIdentifier, this);
 					if (nameView == null) {
 						nameView = new UnfocusableTextField {
-							BackgroundColor = NSColor.Clear,
 							Identifier = nameIdentifier,
 						};
 					}

--- a/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
@@ -13,13 +13,13 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public SizeEditorControl ()
 		{
-			XLabel.Frame = new CGRect (20, -10, 50, 22);
+			XLabel.Frame = new CGRect (20, -5, 50, 22);
 			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			XLabel.StringValue = "WIDTH"; // TODO Localise
 
 			XEditor.Frame = new CGRect (0, 13, 90, 20);
 
-			YLabel.Frame = new CGRect (150, -10, 50, 22);
+			YLabel.Frame = new CGRect (150, -5, 50, 22);
 			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			YLabel.StringValue = "HEIGHT"; // TODO Localise
 

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -30,7 +30,6 @@ namespace Xamarin.PropertyEditing.Mac
 				StringEditor.ConstraintTo (this, (s, c) => s.Width == c.Width - 34),
 				StringEditor.ConstraintTo (this, (s, c) => s.Height == DefaultControlHeight - 3),
 				StringEditor.ConstraintTo (this, (s, c) => s.Top == s.Top + 1),
-				StringEditor.ConstraintTo (this, (s, c) => s.Left == s.Left - 1),
 			});
 
 			UpdateTheme ();

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -26,10 +26,10 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 			AddSubview (StringEditor);
 
-			this.DoConstraints (new[] {
-				StringEditor.ConstraintTo (this, (s, c) => s.Width == c.Width - 34),
-				StringEditor.ConstraintTo (this, (s, c) => s.Height == DefaultControlHeight - 3),
-				StringEditor.ConstraintTo (this, (s, c) => s.Top == s.Top + 1),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (StringEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 1f),
+				NSLayoutConstraint.Create (StringEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -34f),
+				NSLayoutConstraint.Create (StringEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight - 3),
 			});
 
 			UpdateTheme ();

--- a/Xamarin.PropertyEditing.Mac/Controls/ThicknessEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ThicknessEditorControl.cs
@@ -11,25 +11,25 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public CommonThicknessEditorControl ()
 		{
-			XLabel.Frame = new CGRect (28, 23, 50, 22);
+			XLabel.Frame = new CGRect (28, 28, 50, 22);
 			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			XLabel.StringValue = "LEFT";
 
-			XEditor.Frame = new CGRect (-1, 46, 90, 20);
+			XEditor.Frame = new CGRect (0, 46, 90, 20);
 
-			YLabel.Frame = new CGRect (160, 23, 45, 22);
+			YLabel.Frame = new CGRect (160, 28, 45, 22);
 			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			YLabel.StringValue = "TOP";
 
 			YEditor.Frame = new CGRect (132, 46, 90, 20);
 
-			WidthLabel.Frame = new CGRect (24, -10, 50, 22);
+			WidthLabel.Frame = new CGRect (24, -5, 50, 22);
 			WidthLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			WidthLabel.StringValue = "RIGHT";
 
-			WidthEditor.Frame = new CGRect (-1, 13, 90, 20);
+			WidthEditor.Frame = new CGRect (0, 13, 90, 20);
 
-			HeightLabel.Frame = new CGRect (150, -10, 50, 22);
+			HeightLabel.Frame = new CGRect (150, -5, 50, 22);
 			HeightLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			HeightLabel.StringValue = "BOTTOM";
 

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -172,22 +172,22 @@ namespace Xamarin.PropertyEditing.Mac
 			tableContainer.DocumentView = this.propertyTable;
 			AddSubview (tableContainer);
 
-			this.DoConstraints (new NSLayoutConstraint[] {
-				this.propertyArrangeModeLabel.ConstraintTo(this, (pl, c) => pl.Top == c.Top + 5),
-				this.propertyArrangeModeLabel.ConstraintTo(this, (pl, c) => pl.Left == c.Left + 10),
+			this.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.propertyArrangeModeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 5f),
+				NSLayoutConstraint.Create (this.propertyArrangeModeLabel, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 10f),
 
-				this.propertyArrangeMode.ConstraintTo(this, (pa, c) => pa.Top == c.Top + 4),
-				this.propertyArrangeMode.ConstraintTo(this, (pa, c) => pa.Left == c.Left + 90),
-				this.propertyArrangeMode.ConstraintTo(this, (pa, c) => pa.Width == 130),
+				NSLayoutConstraint.Create (this.propertyArrangeMode, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 4f),
+				NSLayoutConstraint.Create (this.propertyArrangeMode, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 90f),
+				NSLayoutConstraint.Create (this.propertyArrangeMode, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 130f),
 
-				this.propertyFilter.ConstraintTo(this, (pf, c) => pf.Top == c.Top + 3),
-				this.propertyFilter.ConstraintTo(this, (pf, c) => pf.Left == c.Left + 255),
-				this.propertyFilter.ConstraintTo(this, (pa, c) => pa.Width == c.Width - 265),
+				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 3f),
+				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 255f),
+				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -265f),
 
-				tableContainer.ConstraintTo(this, (t, c) => t.Top == c.Top + 30),
-				tableContainer.ConstraintTo(this, (t, c) => t.Left == c.Left + 10),
-				tableContainer.ConstraintTo(this, (t, c) => t.Width == c.Width - 20),
-				tableContainer.ConstraintTo(this, (t, c) => t.Height == c.Height - 37),
+				NSLayoutConstraint.Create (tableContainer, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 30f),
+				NSLayoutConstraint.Create (tableContainer, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 10f),
+				NSLayoutConstraint.Create (tableContainer, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -20f),
+				NSLayoutConstraint.Create (tableContainer, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1f, -37f),
 			});
 
 			ThemeManager.ThemeChanged += ThemeManager_ThemeChanged;

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -46,22 +46,14 @@ namespace Xamarin.PropertyEditing.Mac
 			GetVMGroupCellItendifiterFromFacade (item, out evm, out group, out cellIdentifier);
 
 			if (group != null) {
-				var labelContainer = outlineView.MakeView (LabelIdentifier, this);
+				var labelContainer = (UnfocusableTextField)outlineView.MakeView (LabelIdentifier, this);
 				if (labelContainer == null) {
-					labelContainer = new NSView { Identifier = LabelIdentifier };
-					var label = new UnfocusableTextField {
-						TranslatesAutoresizingMaskIntoConstraints = false
+					labelContainer = new UnfocusableTextField {
+						Identifier = LabelIdentifier,
 					};
-
-					labelContainer.AddSubview (label);
-					labelContainer.AddConstraints (new[] {
-						NSLayoutConstraint.Create (labelContainer, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, label, NSLayoutAttribute.CenterY, 1f, 0f),
-						NSLayoutConstraint.Create (labelContainer, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, label, NSLayoutAttribute.Leading, 1f, 0f),
-						NSLayoutConstraint.Create (labelContainer, NSLayoutAttribute.Trailing, NSLayoutRelation.Equal, label, NSLayoutAttribute.Trailing, 1f, 0f)
-					});
 				}
 
-				((UnfocusableTextField)labelContainer.Subviews[0]).StringValue = group.Key;
+				labelContainer.StringValue = group.Key;
 
 				if (this.dataSource.DataContext.GetIsExpanded (group.Key)) {
 					SynchronizationContext.Current.Post (s => {


### PR DESCRIPTION
Fixes #463 

Brushes:
<img width="675" alt="screen shot 2018-11-28 at 21 20 19" src="https://user-images.githubusercontent.com/271363/49183008-af14a100-f353-11e8-8724-9090f7f19047.png">

Resources:
<img width="764" alt="screen shot 2018-11-28 at 21 20 48" src="https://user-images.githubusercontent.com/271363/49183014-b2a82800-f353-11e8-9c3c-b8332d46ca4d.png">
