### PR TITLE
[Mac] Setting the Formatter by default breaks the RatioEditor rendering.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -15,13 +15,8 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
-			this.ratioEditor = new RatioEditor<T> (hostResources) {
-				AllowNegativeValues = false,
-				AllowRatios = true,
-				BackgroundColor = NSColor.Clear,
-				StringValue = string.Empty,
-				TranslatesAutoresizingMaskIntoConstraints = false,
-			};
+			this.ratioEditor = new RatioEditor<T> (hostResources);
+			this.ratioEditor.SetFormatter (null);
 
 			// update the value on keypress
 			this.ratioEditor.ValueChanged += (sender, e) => {

--- a/Xamarin.PropertyEditing.Mac/Extensions.cs
+++ b/Xamarin.PropertyEditing.Mac/Extensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.InteropServices;
+using AppKit;
+using Foundation;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal static class Extensions
+	{
+		internal const string LIBOBJC_DYLIB = "/usr/lib/libobjc.dylib";
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_intptr (IntPtr receiver, IntPtr selector, IntPtr arg1);
+
+		const string selSetFormatter = "setFormatter:";
+		static readonly IntPtr selSetFormatter_Handle = ObjCRuntime.Selector.GetHandle (selSetFormatter);
+
+		internal static void SetFormatter (this NumericSpinEditor control, NSFormatter formatter)
+		{
+			IntPtr pointer = formatter != null ? formatter.Handle : IntPtr.Zero;
+			void_objc_msgSend_intptr (control.NumericEditor.Handle, selSetFormatter_Handle, pointer);
+		}
+	}
+}


### PR DESCRIPTION
The simplest solution would have been to set Formatter property to null, but that blows up :/

So Marius has raised an issue for that on the Mac side here:
https://github.com/xamarin/xamarin-macios/issues/6032

and suggested this workaround
https://gist.github.com/Therzok/f735948ec766d2dca16af958913eef36

Which appears to work.

Fixes #553 