### PR TITLE
[Mac] Exposes ArrangeMode in the public PropertyEditorPanel public API

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -34,6 +34,12 @@ namespace Xamarin.PropertyEditing.Mac
 			Initialize ();
 		}
 
+		public PropertyArrangeMode ArrangeMode
+		{
+			get => this.viewModel.ArrangeMode;
+			set => this.viewModel.ArrangeMode = value;
+		}
+
 		public bool IsArrangeEnabled
 		{
 			get { return this.isArrangeEnabled; }


### PR DESCRIPTION
Exposes ArrangeMode property to the public PropertyEditorPanel API like windows

https://github.com/xamarin/Xamarin.PropertyEditing/blob/025b540af79e3aed097018d5045814432d417dee/Xamarin.PropertyEditing.Windows/PropertyEditorPanel.cs#L75-L79

Fixes: https://github.com/xamarin/Xamarin.PropertyEditing/issues/496