### PR TITLE
Mac object editor

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
@@ -58,6 +58,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void OnViewModelChanged (PropertyViewModel oldModel)
 		{
+			base.OnViewModelChanged (oldModel);
+
+			if (ViewModel == null)
+				return;
+
 			nint rowHeight = GetHeight (ViewModel);
 
 			float top = checkHeight;
@@ -99,9 +104,6 @@ namespace Xamarin.PropertyEditing.Mac
 			// Set our tabable order
 			this.firstKeyView = this.combinableList.KeyAt (0);
 			this.lastKeyView = this.combinableList.KeyAt (this.combinableList.Count - 1);
-
-			base.OnViewModelChanged (oldModel);
-
 		}
 
 		protected override void UpdateValue ()

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/BrushTabViewController.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/BrushTabViewController.cs
@@ -58,7 +58,7 @@ namespace Xamarin.PropertyEditing.Mac
 			this.inhibitSelection = true;
 			base.OnViewModelChanged (oldModel);
 
-			var existing = new HashSet<CommonBrushType> (ViewModel?.BrushTypes?.Values ?? Array.Empty<CommonBrushType> ());
+			var existing = new HashSet<CommonBrushType> (oldModel?.BrushTypes?.Values ?? Array.Empty<CommonBrushType> ());
 			existing.IntersectWith (this.brushTypeTable.Keys);
 
 			var removed = new HashSet<CommonBrushType> (this.brushTypeTable.Keys);

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyButton.cs
@@ -18,14 +18,15 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			get { return viewModel; }
 			set {
-				if (viewModel != null) {
-					viewModel.PropertyChanged -= OnPropertyChanged;
+				if (this.viewModel != null) {
+					this.viewModel.PropertyChanged -= OnPropertyChanged;
 				}
 
-				viewModel = value;
-				viewModel.PropertyChanged += OnPropertyChanged;
-
-				ValueSourceChanged (viewModel.ValueSource);
+				this.viewModel = value;
+				if (this.viewModel != null) {
+					this.viewModel.PropertyChanged += OnPropertyChanged;
+					ValueSourceChanged (this.viewModel.ValueSource);
+				}
 			}
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -43,6 +43,14 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.label.StringValue = value; }
 		}
 
+		public override void ViewWillMoveToSuperview (NSView newSuperview)
+		{
+			if (newSuperview == null && EditorView != null)
+				EditorView.ViewModel = null;
+
+			base.ViewWillMoveToSuperview (newSuperview);
+		}
+
 		private UnfocusableTextField label = new UnfocusableTextField {
 			Alignment = NSTextAlignment.Right,
 			TranslatesAutoresizingMaskIntoConstraints = false
@@ -53,7 +61,5 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.label.TextColor = value; }
 		}
 #endif
-
-		private readonly IHostResourceProvider hostResources;
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -43,6 +43,34 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.label.StringValue = value; }
 		}
 
+		public NSView LeftEdgeView
+		{
+			get { return this.leftEdgeView; }
+			set
+			{
+				if (this.leftEdgeView != null) {
+					this.leftEdgeView.RemoveFromSuperview ();
+					RemoveConstraints (new[] { this.leftEdgeLeftConstraint, this.leftEdgeVCenterConstraint });
+					this.leftEdgeLeftConstraint.Dispose ();
+					this.leftEdgeLeftConstraint = null;
+					this.leftEdgeVCenterConstraint.Dispose ();
+					this.leftEdgeVCenterConstraint = null;
+				}
+
+				this.leftEdgeView = value;
+
+				if (value != null) {
+					AddSubview (value);
+
+					value.TranslatesAutoresizingMaskIntoConstraints = false;
+					this.leftEdgeLeftConstraint = NSLayoutConstraint.Create (this.leftEdgeView, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1, 4);
+					this.leftEdgeVCenterConstraint = NSLayoutConstraint.Create (this.leftEdgeView, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1, 0);
+
+					AddConstraints (new[] { this.leftEdgeLeftConstraint, this.leftEdgeVCenterConstraint });
+				}
+			}
+		}
+
 		public override void ViewWillMoveToSuperview (NSView newSuperview)
 		{
 			if (newSuperview == null && EditorView != null)
@@ -61,5 +89,8 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.label.TextColor = value; }
 		}
 #endif
