### PR TITLE
Enabled must be set for ReadOnly to look and behave correctly. Als…

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -94,8 +94,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void SetEnabled ()
 		{
-			XEditor.Editable = ViewModel.Property.CanWrite;
-			YEditor.Editable = ViewModel.Property.CanWrite;
+			XEditor.Enabled = ViewModel.Property.CanWrite;
+			YEditor.Enabled = ViewModel.Property.CanWrite;
 		}
 
 		protected override void UpdateAccessibilityValues ()

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -150,10 +150,10 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void SetEnabled ()
 		{
-			XEditor.Editable = ViewModel.Property.CanWrite;
-			YEditor.Editable = ViewModel.Property.CanWrite;
-			WidthEditor.Editable = ViewModel.Property.CanWrite;
-			HeightEditor.Editable = ViewModel.Property.CanWrite;
+			XEditor.Enabled = ViewModel.Property.CanWrite;
+			YEditor.Enabled = ViewModel.Property.CanWrite;
+			WidthEditor.Enabled = ViewModel.Property.CanWrite;
+			HeightEditor.Enabled = ViewModel.Property.CanWrite;
 		}
 
 		protected override void UpdateAccessibilityValues ()

--- a/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
@@ -102,6 +102,8 @@ namespace Xamarin.PropertyEditing.Mac
 			// Set our tabable order
 			this.firstKeyView = this.combinableList.KeyAt (0);
 			this.lastKeyView = this.combinableList.KeyAt (this.combinableList.Count - 1);
+
+			SetEnabled ();
 		}
 
 		protected override void UpdateValue ()

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/SpinnerButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/SpinnerButton.cs
@@ -47,7 +47,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private void UpdateImage ()
 		{
-			Image = (this.isMouseOver) ? this.mouseOverImage : this.image;
+			Image = Enabled ? (this.isMouseOver) ? this.mouseOverImage : this.image : this.image;
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -59,6 +59,8 @@ namespace Xamarin.PropertyEditing.Mac
 		public override NSView FirstKeyView => NumericEditor;
 		public override NSView LastKeyView => NumericEditor.DecrementButton;
 
+		private bool CanEnable => ViewModel.Property.CanWrite && (((ViewModel.InputMode != null) && !ViewModel.InputMode.IsSingleValue) || (this.inputModePopup == null));
+
 		protected NSNumberFormatterStyle NumberStyle {
 			get { 
 				return NumericEditor.NumberStyle; }
@@ -91,7 +93,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void SetEnabled ()
 		{
-			NumericEditor.Editable = ViewModel.Property.CanWrite;
+			NumericEditor.Enabled = CanEnable;
 			if (this.inputModePopup != null)
 				this.inputModePopup.Enabled = ViewModel.Property.CanWrite;
 		}
@@ -108,7 +110,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			if (this.underlyingType != null) {
 				NumericEditor.StringValue = ViewModel.Value == null ? string.Empty : ViewModel.Value.ToString ();
-				NumericEditor.Enabled = ((ViewModel.InputMode != null) && !ViewModel.InputMode.IsSingleValue) || (this.inputModePopup == null);
+				NumericEditor.Enabled = CanEnable;
 
 				if (this.inputModePopup != null)
 					this.inputModePopup.SelectItem ((ViewModel.InputMode == null) ? string.Empty : ViewModel.InputMode.Identifier);
@@ -126,7 +128,7 @@ namespace Xamarin.PropertyEditing.Mac
 			NumericEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityNumeric, ViewModel.Property.Name);
 
 			if (this.inputModePopup != null) {
-				this.inputModePopup.AccessibilityEnabled = NumericEditor.Enabled;
+				this.inputModePopup.AccessibilityEnabled = this.inputModePopup.Enabled;
 				this.inputModePopup.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityInpueModeEditor, ViewModel.Property.Name);
 			}
 		}
@@ -174,6 +176,8 @@ namespace Xamarin.PropertyEditing.Mac
 			// If we are reusing the control we'll have to hid the inputMode if this doesn't have InputMode.
 			if (this.inputModePopup != null)
 				this.inputModePopup.Hidden = !ViewModel.HasInputModes;
+
+			SetEnabled ();
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
@@ -100,7 +100,7 @@ namespace Xamarin.PropertyEditing.Mac
 				this.typeDisplay.StringValue = value?.TypeName ?? String.Empty;
 				UpdateValue ();
 				UpdateIcon ();
