### PR TITLE
Workbooks: Prevent NRE on CALayer.ContentsFormat

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -87,6 +87,9 @@ namespace Xamarin.PropertyEditing.Mac
 					if (editor == null) {
 						editor = GetEditor (vm, outlineView);
 					}
+					// HACK: Prevent crash if editor is null
+					if (editor == null)
+						return null;
 
 					// we must reset these every time, as the view may have been reused
 					editor.ViewModel = vm;
@@ -165,6 +168,9 @@ namespace Xamarin.PropertyEditing.Mac
 			if (editor == null) {
 				editor = GetEditor (vm, outlineView);
 			}
+			// HACK: Prevent crash if editor is null
+			if (editor == null)
+				return 30;
 			return editor.RowHeight;
 		}
 

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -413,10 +413,14 @@ namespace Xamarin.PropertyEditing.ViewModels
 			if (hasPredefinedValues != null) {
 				Type type = typeof(PredefinedValuesViewModel<>).MakeGenericType (hasPredefinedValues.GenericTypeArguments[0]);
 				return (PropertyViewModel) Activator.CreateInstance (type, property, this.objEditors);
-			} else if (property.Type.IsEnum) {
+			} /*else if (property.Type.IsEnum) {
 				Type type = typeof(EnumPropertyViewModel<>).MakeGenericType (property.Type);
 				return (PropertyViewModel) Activator.CreateInstance (type, property, this.objEditors);
-			}
+			}*/
+			// HACK: In Workbooks, only CALayer.ContentsFormat seems to trigger above enum code, and when it does no
+			//       editor is created (seems to be related to there being no enum view model in the ViewModelMap).
+			//       Lack of editor was causing crashes due to NRE. Disable this so at least a StringPropertyViewModel
+			//       is created, which does get an editor.
 
 			Func<IPropertyInfo, IEnumerable<IObjectEditor>, PropertyViewModel> vmFactory;
 			if (ViewModelMap.TryGetValue (property.Type, out vmFactory))


### PR DESCRIPTION
It seems that in this branch, using `EnumPropertyViewModel` causes no
editor to be created. `PropertyTableDelegate` does not check for null
editors, resulting in NREs. Add checks, just in case.

In my testing, only `CALayer.ContentsFormat` ends up using
`EnumPropertyViewModel`. For now, comment-out the section in
`PropertiesViewModel.GetViewModel` that creates `EnumPropertyViewModel`,
so that at least a `StringPropertyViewModel` is created.