### PR TITLE
[Mac] NeedsPropertyButton maybe false when the EditorViewModel is set.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -16,13 +16,14 @@ namespace Xamarin.PropertyEditing.Mac
 		public EditorViewModel ViewModel
 		{
 			get => EditorView?.ViewModel;
-			set
-			{
+			set {
 				if (EditorView == null)
 					return;
 
 				EditorView.ViewModel = value;
-				PropertyButton.ViewModel = value as PropertyViewModel;
+
+				if (EditorView.NeedsPropertyButton)
+					PropertyButton.ViewModel = value as PropertyViewModel;
 			}
 		}
 


### PR DESCRIPTION
Therefore the PropertyButton would not have been created.

This check stops a possible NRE.