### PR TITLE
[Win] Respect host-set arrange mode

### DIFF
--- a/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml
+++ b/Xamarin.PropertyEditing.Windows.Standalone/MainWindow.xaml
@@ -30,6 +30,6 @@
 		<local:MockedWpfButton Grid.Row="3" Grid.Column="0" Click="Button_Click">Mocked WPF button</local:MockedWpfButton>
 		<Button Grid.Row="4" Grid.Column="0" Click="Button_Click">Actual WPF button</Button>
 
-		<xamarinprops:PropertyEditorPanel Name="panel" Grid.Row="1" Grid.RowSpan="4" Grid.Column="1" />
+		<xamarinprops:PropertyEditorPanel Name="panel" Grid.Row="1" Grid.RowSpan="4" Grid.Column="1" ArrangeMode="Category" />
 	</Grid>
 </Window>

--- a/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs
@@ -102,7 +102,7 @@ namespace Xamarin.PropertyEditing.Windows
 			this.paneSelector.SelectedItemChanged += OnPaneChanged;
 			OnTargetPlatformChanged();
 
-			if (this.vm.SelectedObjects.Count > 0)
+			if (this.vm.SelectedObjects.Count > 0 || ArrangeMode != PropertyArrangeMode.Name)
 				OnArrangeModeChanged (ArrangeMode);
 		}
 
@@ -215,6 +215,9 @@ namespace Xamarin.PropertyEditing.Windows
 				itemsSource = new Binding ("ArrangedEditors");
 
 			this.items.SetBinding (ItemsControl.ItemsSourceProperty, itemsSource);
+
+			if (this.vm != null)
+				this.vm.ArrangeMode = newMode;
 		}
 	}
 


### PR DESCRIPTION
Allows a host to set `PropertyEditorPanel.ArrangeMode` directly to define the default arrange (#475) mode.