### PR TITLE
Fix 755236

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -1499,7 +1499,7 @@
 						</Grid.ColumnDefinitions>
 
 						<TextBlock Text="{x:Static prop:Resources.CollectionValue}" Grid.Column="0" />
-						<Button Name="launch"  Content="{x:Static prop:Resources.Ellipsis}" MinWidth="20" Grid.Column="1" />
+						<Button Name="launch" AutomationProperties.Name="{Binding Name}" Content="{x:Static prop:Resources.Ellipsis}" MinWidth="20" Grid.Column="1" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
Bind the automation property name for the CollectionEditor launch button to the name of the PropertyEditorControl to satisfy MAS 4.1.2. Siblings are required to have unique names, unless they have a different `LocalizedControlType`