### PR TITLE
Grouped type fixes

### DIFF
--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -209,7 +209,7 @@ namespace Xamarin.PropertyEditing.Tests
 		[Test]
 		public async Task PropertyListCategoryGroupedWithNullCategory ()
 		{
-			// Purposefully a null catgory
+			// Purposefully a null category
 			var normalProp = new Mock<IPropertyInfo> ();
 			normalProp.SetupGet (p => p.Type).Returns (typeof(string));
 			normalProp.SetupGet (p => p.Name).Returns ("name");
@@ -412,6 +412,34 @@ namespace Xamarin.PropertyEditing.Tests
 
 			Assume.That (vm.ArrangedEditors, Is.Not.Empty);
 			Assert.That (vm.GetIsExpanded (normalProp.Object.Category), Is.True);
+		}
+
+		[Test]
+		public void GroupedTypesDoNotLeavePhantomCategory ()
+		{
+			var target = new object ();
+
+			var property = new Mock<IPropertyInfo> ();
+			property.SetupGet (p => p.Type).Returns (typeof (string));
+			property.SetupGet (p => p.Category).Returns ((string)null);
+			property.SetupGet (p => p.Name).Returns ("name");
+
+			var provider = new Mock<IEditorProvider> ();
+			provider.Setup (ep => ep.GetObjectEditorAsync (target))
+				.ReturnsAsync (new MockObjectEditor (property.Object) { Target = target });
+
+			var platform = new TargetPlatform (provider.Object) {
+				GroupedTypes = new Dictionary<Type, string> {
+					{ typeof(string), "strings" }
+				}
+			};
+
+			var vm = CreateVm (platform);
+			vm.ArrangeMode = PropertyArrangeMode.Category;
+			vm.AutoExpand = true;
+			vm.SelectedObjects.Add (target);
+
+			Assert.That (vm.ArrangedEditors.Count, Is.EqualTo (1));
 		}
 
 		internal override PanelViewModel CreateVm (TargetPlatform platform)

--- a/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
+++ b/Xamarin.PropertyEditing.Tests/PanelViewModelTests.cs
@@ -442,6 +442,148 @@ namespace Xamarin.PropertyEditing.Tests
 			Assert.That (vm.ArrangedEditors.Count, Is.EqualTo (1));
 		}
 