-				this.propertyObjectName.Editable = !this.viewModel.IsObjectNameReadOnly;
+				this.propertyObjectName.Enabled = !this.viewModel.IsObjectNameReadOnly;
 			}
 		}
 
@@ -133,7 +133,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			this.propertyObjectName.StringValue = this.viewModel.ObjectName ?? string.Empty;
 			this.propertyObjectName.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityObjectName, nameof (viewModel.ObjectName));
-			this.propertyObjectName.Editable = !this.viewModel.IsObjectNameReadOnly;
+			this.propertyObjectName.Enabled = !this.viewModel.IsObjectNameReadOnly;
 		}
 
 		private void OnObjectNameEdited (object sender, EventArgs e)

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -94,6 +94,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void OnViewModelChanged (PropertyViewModel oldModel)
 		{
+			base.OnViewModelChanged (oldModel);
+
+			if (ViewModel == null)
+				return;
+
 			if (!this.dataPopulated) {
 				if (ViewModel.IsConstrainedToPredefined) {
 					this.popupButtonList.RemoveAllItems ();
@@ -136,7 +141,7 @@ namespace Xamarin.PropertyEditing.Mac
 				this.dataPopulated = true;
 			}
 
-			base.OnViewModelChanged (oldModel);
+			SetEnabled ();
 		}
 
 		protected override void UpdateValue ()

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -49,7 +49,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void SetEnabled ()
 		{
-			this.ratioEditor.Editable = ViewModel.Property.CanWrite;
+			this.ratioEditor.Enabled = ViewModel.Property.CanWrite;
 		}
 
 		protected override void UpdateAccessibilityValues ()

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -25,6 +25,8 @@ namespace Xamarin.PropertyEditing.Mac
 		internal NSPopUpButton inputModePopup;
 		private IReadOnlyList<InputMode> viewModelInputModes;
 
+		private bool CanEnable => ViewModel.Property.CanWrite && (((ViewModel.InputMode != null) && !ViewModel.InputMode.IsSingleValue) || (this.inputModePopup == null));
+
 		public StringEditorControl (IHostResourceProvider hostResource)
 			: base (hostResource)
 		{
@@ -56,7 +58,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override void UpdateValue ()
 		{
 			this.stringEditor.StringValue = ViewModel.Value ?? string.Empty;
-			this.stringEditor.Enabled = ((ViewModel.InputMode != null) && !ViewModel.InputMode.IsSingleValue) || (this.inputModePopup == null);
+			this.stringEditor.Enabled = CanEnable;
 			if (this.inputModePopup != null)
 				this.inputModePopup.SelectItem ((ViewModel.InputMode == null) ? string.Empty : ViewModel.InputMode.Identifier);
 		}
@@ -111,6 +113,8 @@ namespace Xamarin.PropertyEditing.Mac
 			// If we are reusing the control we'll have to hid the inputMode if this doesn't have InputMode.
 			if (this.inputModePopup != null)
 				this.inputModePopup.Hidden = !ViewModel.HasInputModes;
+
+			SetEnabled ();
 		}
 
 		protected override void UpdateErrorsDisplayed (IEnumerable errors)
@@ -125,16 +129,17 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override void SetEnabled ()
 		{
-			this.stringEditor.Editable = ViewModel.Property.CanWrite;
+			this.stringEditor.Enabled = CanEnable;
 			if (this.inputModePopup != null)
 				this.inputModePopup.Enabled = ViewModel.Property.CanWrite;
 		}
 
 		protected override void UpdateAccessibilityValues ()
 		{
-			this.stringEditor.AccessibilityEnabled = this.stringEditor.Editable;
+			this.stringEditor.AccessibilityEnabled = this.stringEditor.Enabled;
 			this.stringEditor.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityString, ViewModel.Property.Name);
 			if (this.inputModePopup != null) {
+				this.inputModePopup.AccessibilityEnabled = this.inputModePopup.Enabled;
 				this.inputModePopup.AccessibilityTitle = string.Format (LocalizationResources.AccessibilityInpueModeEditor, ViewModel.Property.Name);
 			}
 		}


### PR DESCRIPTION
…o fixes InputMode enablement. Also turned out that `CombinablePropertyEditor` wasn't setting the checkboxes to `ReadOnly` either.

Fixes #499 

<img width="318" alt="screen shot 2019-02-27 at 17 53 04" src="https://user-images.githubusercontent.com/271363/53511544-96ce3280-3ab8-11e9-951a-ae38d7d14113.png">
