### PR TITLE
Object editor / type selector fixes

### DIFF
--- a/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ObjectPropertyViewModel.cs
@@ -164,7 +164,9 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 						try {
 							selectedType = await args.SelectedType;
- 						} catch (OperationCanceledException) {
+							if (selectedType == null)
+								return;
+						} catch (OperationCanceledException) {
 							return;
 						}
 					}


### PR DESCRIPTION
 - Fixes a crasher if you canceled type selection in windows (behavior changed when mac changed it to an async)
 - Fixes "Show all assemblies includes blank categories" #522