+		[Test]
+		[Description ("https://github.com/xamarin/Xamarin.PropertyEditing/issues/525")]
+		public void SwitchingFromObjectWithGroupedType ()
+		{
+			var targetWithProperties = new object ();
+			var targetWithoutProperties = new object ();
+
+			var property = new Mock<IPropertyInfo> ();
+			property.SetupGet (p => p.Type).Returns (typeof (string));
+			property.SetupGet (p => p.Category).Returns ((string)null);
+			property.SetupGet (p => p.Name).Returns ("name");
+
+			var property2 = new Mock<IPropertyInfo> ();
+			property2.SetupGet (p => p.Type).Returns (typeof (string));
+			property2.SetupGet (p => p.Category).Returns ((string)null);
+			property2.SetupGet (p => p.Name).Returns ("name2");
+
+			var provider = new Mock<IEditorProvider> ();
+			provider.Setup (ep => ep.GetObjectEditorAsync (targetWithProperties))
+				.ReturnsAsync (new MockObjectEditor (property.Object, property2.Object) { Target = targetWithProperties });
+			provider.Setup (ep => ep.GetObjectEditorAsync (targetWithoutProperties))
+				.ReturnsAsync (new MockObjectEditor (new IPropertyInfo[0]) { Target = targetWithoutProperties });
+
+			var platform = new TargetPlatform (provider.Object) {
+				GroupedTypes = new Dictionary<Type, string> {
+					{ typeof(string), "strings" }
+				}
+			};
+
+			var vm = CreateVm (platform);
+			vm.ArrangeMode = PropertyArrangeMode.Category;
+			vm.AutoExpand = true;
+			vm.SelectedObjects.Add (targetWithProperties);
+
+			Assume.That (vm.ArrangedEditors.Count, Is.EqualTo (1));
+
+			Assert.That (() => vm.SelectedObjects.ReplaceOrAdd (targetWithProperties, targetWithoutProperties),
+				Throws.Nothing);
+			Assert.That (vm.ArrangedEditors.Count, Is.EqualTo (0));
+		}
+
+		[Test]
+		public void SwitchingToObjectWithGroupedType ()
+		{
+			var targetWithProperties = new object ();
+			var targetWithoutProperties = new object ();
+
+			var property = new Mock<IPropertyInfo> ();
+			property.SetupGet (p => p.Type).Returns (typeof (string));
+			property.SetupGet (p => p.Category).Returns ((string)null);
+			property.SetupGet (p => p.Name).Returns ("name");
+
+			var property2 = new Mock<IPropertyInfo> ();
+			property2.SetupGet (p => p.Type).Returns (typeof (string));
+			property2.SetupGet (p => p.Category).Returns ((string)null);
+			property2.SetupGet (p => p.Name).Returns ("name2");
+
+			var provider = new Mock<IEditorProvider> ();
+			provider.Setup (ep => ep.GetObjectEditorAsync (targetWithProperties))
+				.ReturnsAsync (new MockObjectEditor (property.Object, property2.Object) { Target = targetWithProperties });
+			provider.Setup (ep => ep.GetObjectEditorAsync (targetWithoutProperties))
+				.ReturnsAsync (new MockObjectEditor (new IPropertyInfo[0]) { Target = targetWithoutProperties });
+
+			var platform = new TargetPlatform (provider.Object) {
+				GroupedTypes = new Dictionary<Type, string> {
+					{ typeof(string), "strings" }
+				}
+			};
+
+			var vm = CreateVm (platform);
+			vm.ArrangeMode = PropertyArrangeMode.Category;
+			vm.AutoExpand = true;
+			vm.SelectedObjects.Add (targetWithoutProperties);
+
+			Assume.That (vm.ArrangedEditors.Count, Is.EqualTo (0));
+
+			Assert.That (() => vm.SelectedObjects.ReplaceOrAdd (targetWithoutProperties, targetWithProperties),
+				Throws.Nothing);
+			Assert.That (vm.ArrangedEditors.Count, Is.EqualTo (1));
+
+			var group = vm.ArrangedEditors[0].Editors[0] as PropertyGroupViewModel;
+			Assert.That (group, Is.Not.Null);
+			Assert.That (group.Properties.Count, Is.EqualTo (2));
+		}
+
+		[Test]
+		public void GroupedTypeMultiselect ()
+		{
+			var outer = new object ();
+			var inner = new object ();
+
+			var property = new Mock<IPropertyInfo> ();
+			property.SetupGet (p => p.Type).Returns (typeof (string));
+			property.SetupGet (p => p.Category).Returns ((string)null);
+			property.SetupGet (p => p.Name).Returns ("name");
+
+			var property2 = new Mock<IPropertyInfo> ();
+			property2.SetupGet (p => p.Type).Returns (typeof (string));
+			property2.SetupGet (p => p.Category).Returns ((string)null);
+			property2.SetupGet (p => p.Name).Returns ("name2");
+
+			var provider = new Mock<IEditorProvider> ();
+			provider.Setup (ep => ep.GetObjectEditorAsync (outer))
+				.ReturnsAsync (new MockObjectEditor (property.Object, property2.Object) { Target = outer });
+			provider.Setup (ep => ep.GetObjectEditorAsync (inner))
+				.ReturnsAsync (new MockObjectEditor (property.Object) { Target = inner });
+
+			var platform = new TargetPlatform (provider.Object) {
+				GroupedTypes = new Dictionary<Type, string> {
+					{ typeof(string), "strings" }
+				}
+			};
+
+			var vm = CreateVm (platform);
+			vm.ArrangeMode = PropertyArrangeMode.Category;
+			vm.AutoExpand = true;
+			vm.SelectedObjects.Add (outer);
+
+			Assume.That (vm.ArrangedEditors.Count, Is.EqualTo (1));
+
+			var group = vm.ArrangedEditors[0].Editors[0] as PropertyGroupViewModel;
+			Assume.That (group, Is.Not.Null);
+			Assume.That (group.Properties.Count, Is.EqualTo (2));
+
+			bool shouldChange = false, changed = false;
+			if (group.Properties is INotifyCollectionChanged incc) {
+				shouldChange = true;
+				incc.CollectionChanged += (o, e) => changed = true;
+			}
+
+			vm.SelectedObjects.Add (inner);
+			Assert.That (vm.ArrangedEditors[0].Editors[0] as PropertyGroupViewModel, Is.SameAs (group));
+			Assert.That (group.Properties.Count, Is.EqualTo (1), "Number of remaining properties isn't correct");
+			Assert.That (group.Properties[0].Property, Is.EqualTo (property.Object), "Wrong property found in the group");
+			Assert.That (changed, Is.EqualTo (shouldChange), "Changed status didn't match expected");
+			
+			vm.SelectedObjects.Remove (inner);
+			group = vm.ArrangedEditors[0].Editors[0] as PropertyGroupViewModel;
+			Assert.That (group, Is.Not.Null);
+			Assert.That (group.Properties.Count, Is.EqualTo (2), "Outer properties didn't restore");
+		}
+
 		internal override PanelViewModel CreateVm (TargetPlatform platform)
 		{
 			return new PanelViewModel (platform);

--- a/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PanelViewModel.cs
@@ -246,10 +246,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 					}
 				}
 
