### PR TITLE
Adds tooltips for color swatches on mac

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
@@ -123,7 +123,7 @@ namespace Xamarin.PropertyEditing.Mac
 				l.ColorType = MaterialColorType.Normal;
 				l.IsSelected = color.Value == ViewModel.NormalColor || color.Value == ViewModel.Color;
 				l.Frame = new CGRect (x, 0, width, height);
-				AddToolTip (new CGRect (x, y, width, height), new NSString (color.ToString ()), new IntPtr ());
+				AddToolTip (new CGRect (x, y, width, height), new NSString (color.ToString ()), IntPtr.Zero);
 				normal.AddSublayer (l);
 				x += width;
 			}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
@@ -148,7 +148,7 @@ namespace Xamarin.PropertyEditing.Mac
 				l.ColorType = MaterialColorType.Accent;
 				l.IsSelected = color.Value == ViewModel.AccentColor || color.Value == ViewModel.Color;
 				l.Frame = new CGRect (x, 0, width, height);
-				AddToolTip (new CGRect (x, y, width, height), new NSString (color.ToString ()), new IntPtr ());
+				AddToolTip (new CGRect (x, y, width, height), new NSString (color.ToString ()), IntPtr.Zero);
 				accent.AddSublayer (l);
 				x += width;
 			}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
@@ -89,7 +89,7 @@ namespace Xamarin.PropertyEditing.Mac
 				l.BorderColor = new CGColor (.5f, .5f, .5f, .5f);
 				l.Frame = new CGRect (x, y, width, height);
 				Layer.AddSublayer (l);
-				AddToolTip (new CGRect (x, y, width, height), new NSString(p.Name), new IntPtr());
+				AddToolTip (new CGRect (x, y, width, height), new NSString(p.Name), IntPtr.Zero);
 				x += width + 6;
 				col++;
 				if (col >= 10) {

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/MaterialView.cs
@@ -1,9 +1,11 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.InteropServices;
 using AppKit;
 using CoreAnimation;
 using CoreGraphics;
+using Foundation;
 using Xamarin.PropertyEditing.Drawing;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -87,6 +89,7 @@ namespace Xamarin.PropertyEditing.Mac
 				l.BorderColor = new CGColor (.5f, .5f, .5f, .5f);
 				l.Frame = new CGRect (x, y, width, height);
 				Layer.AddSublayer (l);
+				AddToolTip (new CGRect (x, y, width, height), new NSString(p.Name), new IntPtr());
 				x += width + 6;
 				col++;
 				if (col >= 10) {
@@ -120,6 +123,7 @@ namespace Xamarin.PropertyEditing.Mac
 				l.ColorType = MaterialColorType.Normal;
 				l.IsSelected = color.Value == ViewModel.NormalColor || color.Value == ViewModel.Color;
 				l.Frame = new CGRect (x, 0, width, height);
+				AddToolTip (new CGRect (x, y, width, height), new NSString (color.ToString ()), new IntPtr ());
 				normal.AddSublayer (l);
 				x += width;
 			}
@@ -144,6 +148,7 @@ namespace Xamarin.PropertyEditing.Mac
 				l.ColorType = MaterialColorType.Accent;
 				l.IsSelected = color.Value == ViewModel.AccentColor || color.Value == ViewModel.Color;
 				l.Frame = new CGRect (x, 0, width, height);
+				AddToolTip (new CGRect (x, y, width, height), new NSString (color.ToString ()), new IntPtr ());
 				accent.AddSublayer (l);
 				x += width;
 			}


### PR DESCRIPTION
I'm not totally confident I used the API correctly, though. Here's some screenshots.

![image](https://user-images.githubusercontent.com/12160725/56989117-8c76f600-6b46-11e9-9849-7fc5fc9924b6.png)

![image](https://user-images.githubusercontent.com/12160725/56989122-91d44080-6b46-11e9-8a82-8ddb80490d92.png)

![image](https://user-images.githubusercontent.com/12160725/56989129-9698f480-6b46-11e9-9ddc-18808d226709.png)
