### PR TITLE
[Mac] Add new BasePropertyControlTextField to have ellipses and Allow…

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
@@ -31,7 +31,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public override nint GetHeight (EditorViewModel vm)
 		{
 			var realVm = (CombinablePropertyViewModel<T>)vm;
-			return checkHeight * realVm.Choices.Count;
+			return DefaultControlHeight * realVm.Choices.Count;
 		}
 
 		protected override void HandleErrorsChanged (object sender, DataErrorsChangedEventArgs e)
@@ -63,9 +63,7 @@ namespace Xamarin.PropertyEditing.Mac
 			if (ViewModel == null)
 				return;
 
-			nint rowHeight = GetHeight (ViewModel);
-
-			float top = checkHeight;
+			float top = 0;
 
 			while (this.combinableList.Count > ViewModel.Choices.Count) {
 				var child = this.combinableList.KeyAt (ViewModel.Choices.Count);
@@ -80,7 +78,12 @@ namespace Xamarin.PropertyEditing.Mac
 				NSButton checkbox;
 				if (i >= this.combinableList.Count) {
 					checkbox = new NSButton {
+						AllowsExpansionToolTips = true,
 						AllowsMixedState = true,
+						Cell = {
+							LineBreakMode = NSLineBreakMode.TruncatingTail,
+							UsesSingleLineMode = true,
+						},
 						ControlSize = NSControlSize.Small,
 						Font = NSFont.FromFontName (DefaultFontName, DefaultFontSize),
 						TranslatesAutoresizingMaskIntoConstraints = false,
@@ -90,15 +93,21 @@ namespace Xamarin.PropertyEditing.Mac
 					checkbox.Activated += SelectionChanged;
 
 					AddSubview (checkbox);
+
+					this.AddConstraints (new[] {
+						NSLayoutConstraint.Create (checkbox, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1f, top),
+						NSLayoutConstraint.Create (checkbox, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 0f),
+						NSLayoutConstraint.Create (checkbox, NSLayoutAttribute.Width, NSLayoutRelation.Equal, this, NSLayoutAttribute.Width, 1f, -33f),
+						NSLayoutConstraint.Create (checkbox, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, DefaultControlHeight),
+					});
 				} else {
 					checkbox = this.combinableList.KeyAt (i);
 				}
 
 				checkbox.Title = choice.Name;
-				checkbox.Frame = new CGRect (0, rowHeight - top, Frame.Width, checkHeight);
 
 				this.combinableList[checkbox] = choice;
-				top += checkHeight;
+				top += DefaultControlHeight;
 			}
 
 			// Set our tabable order
@@ -127,7 +136,6 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 		}
 
-		private const int checkHeight = 22;
 		private readonly OrderedDictionary<NSButton, FlaggableChoiceViewModel<T>> combinableList = new OrderedDictionary<NSButton, FlaggableChoiceViewModel<T>> ();
 		private NSView firstKeyView;
 		private NSView lastKeyView;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using AppKit;
 using CoreGraphics;
 using Foundation;