-				string key = grouping.Key ?? String.Empty;
-				if (remainingItems != null) // TODO: pretty sure this was out of order before, add test
-					this.arranged.Add (key, new PanelGroupViewModel (key, grouping.Where (evm => remainingItems.Contains (evm))));
-				else
+				string key = grouping.Key;
+				if (remainingItems != null) {// TODO: pretty sure this was out of order before, add test
+					if (remainingItems.Count > 0)
+						this.arranged.Add (key, new PanelGroupViewModel (key, grouping.Where (evm => remainingItems.Contains (evm))));
+				} else
 					this.arranged.Add (key, new PanelGroupViewModel (key, grouping, separateUncommon: !isFlat));
 
 				AutoExpandGroup (key);

--- a/Xamarin.PropertyEditing/ViewModels/PropertyGroupViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertyGroupViewModel.cs
@@ -20,7 +20,7 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			Category = category;
 
-			this.properties = properties.ToArray ();
+			this.properties = properties.ToList ();
 			foreach (var vm in this.properties) {
 				if (vm.IsAvailable)
 					this.propertiesView.Add (vm);
@@ -55,9 +55,34 @@ namespace Xamarin.PropertyEditing.ViewModels
 			}
 		}
 
-		private readonly PropertyViewModel[] properties;
+		public void Add (PropertyViewModel property)
+		{
+			if (property == null)
+				throw new ArgumentNullException (nameof(property));
+
+			this.properties.Add (property);
+			Reload ();
+		}
+
+		public bool Remove (PropertyViewModel property)
+		{
+			if (property == null)
+				throw new ArgumentNullException (nameof(property));
+
+			if (this.properties.Remove (property))
+				return this.propertiesView.Remove (property);
+
+			return false;
+		}
+
+		private readonly List<PropertyViewModel> properties;
 		private readonly ObservableCollectionEx<PropertyViewModel> propertiesView = new ObservableCollectionEx<PropertyViewModel> ();
 		private string filterText;
+
+		private void Reload ()
+		{
+			Filter (null);
+		}
 
 		private void Filter (string oldFilter)
 		{


### PR DESCRIPTION
Fixes #525

When we moved to the new panel group system, the grouped editors weren't
accounted for and so when we try to remove their child property from the
container group it's not found since they're inside the group editor VM.

This also meant that even if removal had worked, we wouldn't properly
add new shared view model types to the group.