### PR TITLE
[Core] Use a Task result for type request

### DIFF
--- a/Xamarin.PropertyEditing.Tests/CollectionPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/CollectionPropertyViewModelTests.cs
@@ -45,7 +45,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 			var buttonType = GetTypeInfo (typeof(MockWpfButton));
 			vm.TypeRequested += (o, e) => {
-				e.SelectedType = buttonType;
+				e.SelectedType = Task.FromResult (buttonType);
 			};
 
 			vm.AssignableTypes.Task.Wait();
@@ -121,7 +121,7 @@ namespace Xamarin.PropertyEditing.Tests
 
 			var buttonType = GetTypeInfo (typeof (MockWpfButton));
 			vm.TypeRequested += (o, e) => {
-				e.SelectedType = buttonType;
+				e.SelectedType = Task.FromResult (buttonType);
 			};
 
 			vm.SelectedType = vm.SuggestedTypes.Last ();

--- a/Xamarin.PropertyEditing.Windows/CollectionEditorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/CollectionEditorWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -39,7 +40,7 @@ namespace Xamarin.PropertyEditing.Windows
 
 		private void OnTypeRequested (object sender, TypeRequestedEventArgs args)
 		{
-			args.SelectedType = TypeSelectorWindow.RequestType (this, ((CollectionPropertyViewModel)DataContext).AssignableTypes);
+			args.SelectedType = Task.FromResult (TypeSelectorWindow.RequestType (this, ((CollectionPropertyViewModel)DataContext).AssignableTypes));
 		}
 
 		private void OnOkClick (object sender, RoutedEventArgs e)

--- a/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/ObjectEditorControl.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using System.Windows;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -35,7 +36,7 @@ namespace Xamarin.PropertyEditing.Windows
 			var panel = this.FindPropertiesHost ();
 
 			ITypeInfo type = TypeSelectorWindow.RequestType (panel, vsender.AssignableTypes);
-			e.SelectedType = type;
+			e.SelectedType = Task.FromResult (type);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/CollectionPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/CollectionPropertyViewModel.cs
@@ -353,15 +353,15 @@ namespace Xamarin.PropertyEditing.ViewModels
 			await PushValueAsync ();
 		}
 
-		private void RequestOtherType (ITypeInfo previousType)
+		private async void RequestOtherType (ITypeInfo previousType)
 		{
 			var args = new TypeRequestedEventArgs();
 			TypeRequested?.Invoke (this, args);
 
-			ITypeInfo st = args.SelectedType;
-			if (args.SelectedType != null) {
-				if (!this.suggestedTypes.Contains (args.SelectedType))
-					this.suggestedTypes.Insert (0, args.SelectedType);
+			ITypeInfo st = await args.SelectedType;
+			if (st != null) {
+				if (!this.suggestedTypes.Contains (st))
+					this.suggestedTypes.Insert (0, st);
 			} else {
 				st = previousType;
 			}

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -16,7 +16,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		/// <summary>
 		/// Gets or sets the type selected by the user from the UI
 		/// </summary>
-		public ITypeInfo SelectedType
+		public Task<ITypeInfo> SelectedType
 		{
 			get;
 			set;
@@ -164,14 +164,14 @@ namespace Xamarin.PropertyEditing.ViewModels
 						if (args.SelectedType == null)
 							return;
 
-						selectedType = args.SelectedType;
+						selectedType = await args.SelectedType;
 					}
 
 					await SetValueAsync (new ValueInfo<object> {
-							Value = await TargetPlatform.EditorProvider.CreateObjectAsync (selectedType),
-							ValueDescriptor = selectedType,
-							Source = ValueSource.Local
-						});
+						Value = await TargetPlatform.EditorProvider.CreateObjectAsync (selectedType),
+						ValueDescriptor = selectedType,
+						Source = ValueSource.Local
+					});
 				}
 			} finally {
 				IsCreateInstancePending = false;


### PR DESCRIPTION
This allows for a request to be answered in the future, preventing the
implementing UI to have to block for a response during the event
request. Primarily used to support Mac as it uses popovers rather than
whole windows.