### PR TITLE
Resize Point and Rectangle controls based on overall width.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -20,7 +20,10 @@ namespace Xamarin.PropertyEditing.Mac
 		protected BasePointEditorControl (IHostResourceProvider hostResources)
 			: base (hostResources)
 		{
-			XLabel = new UnfocusableTextField ();
+			XLabel = new UnfocusableTextField {
+				Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
 
 			XEditor = new NumericSpinEditor<T> (hostResources) {
 				BackgroundColor = NSColor.Clear,
@@ -28,7 +31,10 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 			XEditor.ValueChanged += OnInputUpdated;
 
-			YLabel = new UnfocusableTextField ();
+			YLabel = new UnfocusableTextField {
+				Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
 
 			YEditor = new NumericSpinEditor<T> (hostResources) {
 				BackgroundColor = NSColor.Clear,
@@ -42,11 +48,24 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (YEditor);
 
 			this.AddConstraints (new[] {
-				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 0f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, YEditor,  NSLayoutAttribute.Left, 1f, -10f),
 				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 
-				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (XLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, XEditor,  NSLayoutAttribute.Bottom, 1f, -4f),
+				NSLayoutConstraint.Create (XLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Right, 1f, -32f),
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, XEditor,  NSLayoutAttribute.Width, 1f, 0f),
 				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (YLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, XLabel,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (YLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (XLabel, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, XEditor.Subviews[0], NSLayoutAttribute.CenterX, 1f, 0),
+				NSLayoutConstraint.Create (YLabel, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, YEditor.Subviews[0], NSLayoutAttribute.CenterX, 1f, 0),
 			});
 
 			ViewDidChangeEffectiveAppearance ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -26,28 +26,44 @@ namespace Xamarin.PropertyEditing.Mac
 		protected BaseRectangleEditorControl (IHostResourceProvider hostResources)
 			: base (hostResources)
 		{
-			XLabel = new UnfocusableTextField ();
-			XEditor = new NumericSpinEditor<T> (hostResources);
-			XEditor.BackgroundColor = NSColor.Clear;
-			XEditor.Value = 0.0f;
+			XLabel = new UnfocusableTextField {
+				Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
+			XEditor = new NumericSpinEditor<T> (hostResources) {
+				BackgroundColor = NSColor.Clear,
+				Value = 0.0f
+			};
 			XEditor.ValueChanged += OnInputUpdated;
 
-			YLabel =  new UnfocusableTextField ();
-			YEditor = new NumericSpinEditor<T> (hostResources);
-			YEditor.BackgroundColor = NSColor.Clear;
-			YEditor.Value = 0.0f;
+			YLabel =  new UnfocusableTextField {
+				Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
+			YEditor = new NumericSpinEditor<T> (hostResources) {
+				BackgroundColor = NSColor.Clear,
+				Value = 0.0f
+			};
 			YEditor.ValueChanged += OnInputUpdated;
 
-			WidthLabel = new UnfocusableTextField ();
-			WidthEditor = new NumericSpinEditor<T> (hostResources);
-			WidthEditor.BackgroundColor = NSColor.Clear;
-			WidthEditor.Value = 0.0f;
+			WidthLabel = new UnfocusableTextField {
+				Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
+			WidthEditor = new NumericSpinEditor<T> (hostResources) {
+				BackgroundColor = NSColor.Clear,
+				Value = 0.0f
+			};
 			WidthEditor.ValueChanged += OnInputUpdated;
 
-			HeightLabel =  new UnfocusableTextField ();
-			HeightEditor = new NumericSpinEditor<T> (hostResources);
-			HeightEditor.BackgroundColor = NSColor.Clear;
-			HeightEditor.Value = 0.0f;
+			HeightLabel =  new UnfocusableTextField {
+				Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+			};
+			HeightEditor = new NumericSpinEditor<T> (hostResources) {
+				BackgroundColor = NSColor.Clear,
+				Value = 0.0f
+			};
 			HeightEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);
@@ -60,17 +76,43 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (HeightEditor);
 
 			this.AddConstraints (new[] {
-				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 0f),
+				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, YEditor,  NSLayoutAttribute.Left, 1f, -10f),
 				NSLayoutConstraint.Create (XEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 
-				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (XLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, XEditor,  NSLayoutAttribute.Bottom, 1f, -4f),
+				NSLayoutConstraint.Create (XLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Right, 1f, -32f),
+				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, XEditor,  NSLayoutAttribute.Width, 1f, 0f),
 				NSLayoutConstraint.Create (YEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 
-				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (YLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, XLabel,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (YLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 33f),
+				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Left, 1f, 0f),
+				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, HeightEditor,  NSLayoutAttribute.Left, 1f, -10f),
 				NSLayoutConstraint.Create (WidthEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 
-				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 90f),
+				NSLayoutConstraint.Create (WidthLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, WidthEditor,  NSLayoutAttribute.Bottom, 1f, -4f),
+				NSLayoutConstraint.Create (WidthLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Top, NSLayoutRelation.Equal, WidthEditor,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Right, 1f, -32f),
+				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, WidthEditor,  NSLayoutAttribute.Width, 1f, 0f),
 				NSLayoutConstraint.Create (HeightEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+				NSLayoutConstraint.Create (HeightLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, WidthLabel,  NSLayoutAttribute.Top, 1f, 0f),
+				NSLayoutConstraint.Create (HeightLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+
+
+				NSLayoutConstraint.Create (XLabel, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, XEditor.Subviews[0], NSLayoutAttribute.CenterX, 1f, 0),
+				NSLayoutConstraint.Create (YLabel, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, YEditor.Subviews[0], NSLayoutAttribute.CenterX, 1f, 0),
+				NSLayoutConstraint.Create (WidthLabel, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, WidthEditor.Subviews[0], NSLayoutAttribute.CenterX, 1f, 0),
+				NSLayoutConstraint.Create (HeightLabel, NSLayoutAttribute.CenterX, NSLayoutRelation.Equal, HeightEditor.Subviews[0], NSLayoutAttribute.CenterX, 1f, 0),
 			});
 
 			ViewDidChangeEffectiveAppearance ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -76,8 +76,8 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.popUpButton);
 
 			this.AddConstraints (new[] {
-				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
-				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -33f),
+				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 2f),
+				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -32f),
 				NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight - 3),
 			});
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using AppKit;
 using CoreGraphics;
@@ -18,8 +18,8 @@ namespace Xamarin.PropertyEditing.Mac
 	internal class NumericSpinEditor
 		: NSView, INSAccessibilityGroup
 	{
-		const int stepperSpace = 2;
-		const int stepperWidth = 11;
+		internal const int StepperSpace = 2;
+		internal const int StepperWidth = 11;
 		const int stepperTopHeight = 9;
 		const int stepperBotHeight = 10;
 		const int inputModeWidth = 60;
@@ -221,17 +221,17 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.decrementButton);
 
 			this.AddConstraints (new[] {
-				NSLayoutConstraint.Create (this.numericEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -(stepperWidth + stepperSpace + 1)),
+				NSLayoutConstraint.Create (this.numericEditor, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -(StepperWidth + StepperSpace + 1)),
 				NSLayoutConstraint.Create (this.numericEditor, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight - 3),
 
 				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Top, 1f, 0f),
-				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Right, 1f, stepperSpace),
-				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, stepperWidth),
+				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Right, 1f, StepperSpace),
+				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, StepperWidth),
 				NSLayoutConstraint.Create (this.incrementButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, stepperTopHeight),
 
 				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Top, 1f, stepperTopHeight),
