### PR TITLE
[mac] Fix resource selection on non-brushes

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/RequestResource/RequestResourceView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RequestResource/RequestResourceView.cs
@@ -75,14 +75,7 @@ namespace Xamarin.PropertyEditing.Mac
 			var vmType = propertyViewModel.GetType ();
 			var valuePropertyInfo = vmType.GetProperty ("Value");
 			var resourceValue = valuePropertyInfo.GetValue (propertyViewModel);
-			var resourceSelectorPropertyInfo = vmType.GetProperty ("ResourceSelector");
-			var resourceSelector = resourceSelectorPropertyInfo.GetValue (propertyViewModel) as ResourceSelectorViewModel;
-
-			if (resourceSelector != null) {
-				this.resourceSelectorPanel = new RequestResourcePanel (HostResources, resourceSelector, resourceValue);
-			} else {
-				this.resourceSelectorPanel = new RequestResourcePanel (HostResources, new ResourceSelectorViewModel (propertyViewModel.TargetPlatform.ResourceProvider, propertyViewModel.Editors.Select (ed => ed.Target), propertyViewModel.Property), resourceValue);
-			}
+			this.resourceSelectorPanel = new RequestResourcePanel (HostResources, new ResourceSelectorViewModel (propertyViewModel.TargetPlatform.ResourceProvider, propertyViewModel.Editors.Select (ed => ed.Target), propertyViewModel.Property), resourceValue);
 			this.resourceSelectorPanel.ResourceSelected += (sender, e) => {
 				propertyViewModel.Resource = this.resourceSelectorPanel.SelectedResource;
 			};


### PR DESCRIPTION
Originally it was trying to use the ResourceSelector property from BrushPropertyViewModel
but that's intended for a resource request, it's for the inline resource selector. In
trying to do this it didn't do proper null checks for the property, so it'd crash when
it inevitably wasn't found.