+
+		private NSView leftEdgeView;
+		private NSLayoutConstraint leftEdgeLeftConstraint, leftEdgeVCenterConstraint;
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -133,6 +133,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void OnViewModelChanged (PropertyViewModel oldModel)
 		{
+			base.OnViewModelChanged (oldModel);
+
+			if (ViewModel == null)
+				return;
+
 			if (ViewModel.HasInputModes) {
 				if (this.inputModePopup == null) {
 					this.inputModePopup = new NSPopUpButton {
@@ -169,8 +174,6 @@ namespace Xamarin.PropertyEditing.Mac
 			// If we are reusing the control we'll have to hid the inputMode if this doesn't have InputMode.
 			if (this.inputModePopup != null)
 				this.inputModePopup.Hidden = !ViewModel.HasInputModes;
-
-			base.OnViewModelChanged (oldModel);
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ObjectEditorControl.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using AppKit;
+using Foundation;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class ObjectEditorControl
+		: PropertyEditorControl<ObjectPropertyViewModel>
+	{
+		public ObjectEditorControl (IHostResourceProvider hostResources)
+			: base (hostResources)
+		{
+			this.typeLabel = new UnfocusableTextField {
+				TranslatesAutoresizingMaskIntoConstraints = false
+			};
+			AddSubview (this.typeLabel);
+
+			this.createObject = new NSButton {
+				Title = Properties.Resources.New,
+				TranslatesAutoresizingMaskIntoConstraints = false,
+				BezelStyle = NSBezelStyle.Rounded
+			};
+			this.createObject.Activated += OnNewPressed;
+			AddSubview (this.createObject);
+
+			this.buttonConstraint = NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Trailing, 1f, 12);
+
+			AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1f, 0f),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1, 0),
+				this.buttonConstraint,
+				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1, 0).WithPriority (NSLayoutPriority.DefaultLow),
+				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
+				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Width, NSLayoutRelation.GreaterThanOrEqual, 1f, 70f),
+			});
+		}
+
+		public override NSView FirstKeyView => this.createObject;
+
+		public override NSView LastKeyView => this.createObject;
+
+		protected override void UpdateValue ()
+		{
+		}
+
+		protected override void UpdateErrorsDisplayed (IEnumerable errors)
+		{
+		}
+
+		protected override void HandleErrorsChanged (object sender, DataErrorsChangedEventArgs e)
+		{
+		}
+
+		protected override void SetEnabled ()
+		{
+			this.createObject.Enabled = ViewModel.Property.CanWrite;
+		}
+
+		protected override void UpdateAccessibilityValues ()
+		{
+			this.createObject.AccessibilityTitle = String.Format (Properties.Resources.NewInstanceForProperty, ViewModel.Property.Name);
+		}
+
+		protected override void OnViewModelChanged (PropertyViewModel oldModel)
+		{
+			base.OnViewModelChanged (oldModel);
+
+			if (oldModel is ObjectPropertyViewModel ovm) {
+				ovm.TypeRequested -= OnTypeRequested;
+				ovm.CreateInstanceCommand.CanExecuteChanged -= OnCreateInstanceExecutableChanged;
+			}
+
+			if (ViewModel != null) {
+				ViewModel.TypeRequested += OnTypeRequested;
+				ViewModel.CreateInstanceCommand.CanExecuteChanged += OnCreateInstanceExecutableChanged;
+
+				OnPropertyChanged (ViewModel, new PropertyChangedEventArgs (null));
+			}
+		}
+
+		protected override void OnPropertyChanged (object sender, PropertyChangedEventArgs e)
+		{
+			switch (e.PropertyName) {
+			case nameof (ObjectPropertyViewModel.ValueType):
+				UpdateTypeLabel ();
+				break;
+			case null:
+			case "":
+				UpdateTypeLabel ();
+				UpdateCreateInstanceCommand ();
+				break;
+			}
+
+			base.OnPropertyChanged (sender, e);
+		}
+
+		private readonly UnfocusableTextField typeLabel;
+		private readonly NSButton createObject;
+		private readonly NSLayoutConstraint buttonConstraint;
+
+		private void OnCreateInstanceExecutableChanged (object sender, EventArgs e)
+		{
+			UpdateCreateInstanceCommand ();
+		}
+
+		private void OnTypeRequested (object sender, TypeRequestedEventArgs e)
+		{
+			var tcs = new TaskCompletionSource<ITypeInfo> ();
+			e.SelectedType = tcs.Task;
+
+			var vm = new TypeSelectorViewModel (ViewModel.AssignableTypes);
+			var selector = new TypeSelectorControl {
+				ViewModel = vm,
+				Appearance = EffectiveAppearance
+			};
+
+			vm.PropertyChanged += (vms, ve) => {
+				if (ve.PropertyName == nameof (TypeSelectorViewModel.SelectedType)) {
+					tcs.TrySetResult (vm.SelectedType);
+				}
+			};
+
+			var popover = new NSPopover {
+				Behavior = NSPopoverBehavior.Transient,
+				Delegate = new PopoverDelegate<ITypeInfo> (tcs),
+				ContentViewController = new NSViewController {
+					View = selector,
+					PreferredContentSize = new CoreGraphics.CGSize (360, 335)
+				},
+			};
+
+			popover.SetAppearance (HostResources.GetVibrantAppearance (EffectiveAppearance));
+
+			tcs.Task.ContinueWith (t => {
+				popover.PerformClose (popover);
+				popover.Dispose ();
+			}, TaskScheduler.FromCurrentSynchronizationContext());
+
+			popover.Show (this.createObject.Frame, this, NSRectEdge.MinYEdge);
+		}
+
+		private void UpdateTypeLabel ()
+		{
+			if (ViewModel.ValueType == null) {
+				this.typeLabel.StringValue = String.Empty;
+				this.buttonConstraint.Active = false;
+			} else {
+				this.typeLabel.StringValue = $"({ViewModel.ValueType.Name})";
+				this.buttonConstraint.Active = true;
+			}
+		}
+
+		private void UpdateCreateInstanceCommand()
+		{
+			this.createObject.Enabled = ViewModel.CreateInstanceCommand.CanExecute (null);
+		}
+
+		private void OnNewPressed (object sender, EventArgs e)
+		{
+			ViewModel.CreateInstanceCommand.Execute (null);
+		}
+
+		private class PopoverDelegate<T>
+			: NSPopoverDelegate
+		{
+			public PopoverDelegate (TaskCompletionSource<T> tcs)
+			{
+				this.tcs = tcs;
+			}
+
+			public override void WillClose (NSNotification notification)
+			{
+				this.tcs.TrySetCanceled ();
+			}
+
+			private readonly TaskCompletionSource<T> tcs;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -32,9 +32,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 		PropertyViewModel viewModel;
 		public PropertyViewModel ViewModel {
-			get { return viewModel; }
+			get { return this.viewModel; }
 			set {
-				if (viewModel == value)
+				if (this.ViewModel == value)
 					return;
 
 				PropertyViewModel oldModel = this.viewModel;
@@ -45,10 +45,10 @@ namespace Xamarin.PropertyEditing.Mac
 
 				this.viewModel = value;
 				OnViewModelChanged (oldModel);
-				viewModel.PropertyChanged += OnPropertyChanged;
-
-				// FIXME: figure out what we want errors to display as (tooltip, etc.)
-				viewModel.ErrorsChanged += HandleErrorsChanged;
+				if (this.viewModel != null) {
+					this.viewModel.PropertyChanged += OnPropertyChanged;
+					this.viewModel.ErrorsChanged += HandleErrorsChanged;
+				}
 			}
 		}
 
@@ -103,11 +103,12 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected virtual void OnViewModelChanged (PropertyViewModel oldModel)
 		{
-			SetEnabled ();
-			UpdateValue ();
-			UpdateAccessibilityValues ();
+			if (ViewModel != null) {
+				SetEnabled ();
+				UpdateValue ();
+				UpdateAccessibilityValues ();
+			}
 
-			// Hook this up so we know when to reset values 
 			PropertyButton.ViewModel = viewModel;
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -65,6 +65,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void OnViewModelChanged (PropertyViewModel oldModel)
 		{
+			base.OnViewModelChanged (oldModel);
+
+			if (ViewModel == null)
+				return;
+
 			if (ViewModel.HasInputModes) {
 				if (this.inputModePopup == null) {
 					this.inputModePopup = new NSPopUpButton {
@@ -101,8 +106,6 @@ namespace Xamarin.PropertyEditing.Mac
 			// If we are reusing the control we'll have to hid the inputMode if this doesn't have InputMode.
 			if (this.inputModePopup != null)
 				this.inputModePopup.Hidden = !ViewModel.HasInputModes;
-
-			base.OnViewModelChanged (oldModel);
 		}
 
 		protected override void UpdateErrorsDisplayed (IEnumerable errors)

--- a/Xamarin.PropertyEditing.Mac/Controls/TypeSelectorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TypeSelectorControl.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using AppKit;
+using Foundation;
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class TypeSelectorControl
+		: NotifyingView<TypeSelectorViewModel>
+	{
+		public TypeSelectorControl()
+		{
+			this.checkbox = NSButton.CreateCheckbox (Properties.Resources.ShowAllAssemblies, OnCheckedChanged);
+			this.checkbox.TranslatesAutoresizingMaskIntoConstraints = false;
+			AddSubview (this.checkbox);
+
+			var scroll = new NSScrollView {
+				TranslatesAutoresizingMaskIntoConstraints = false
+			};
+
+			var d = new TypeSelectorDelegate ();
+			this.outlineView = new NSOutlineView  {
+				Delegate = d,
+				AutoresizingMask = NSViewResizingMask.WidthSizable,
+				HeaderView = null,
+				Action = new ObjCRuntime.Selector ("onActivatedItem"),
+				Target = this
+			};
+			var col = new NSTableColumn ();
+			this.outlineView.AddColumn (col);
+			this.outlineView.OutlineTableColumn = col;
+			scroll.DocumentView = this.outlineView;
+
+			AddSubview (scroll);
+
+			this.filter = new NSTextField {
+				TranslatesAutoresizingMaskIntoConstraints = false,
+				PlaceholderString = "Filter"
+			};
+			this.filter.Changed += OnFilterChanged;
+
+			AddSubview (this.filter);
+
+			AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.filter, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 10),
+				NSLayoutConstraint.Create (this.filter, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1, -20),
+				NSLayoutConstraint.Create (this.filter, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterX, 1, 0),
+
+				NSLayoutConstraint.Create (scroll, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.filter, NSLayoutAttribute.Bottom, 1, 8),
+				NSLayoutConstraint.Create (scroll, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this.filter, NSLayoutAttribute.Width, 1, 0),
+				NSLayoutConstraint.Create (scroll, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterX, 1, 0),
+				NSLayoutConstraint.Create (scroll, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, this.checkbox, NSLayoutAttribute.Top, 1, -8),
+
+				NSLayoutConstraint.Create (this.checkbox, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, this, NSLayoutAttribute.Bottom, 1, -10),
+				NSLayoutConstraint.Create (this.checkbox, NSLayoutAttribute.Left, NSLayoutRelation.Equal, scroll, NSLayoutAttribute.Left, 1, 0)
+			});
+		}
+
+		public override void OnViewModelChanged (TypeSelectorViewModel oldModel)
+		{
+			base.OnViewModelChanged (oldModel);
+
+			this.outlineView.DataSource = new TypeSelectorDataSource (ViewModel);
+			OnPropertyChanged (ViewModel, new PropertyChangedEventArgs (null));
+		}
+
+		public override void OnPropertyChanged (object sender, PropertyChangedEventArgs e)
+		{
+			base.OnPropertyChanged (sender, e);
+
+			switch (e.PropertyName) {
+			case nameof (TypeSelectorViewModel.Types):
+				Reload ();
+				break;
+			case nameof (TypeSelectorViewModel.FilterText):
+			default:
+				UpdateFilter ();
+				break;
+			}
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if (theEvent.KeyCode == 76 || theEvent.KeyCode == 36) {
+				if (this.outlineView.SelectedRow >= 0) {
+					var facade = (NSObjectFacade)this.outlineView.ItemAtRow (this.outlineView.SelectedRow);
+					if (facade.Target is ITypeInfo)
+						OnActivatedItem ();
+				} else {
+					OnActivatedItem ();
+				}
+			}
+
+			base.KeyDown (theEvent);
+		}
+
+		private readonly NSOutlineView outlineView;
+		private readonly NSTextField filter;
+		private readonly NSButton checkbox;
+
+		private void Reload()
+		{
+			this.outlineView.ReloadData ();
+
+			if (!String.IsNullOrWhiteSpace (ViewModel?.FilterText)) {
+				for (int i = 0; i < this.outlineView.RowCount; i++) {
+					this.outlineView.ExpandItem (this.outlineView.ItemAtRow (i));
+				}
+			}
+		}
+
+		[Export ("onActivatedItem")]
+		private void OnActivatedItem()
+		{
+			if (this.outlineView.SelectedRow >= 0) {
+				var facade = (NSObjectFacade)this.outlineView.ItemAtRow (this.outlineView.SelectedRow);
+				ViewModel.SelectedType = facade.Target as ITypeInfo;
+			} else {
+				ViewModel.SelectedType = null;
+			}
+		}
+
+		private void OnFilterChanged (object sender, EventArgs e)
+		{
+			if (ViewModel == null)
+				return;
+
+			ViewModel.FilterText = this.filter.StringValue;
+			Reload ();
+		}
+
+		private void UpdateFilter()
+		{
+			this.filter.StringValue = ViewModel?.FilterText ?? String.Empty;
+		}
+
+		private void OnCheckedChanged ()
+		{
+			ViewModel.ShowAllAssemblies = this.checkbox.State == NSCellStateValue.On;
+			Reload ();
+		}
+
+		private class TypeSelectorDataSource
+			: NSOutlineViewDataSource
+		{
+			public TypeSelectorDataSource (TypeSelectorViewModel viewModel)
+			{
+				this.viewModel = viewModel;
+			}
+
+			public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
+			{
+				if (item == null) {
+					return this.viewModel.Types?.Count ?? 0;
+				} else if (((NSObjectFacade)item).Target is KeyValuePair<string, SimpleCollectionView> kvp) {
+					return kvp.Value.Count;
+				}
+
+				return base.GetChildrenCount (outlineView, item);
+			}
+
+			public override NSObject GetChild (NSOutlineView outlineView, nint childIndex, NSObject item)
+			{
+				if (item == null) {
+					return new NSObjectFacade (this.viewModel.Types[(int)childIndex]);
+				} else if (((NSObjectFacade)item).Target is KeyValuePair<string, SimpleCollectionView> kvp) {
+					return new NSObjectFacade (kvp.Value[(int)childIndex]);
+				}
+
+				return base.GetChild (outlineView, childIndex, item);
+			}
+
+			public override bool ItemExpandable (NSOutlineView outlineView, NSObject item)
+			{
+				return !(((NSObjectFacade)item).Target is ITypeInfo);
+			}
+
+			private TypeSelectorViewModel viewModel;
+		}
+
+		private class TypeSelectorDelegate
+			: NSOutlineViewDelegate
+		{
+
+			public override NSView GetView (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
+			{
+				var label = (UnfocusableTextField)outlineView.MakeView (LabelId, outlineView);
+				if (label == null) {
+					label = new UnfocusableTextField {
+						Identifier = LabelId
+					};
+				}
+
+				string text = String.Empty;
+				var facade = (NSObjectFacade)item;
+				if (facade.Target is KeyValuePair<string, SimpleCollectionView> kvp)
+					text = kvp.Key;
+				else if (facade.Target is ITypeInfo type)
+					text = type.Name;
+
+				label.StringValue = text;
+				return label;
+			}
+
+			private const string LabelId = "label";
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/Controls/TypeSelectorWindow.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TypeSelectorWindow.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AppKit;
+using CoreGraphics;
+
+using Xamarin.PropertyEditing.ViewModels;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class TypeSelectorWindow
+		: NSWindow
+	{
+		public TypeSelectorWindow (TypeSelectorViewModel viewModel)
+			: base (new CGRect (0, 0, 300, 300), NSWindowStyle.Titled | NSWindowStyle.Closable | NSWindowStyle.Resizable, NSBackingStore.Buffered, true)
+		{
+			Title = Properties.Resources.SelectObjectTitle;
+
+			this.selector = new TypeSelectorControl {
+				ViewModel = viewModel,
+				TranslatesAutoresizingMaskIntoConstraints = false
+			};
+
+			ContentView.AddSubview (this.selector);
+
+			this.ok = NSButton.CreateButton (Properties.Resources.OK, OnOked);
+			this.ok.TranslatesAutoresizingMaskIntoConstraints = false;
+			ContentView.AddSubview (this.ok);
+
+			this.cancel = NSButton.CreateButton (Properties.Resources.Cancel, OnCanceled);
+			this.cancel.TranslatesAutoresizingMaskIntoConstraints = false;
+			ContentView.AddSubview (this.cancel);
+
+			ContentView.AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.selector, NSLayoutAttribute.Width, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Width, 1, -20),
+				NSLayoutConstraint.Create (this.selector, NSLayoutAttribute.Top, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Top, 1, 0),
+				NSLayoutConstraint.Create (this.selector, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.CenterX, 1, 0),
+				NSLayoutConstraint.Create (this.selector, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, this.ok, NSLayoutAttribute.Top, 1, -10),
+
+				NSLayoutConstraint.Create (this.ok, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Bottom, 1, -10),
+				NSLayoutConstraint.Create (this.ok, NSLayoutAttribute.Right, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Right, 1, -10),
+
+				NSLayoutConstraint.Create (this.cancel, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.ok, NSLayoutAttribute.Left, 1, -10),
+				NSLayoutConstraint.Create (this.cancel, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, ContentView, NSLayoutAttribute.Bottom, 1, -10),
+			});
+		}
+
+		private TypeSelectorControl selector;
+		private NSButton ok, cancel;
+
+		private void OnOked ()
+		{
+			NSApplication.SharedApplication.StopModalWithCode ((int)NSModalResponse.OK);
+			Close ();
+		}
+
+		private void OnCanceled ()
+		{
+			NSApplication.SharedApplication.StopModalWithCode ((int)NSModalResponse.Cancel);
+			Close ();
+		}
+
+		public static ITypeInfo RequestType (AsyncValue<IReadOnlyDictionary<IAssemblyInfo, ILookup<string, ITypeInfo>>> assignableTypes)
+		{
+			var w = new TypeSelectorWindow (new TypeSelectorViewModel (assignableTypes));
+
+			var result = (NSModalResponse)(int)NSApplication.SharedApplication.RunModalForWindow (w);
+			if (result != NSModalResponse.OK)
+				return null;
+
+			return w.selector.ViewModel.SelectedType;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -175,6 +175,7 @@ namespace Xamarin.PropertyEditing.Mac
 			((NSView)this.header.ContentView).AddSubview (this.tabStack);
 
 			this.propertyTable = new FirstResponderOutlineView {
+				IndentationPerLevel = 0,
 				RefusesFirstResponder = true,
 				SelectionHighlightStyle = NSTableViewSelectionHighlightStyle.None,
 				HeaderView = null,
@@ -183,9 +184,6 @@ namespace Xamarin.PropertyEditing.Mac
 
 			var propertyEditors = new NSTableColumn (PropertyEditorColId);
 			this.propertyTable.AddColumn (propertyEditors);
-
-			// Set OutlineTableColumn or the arrows showing children/expansion or they will not be drawn
-			this.propertyTable.OutlineTableColumn = propertyEditors;
 
 			var tableContainer = new NSScrollView {
 				TranslatesAutoresizingMaskIntoConstraints = false,
@@ -278,18 +276,6 @@ namespace Xamarin.PropertyEditing.Mac
 			public bool validateProposedFirstResponder (NSResponder responder, NSEvent ev)
 			{
 				return true;
-			}
-
-			public override CGRect GetCellFrame (nint column, nint row)
-			{
-				var super = base.GetCellFrame (column, row);
-				if (column == 0) {
-					var obj = (NSObjectFacade)ItemAtRow (row);
-					if (obj.Target is PropertyGroupViewModel)
-						return new CGRect (0, super.Top, super.Right - (super.Left / 2), super.Height);
-				}
-
-				return super;
 			}
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -183,7 +183,7 @@ namespace Xamarin.PropertyEditing.Mac
 			var propertyEditors = new NSTableColumn (PropertyEditorColId);
 			this.propertyTable.AddColumn (propertyEditors);
 
-			// Set OutlineTableColumn or the arrows showing children/expansion will not be drawn
+			// Set OutlineTableColumn or the arrows showing children/expansion or they will not be drawn
 			this.propertyTable.OutlineTableColumn = propertyEditors;
 
 			var tableContainer = new NSScrollView {

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -178,6 +178,7 @@ namespace Xamarin.PropertyEditing.Mac
 				RefusesFirstResponder = true,
 				SelectionHighlightStyle = NSTableViewSelectionHighlightStyle.None,
 				HeaderView = null,
+				IntercellSpacing = new CGSize (0, 0)
 			};
 
 			var propertyEditors = new NSTableColumn (PropertyEditorColId);

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorSelector.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorSelector.cs
@@ -54,6 +54,8 @@ namespace Xamarin.PropertyEditing.Mac
 			{typeof (RatioViewModel), typeof (RatioEditorControl<CommonRatio>)},
 			{typeof (ThicknessPropertyViewModel), typeof (CommonThicknessEditorControl) },
 			{typeof (PropertyGroupViewModel), typeof (GroupEditorControl)},
+			{typeof (ObjectPropertyViewModel), typeof (ObjectEditorControl)},
+
 		};
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -74,7 +74,7 @@ namespace Xamarin.PropertyEditing.Mac
 			NSView editorOrContainer = null;
 			if (this.firstCache.TryGetValue (cellIdentifier, out IEditorView editor)) {
 				this.firstCache.Remove (cellIdentifier);
-				editorOrContainer = (editor.NativeView is PropertyEditorControl) ? new EditorContainer (this.hostResources, editor) : editor.NativeView;
+				editorOrContainer = (editor.NativeView is PropertyEditorControl) ? new EditorContainer (this.hostResources, editor) { Identifier = cellIdentifier } : editor.NativeView;
 			} else {
 				editorOrContainer = GetEditor (cellIdentifier, evm, outlineView);
 				editor = ((editorOrContainer as EditorContainer)?.EditorView) ?? editorOrContainer as IEditorView;

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -90,15 +90,11 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 
 			if (editor != null) {
-				nint index = outlineView.RowForItem (item);
-				if (editor.NativeView is PropertyEditorControl pec) {
-					pec.TableRow = index;
-				}
-
 				editor.ViewModel = evm;
 
 				// Force a row update due to new height, but only when we are non-default
 				if (editor.IsDynamicallySized) {
+					nint index = outlineView.RowForItem (item);
 					outlineView.NoteHeightOfRowsWithIndexesChanged (new NSIndexSet (index));
 				}
 			} else if (editorOrContainer is PanelHeaderEditorControl header) {

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Controls\Custom\DynamicFillBox.cs" />
     <Compile Include="Controls\Custom\TabButton.cs" />
     <Compile Include="Controls\Custom\FocusableComboBox.cs" />
+    <Compile Include="Controls\TypeSelectorControl.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\" />

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -145,7 +145,9 @@
     <Compile Include="Controls\Custom\DynamicFillBox.cs" />
     <Compile Include="Controls\Custom\TabButton.cs" />
     <Compile Include="Controls\Custom\FocusableComboBox.cs" />
+    <Compile Include="Controls\ObjectEditorControl.cs" />
     <Compile Include="Controls\TypeSelectorControl.cs" />
+    <Compile Include="Controls\TypeSelectorWindow.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\" />

--- a/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/ObjectPropertyViewModelTests.cs
@@ -179,7 +179,7 @@ namespace Xamarin.PropertyEditing.Tests
 		}
 
 		[Test]
-		public void CanDelve ()
+		public async Task CanDelve ()
 		{
 			object value = new object();
 
@@ -189,6 +189,7 @@ namespace Xamarin.PropertyEditing.Tests
 			var editor = new MockObjectEditor (new[] { p.Object }, new Dictionary<IPropertyInfo, IReadOnlyList<ITypeInfo>> {
 				{ p.Object, new[] { childsubInfo } }
 			});
+			await editor.SetValueAsync (p.Object, new ValueInfo<object> { Value = value, Source = ValueSource.Local });
 
 			var providerMock = CreateProviderMock (value, new MockObjectEditor { Target = value });
 

--- a/Xamarin.PropertyEditing/Extensions.cs
+++ b/Xamarin.PropertyEditing/Extensions.cs
@@ -107,6 +107,21 @@ namespace Xamarin.PropertyEditing
 			self.Add (with);
 		}
 
+		public static void Reset<T> (this ICollection<T> self, IEnumerable<T> newContents)
+		{
+			if (self == null)
+				throw new ArgumentNullException (nameof(self));
+			if (newContents == null)
+				throw new ArgumentNullException (nameof(newContents));
+
+			if (self is ObservableCollectionEx<T> oce) {
+				oce.Reset (newContents);
+			} else {
+				self.Clear();
+				self.AddItems (newContents);
+			}
+		}
+
 		public static void Move (this IList self, int index, int moveTo)
 		{
 			if (self == null)

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -1168,7 +1168,7 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Show all assemblies.
+        ///   Looks up a localized string similar to Show all assemblies.
         /// </summary>
         public static string ShowAllAssemblies {
             get {
@@ -1177,7 +1177,7 @@ namespace Xamarin.PropertyEditing.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Show system resources.
+        ///   Looks up a localized string similar to Show system resources.
         /// </summary>
         public static string ShowSystemResources {
             get {

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -327,7 +327,7 @@
     <value>OK</value>
   </data>
   <data name="ShowAllAssemblies" xml:space="preserve">
-    <value>_Show all assemblies</value>
+    <value>Show all assemblies</value>
   </data>
   <data name="SearchProperties" xml:space="preserve">
     <value>Search properties</value>
@@ -354,7 +354,7 @@
     <value>Select Resource</value>
   </data>
   <data name="ShowSystemResources" xml:space="preserve">
-    <value>_Show system resources</value>
+    <value>Show system resources</value>
   </data>
   <data name="ResourceEllipsis" xml:space="preserve">
     <value>Resource…</value>

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -90,8 +90,6 @@ namespace Xamarin.PropertyEditing.ViewModels
 				return;
 
 			using (await AsyncWork.RequestAsyncWork (this)) {
-				
-
 				await base.UpdateCurrentValueAsync ();
 				ValueType = CurrentValue?.ValueDescriptor as ITypeInfo;
 

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -90,13 +90,16 @@ namespace Xamarin.PropertyEditing.ViewModels
 				return;
 
 			using (await AsyncWork.RequestAsyncWork (this)) {
-				ValueModel.SelectedObjects.Clear();
+				
 
 				await base.UpdateCurrentValueAsync ();
 				ValueType = CurrentValue?.ValueDescriptor as ITypeInfo;
 
-				if (CurrentValue?.Value != null)
-					ValueModel.SelectedObjects.Add (CurrentValue.Value);
+				if (CurrentValue?.Value != null) {
+					ValueModel.SelectedObjects.Reset (new[] { CurrentValue.Value });
+				} else {
+					ValueModel.SelectedObjects.Clear ();
+				}
 
 				SetCanDelve (ValueModel.SelectedObjects.Count > 0);
 			}

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -164,7 +164,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 						if (args.SelectedType == null)
 							return;
 
-						selectedType = await args.SelectedType;
+						try {
+							selectedType = await args.SelectedType;
+ 						} catch (OperationCanceledException) {
+							return;
+						}
 					}
 
 					await SetValueAsync (new ValueInfo<object> {

--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using Cadenza.Collections;
 
 namespace Xamarin.PropertyEditing.ViewModels
 {
@@ -14,7 +11,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 		: EventArgs
 	{
 		/// <summary>
-		/// Gets or sets the type selected by the user from the UI
+		/// Gets or sets a task for the type selected by the user from the UI
 		/// </summary>
 		public Task<ITypeInfo> SelectedType
 		{
@@ -101,7 +98,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 				if (CurrentValue?.Value != null)
 					ValueModel.SelectedObjects.Add (CurrentValue.Value);
 
-				SetCanDelve (Editors.Any (e => e != null));
+				SetCanDelve (ValueModel.SelectedObjects.Count > 0);
 			}
 		}
 

--- a/Xamarin.PropertyEditing/ViewModels/TypeSelectorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/TypeSelectorViewModel.cs
@@ -61,7 +61,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		public IEnumerable Types
+		public IList Types
 		{
 			get { return this.assemblyView; }
 		}


### PR DESCRIPTION
This PR:
 - Adds the object editor control for Mac (closes #141)
 - Reimplements the disclosure handling for the outline view allowing us to properly control backgrounds
 - Adds a reusable type selector which is needed for the both this editor and the binding editor
 - Fixes reuse for first instance of each editor type (first-sized)

<img width="650" alt="screen shot 2019-02-05 at 3 45 40 pm" src="https://user-images.githubusercontent.com/156582/52303181-4d794000-295d-11e9-91f6-612be2f5b467.png">

<img width="649" alt="screen shot 2019-02-05 at 3 45 54 pm" src="https://user-images.githubusercontent.com/156582/52303186-4eaa6d00-295d-11e9-932a-d749b38b8ece.png">