-				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Right, 1f, stepperSpace),
-				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, stepperWidth),
+				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.numericEditor,  NSLayoutAttribute.Right, 1f, StepperSpace),
+				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, StepperWidth),
 				NSLayoutConstraint.Create (this.decrementButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, stepperBotHeight),
 			});
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -168,7 +168,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 				this.numericEditorWidthConstraint.Constant = -117f; // Shorten the stringEditor if we have Inputmodes Showing.
 			} else {
-				this.numericEditorWidthConstraint.Constant = -34f; // Lengthen the stringEditor if we have Inputmodes Hidden.
+				this.numericEditorWidthConstraint.Constant = -32f; // Lengthen the stringEditor if we have Inputmodes Hidden.
 			}
 
 			// If we are reusing the control we'll have to hid the inputMode if this doesn't have InputMode.

--- a/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PointEditorControl.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Drawing;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using Xamarin.PropertyEditing.Drawing;
 using Xamarin.PropertyEditing.Mac.Resources;
 using Xamarin.PropertyEditing.ViewModels;
@@ -13,14 +14,10 @@ namespace Xamarin.PropertyEditing.Mac
 		public PointEditorControl (IHostResourceProvider hostResources)
 			: base (hostResources)
 		{
-			XLabel.Frame = new CGRect (34, -5, 25, 22);
-			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			XLabel.StringValue = "X"; // TODO Localise
 
 			XEditor.Frame = new CGRect (0, 13, 90, 20);
-
-			YLabel.Frame = new CGRect (166, -5, 25, 22);
-			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
+			
 			YLabel.StringValue = "Y"; // TODO Localise
 
 			YEditor.Frame = new CGRect (132, 13, 90, 20);

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -105,7 +105,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 					this.AddConstraints (new[] {
 						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Top, 1f, 0f),
-						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -33f),
+						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, -1f),
+						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Width, 1f, -32f),
 						NSLayoutConstraint.Create (this.popUpButton, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight + 1),
 					});
 
@@ -123,8 +124,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 					this.AddConstraints (new[] {
 						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, 0f),
-						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 0f),
-						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -34f),
+						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, -1f),
+						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -33f),
 						NSLayoutConstraint.Create (this.comboBox, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
 					});
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using AppKit;
 using CoreGraphics;
@@ -25,7 +25,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public const int DefaultControlHeight = 22;
 		public const int DefaultFontSize = 11;
 		public const int DefaultPropertyLabelFontSize = 11;
