### PR TITLE
[Mac] Handle tabbing into the NSOutlineView

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -97,7 +97,7 @@ namespace Xamarin.PropertyEditing.Mac
 			this.propertyTable.BackgroundColor = this.hostResources.GetNamedColor (NamedResources.PadBackgroundColor);
 		}
 
-		public void UpdateExpansions()
+		public void UpdateExpansions ()
 		{
 			((PropertyTableDelegate)this.propertyTable.Delegate).UpdateExpansions (this.propertyTable);
 		}
@@ -111,24 +111,36 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private class FirstResponderOutlineView : NSOutlineView
 		{
-			[Export ("validateProposedFirstResponder:forEvent:")]
-			public bool validateProposedFirstResponder (NSResponder responder, NSEvent ev)
+			private bool tabbedIn;
+			public override bool ValidateProposedFirstResponder (NSResponder responder, NSEvent forEvent)
 			{
 				return true;
 			}
 
 			public override bool BecomeFirstResponder ()
 			{
-				if (base.BecomeFirstResponder ()) {
-					if (SelectedRows.Count == 0 && RowCount > 0)
+				var willBecomeFirstResponder = base.BecomeFirstResponder ();
+				if (willBecomeFirstResponder) {
+					if (SelectedRows.Count == 0 && RowCount > 0) {
 						SelectRow (0, false);
-
-					if (SelectedRows.Count > 0) {
-						var row = GetRowView ((nint) SelectedRows.FirstIndex, false);
+						this.tabbedIn = true;
+						var row = GetRowView ((nint)SelectedRows.FirstIndex, false);
 						return Window.MakeFirstResponder (row.NextValidKeyView);
 					}
 				}
-				return false;
+				this.tabbedIn = false;
+				return willBecomeFirstResponder;
+			}
+
+			public override bool ResignFirstResponder ()
+			{
+				var wilResignFirstResponder = base.ResignFirstResponder ();
+				if (wilResignFirstResponder) {
+					if (SelectedRows.Count > 0 && !this.tabbedIn) {
+						DeselectRow ((nint)SelectedRows.FirstIndex);
+					}
+				}
+				return wilResignFirstResponder;
 			}
 		}
 

--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -17,7 +17,6 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			this.propertyTable = new FirstResponderOutlineView {
 				IndentationPerLevel = 0,
-				RefusesFirstResponder = true,
 				SelectionHighlightStyle = NSTableViewSelectionHighlightStyle.None,
 				HeaderView = null,
 				IntercellSpacing = new CGSize (0, 0)
@@ -116,6 +115,20 @@ namespace Xamarin.PropertyEditing.Mac
 			public bool validateProposedFirstResponder (NSResponder responder, NSEvent ev)
 			{
 				return true;
+			}
+
+			public override bool BecomeFirstResponder ()
+			{
+				if (base.BecomeFirstResponder ()) {
+					if (SelectedRows.Count == 0 && RowCount > 0)
+						SelectRow (0, false);
+
+					if (SelectedRows.Count > 0) {
+						var row = GetRowView ((nint) SelectedRows.FirstIndex, false);
+						return Window.MakeFirstResponder (row.NextValidKeyView);
+					}
+				}
+				return false;
 			}
 		}
 


### PR DESCRIPTION
Fixes - https://github.com/xamarin/Xamarin.PropertyEditing/issues/510
If the outline view is made the first responder we should select
the first row (if there's no selection) and then we should make
it the first responder.