@@ -6,13 +6,13 @@ using ObjCRuntime;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	public class NumericTextField : NSTextField
+	internal class NumericTextField : PropertyTextField
 	{
-		NSText CachedCurrentEditor {
+		private NSText CachedCurrentEditor {
 			get; set;
 		}
 
-		string cachedValueString;
+		private string cachedValueString;
 
 		public bool AllowNegativeValues {
 			get; set;
@@ -54,7 +54,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public override bool ShouldBeginEditing (NSText textObject)
 		{
 			CachedCurrentEditor = textObject;
-			cachedValueString = textObject.Value;
+			this.cachedValueString = textObject.Value;
 
 			if (AllowRatios)
 				CachedCurrentEditor.Delegate = new RatioValidateDelegate (this);
@@ -81,7 +81,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public virtual void ResetInvalidInput ()
 		{
-			this.StringValue = cachedValueString;
+			this.StringValue = this.cachedValueString;
 		}
 
 		public static bool CheckIfNumber (string finalString, ValidationType mode, bool allowNegativeValues)
@@ -93,9 +93,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public static bool ValidateDecimal (string finalString, bool allowNegativeValues)
 		{
-			double value;
 			//Checks parsing to number
-			if (!double.TryParse (finalString, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.CurrentUICulture, out value))
+			if (!double.TryParse (finalString, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.CurrentUICulture, out var value))
 				return false;
 			//Checks if needs to be possitive value
 			if (!allowNegativeValues && value < 0)
@@ -106,9 +105,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public static bool ValidateInteger (string finalString, bool allowNegativeValues)
 		{
-			int value;
 			//Checks parsing to number
-			if (!int.TryParse (finalString, out value))
+			if (!int.TryParse (finalString, out var value))
 				return false;
 			//Checks if needs to be possitive value
 			if (!allowNegativeValues && value < 0)
@@ -156,7 +154,7 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 	}
 
-	class KeyUpDownDelegate : NSTextFieldDelegate
+	internal class KeyUpDownDelegate : NSTextFieldDelegate
 	{
 		public event EventHandler<bool> KeyArrowUp;
 		public event EventHandler<bool> KeyArrowDown;
@@ -194,7 +192,7 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 	}
 
-	public abstract class TextViewValidationDelegate : NSTextViewDelegate
+	internal abstract class TextViewValidationDelegate : NSTextViewDelegate
 	{
 		protected NumericTextField TextField {
 			get; set;
@@ -233,7 +231,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected abstract bool ValidateFinalString (string value);
 	}
 
-	public class NumericValidationDelegate : TextViewValidationDelegate
+	internal class NumericValidationDelegate : TextViewValidationDelegate
 	{
 		public NumericValidationDelegate (NumericTextField textField)
 			: base (textField)
@@ -249,7 +247,7 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 	}
 
-	public class RatioValidateDelegate : TextViewValidationDelegate
+	internal class RatioValidateDelegate : TextViewValidationDelegate
 	{
 		public RatioValidateDelegate (NumericTextField textField)
 			: base (textField)

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyTextField.cs
@@ -1,0 +1,15 @@
+using System;
+using AppKit;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class PropertyTextField : NSTextField
+	{
+		public PropertyTextField ()
+		{
+			AllowsExpansionToolTips = true;
+			Cell.LineBreakMode = NSLineBreakMode.TruncatingTail;
+			Cell.UsesSingleLineMode = true;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableTextField.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using AppKit;
 using CoreGraphics;
 using Foundation;
@@ -59,14 +59,10 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private void SetDefaultTextProperties ()
 		{
-			this.label = new NSTextField {
+			this.label = new PropertyTextField {
 				AccessibilityElement = false,
 				BackgroundColor = NSColor.Clear,
 				Bordered = false,
-				Cell = {
-					LineBreakMode = NSLineBreakMode.TruncatingTail,
-					UsesSingleLineMode = true,
-				},
 				ControlSize = NSControlSize.Small,
 				Editable = false,
 				Font = NSFont.FromFontName (PropertyEditorControl.DefaultFontName, PropertyEditorControl.DefaultPropertyLabelFontSize),

--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -81,7 +81,10 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private UnfocusableTextField label = new UnfocusableTextField {
 			Alignment = NSTextAlignment.Right,
-			TranslatesAutoresizingMaskIntoConstraints = false
+			Cell = {
+				LineBreakMode = NSLineBreakMode.TruncatingHead,
+			},
+			TranslatesAutoresizingMaskIntoConstraints = false,
 		};
 
 #if DEBUG // Currently only used to highlight which controls haven't been implemented

--- a/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
@@ -22,7 +22,7 @@ namespace Xamarin.PropertyEditing.Mac
 			NSControlSize controlSize = NSControlSize.Small;
 			TranslatesAutoresizingMaskIntoConstraints = false;
 
-			this.propertyObjectName = new NSTextField {
+			this.propertyObjectName = new PropertyTextField {
 				ControlSize = controlSize,
 				PlaceholderString = LocalizationResources.ObjectNamePlaceholder,
 				TranslatesAutoresizingMaskIntoConstraints = false,

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -21,22 +21,32 @@ namespace Xamarin.PropertyEditing.Mac
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
 			this.comboBox = new FocusableComboBox {
-				TranslatesAutoresizingMaskIntoConstraints = false,
+				AllowsExpansionToolTips = true,
 				BackgroundColor = NSColor.Clear,
-				StringValue = String.Empty,
+				Cell = {
+					LineBreakMode = NSLineBreakMode.TruncatingTail,
+					UsesSingleLineMode = true,
+				},
 				ControlSize = NSControlSize.Small,
-				Font = NSFont.FromFontName(DefaultFontName, DefaultFontSize),
+				Font = NSFont.FromFontName (DefaultFontName, DefaultFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+				StringValue = String.Empty,
 			};
 
 			this.comboBox.SelectionChanged += (sender, e) => {
-				ViewModel.ValueName = comboBox.SelectedValue.ToString ();
+				ViewModel.ValueName = this.comboBox.SelectedValue.ToString ();
 			};
 
 			this.popUpButton = new NSPopUpButton {
-				TranslatesAutoresizingMaskIntoConstraints = false,
-				StringValue = String.Empty,
+				AllowsExpansionToolTips = true,
+				Cell = {
+					LineBreakMode = NSLineBreakMode.TruncatingTail,
+					UsesSingleLineMode = true,
+				},
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.FromFontName (DefaultFontName, DefaultFontSize),
+				TranslatesAutoresizingMaskIntoConstraints = false,
+				StringValue = String.Empty,
 			};
 
 			popupButtonList = new NSMenu ();

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -27,7 +27,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public StringEditorControl (IHostResourceProvider hostResource)
 			: base (hostResource)
 		{
-			this.stringEditor = new NSTextField {
+			this.stringEditor = new PropertyTextField {
 				BackgroundColor = NSColor.Clear,
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.FromFontName (DefaultFontName, DefaultFontSize),

--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Controls\ObjectEditorControl.cs" />
     <Compile Include="Controls\TypeSelectorControl.cs" />
     <Compile Include="Controls\TypeSelectorWindow.cs" />
+    <Compile Include="Controls\Custom\PropertyTextField.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controls\" />


### PR DESCRIPTION
…sExpansionToolTips by default.

Fixes: #531 

<img width="236" alt="screen shot 2019-02-13 at 14 53 39" src="https://user-images.githubusercontent.com/271363/52720666-f2b89780-2f9f-11e9-95e9-60d5dbc91dbb.png">