-		public const int DefaultDescriptionLabelFontSize = 10;
+		public const int DefaultDescriptionLabelFontSize = 9;
 		public const string DefaultFontName = ".AppleSystemUIFont";
 		public virtual bool IsDynamicallySized => false;
 

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.ComponentModel;
 using AppKit;

--- a/Xamarin.PropertyEditing.Mac/Controls/RectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RectangleEditorControl.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Drawing;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using Xamarin.PropertyEditing.Drawing;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -14,26 +15,18 @@ namespace Xamarin.PropertyEditing.Mac
 			: base (hostResources)
 		{
 			// TODO localize
-			XLabel.Frame = new CGRect (34, 28, 25, 22);
-			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			XLabel.StringValue = "X";
 
 			XEditor.Frame = new CGRect (0, 46, 90, 20);
-
-			YLabel.Frame = new CGRect (166, 28, 25, 22);
-			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
+			
 			YLabel.StringValue = "Y";
 
 			YEditor.Frame = new CGRect (132, 46, 90, 20);
-
-			WidthLabel.Frame = new CGRect (20, -5, 50, 22);
-			WidthLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
+			
 			WidthLabel.StringValue = "WIDTH";
 
 			WidthEditor.Frame = new CGRect (0, 13, 90, 20);
-
-			HeightLabel.Frame = new CGRect (150, -5, 50, 22);
-			HeightLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
+			
 			HeightLabel.StringValue = "HEIGHT";
 
 			HeightEditor.Frame = new CGRect (132, 13, 90, 20);

--- a/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/SizeEditorControl.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Drawing;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using Xamarin.PropertyEditing.Drawing;
 using Xamarin.PropertyEditing.Mac.Resources;
 using Xamarin.PropertyEditing.ViewModels;
@@ -14,14 +15,10 @@ namespace Xamarin.PropertyEditing.Mac
 		public SizeEditorControl (IHostResourceProvider hostResource)
 			: base (hostResource)
 		{
-			XLabel.Frame = new CGRect (20, -5, 50, 22);
-			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
 			XLabel.StringValue = "WIDTH"; // TODO Localise
 
 			XEditor.Frame = new CGRect (0, 13, 90, 20);
-
-			YLabel.Frame = new CGRect (150, -5, 50, 22);
-			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize); // TODO: Washed-out color following specs
+			
 			YLabel.StringValue = "HEIGHT"; // TODO Localise
 
 			YEditor.Frame = new CGRect (132, 13, 90, 20);

--- a/Xamarin.PropertyEditing.Mac/Controls/ThicknessEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ThicknessEditorControl.cs
@@ -1,6 +1,7 @@
 using System;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using Xamarin.PropertyEditing.Drawing;
 using Xamarin.PropertyEditing.Mac.Resources;
 using Xamarin.PropertyEditing.ViewModels;
@@ -13,26 +14,18 @@ namespace Xamarin.PropertyEditing.Mac
 		public CommonThicknessEditorControl (IHostResourceProvider hostResources)
 			: base (hostResources)
 		{
-			XLabel.Frame = new CGRect (28, 28, 50, 22);
-			XLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			XLabel.StringValue = "LEFT";
 
 			XEditor.Frame = new CGRect (0, 46, 90, 20);
 
-			YLabel.Frame = new CGRect (160, 28, 45, 22);
-			YLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			YLabel.StringValue = "TOP";
 
 			YEditor.Frame = new CGRect (132, 46, 90, 20);
 
-			WidthLabel.Frame = new CGRect (24, -5, 50, 22);
-			WidthLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			WidthLabel.StringValue = "RIGHT";
 
 			WidthEditor.Frame = new CGRect (0, 13, 90, 20);
 
-			HeightLabel.Frame = new CGRect (150, -5, 50, 22);
-			HeightLabel.Font = NSFont.FromFontName (DefaultFontName, DefaultDescriptionLabelFontSize);
 			HeightLabel.StringValue = "BOTTOM";
 
 			HeightEditor.Frame = new CGRect (132, 13, 90, 20);

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -46,11 +46,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override NSView GetView (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
 		{
-			EditorViewModel evm;
-			PropertyViewModel vm;
-			PanelGroupViewModel group;
-			string cellIdentifier;
-			GetVMGroupCellItendifiterFromFacade (item, out evm, out group, out cellIdentifier);
+			GetVMGroupCellItendifiterFromFacade (item, out EditorViewModel evm, out PanelGroupViewModel group, out var cellIdentifier);
 
 			if (group != null) {
 				var labelContainer = (NSView)outlineView.MakeView (CategoryIdentifier, this);


### PR DESCRIPTION
Controls resized as per control width

Supposed to fix this - https://github.com/xamarin/Xamarin.PropertyEditing/issues/518

Narrow:
<img width="236" alt="screen shot 2019-02-14 at 10 06 13" src="https://user-images.githubusercontent.com/271363/52779499-3531b100-3040-11e9-9c73-cc759487d246.png">

Wide:
<img width="641" alt="screen shot 2019-02-14 at 10 04 12" src="https://user-images.githubusercontent.com/271363/52779405-f865ba00-303f-11e9-8f41-f7c6953c8883.png">

