### PR TITLE
[Mac] Set Tooltip value for when resizing occurs & long properties are…

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using AppKit;
 using CoreGraphics;
 using Foundation;

--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -1,5 +1,7 @@
 using System;
 using AppKit;
+using CoreGraphics;
+using Foundation;
 
 namespace Xamarin.PropertyEditing.Mac
 {
@@ -27,7 +29,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 				this.AddConstraints (new[] {
 					NSLayoutConstraint.Create (EditorView.NativeView, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
-					NSLayoutConstraint.Create (EditorView.NativeView, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.label, NSLayoutAttribute.Right, 1f, 5f),
+					NSLayoutConstraint.Create (EditorView.NativeView, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.label, NSLayoutAttribute.Right, 1f, LabelToControlSpacing),
 					NSLayoutConstraint.Create (EditorView.NativeView, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1f, 0f),
 					NSLayoutConstraint.Create (EditorView.NativeView, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1f, 0f)
 				});
@@ -40,7 +42,10 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public string Label {
 			get { return this.label.StringValue; }
-			set { this.label.StringValue = value; }
+			set {
+				this.label.StringValue = value + ":";
+				this.label.ToolTip = value;
+			}
 		}
 
 		public NSView LeftEdgeView
@@ -92,5 +97,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private NSView leftEdgeView;
 		private NSLayoutConstraint leftEdgeLeftConstraint, leftEdgeVCenterConstraint;
+		private readonly IHostResourceProvider hostResources;
+		private const float LabelToControlSpacing = 5f;
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -97,7 +97,7 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 
 			if (editorOrContainer is EditorContainer ec) {
-				ec.Label = evm.Name + ":";
+				ec.Label = evm.Name;
 
 #if DEBUG // Currently only used to highlight which controls haven't been implemented
 				if (editor == null)


### PR DESCRIPTION
… clipped

Fixes: https://github.com/xamarin/Xamarin.PropertyEditing/issues/486

I did try hooking into 
		```
public override void ResizeWithOldSuperviewSize (CGSize oldSize)
		{
			base.ResizeWithOldSuperviewSize (oldSize);
		}
```

and tracking `ObserveFrameChanged`

But both of these fire for all controls in the property list, so make resizing very laggy and almost unusable. So pulled that code out.