### PR TITLE
[Mac] Fix so that Property Labels truncate to a centre ellipsis.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyContainer.cs
@@ -16,6 +16,7 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.label);
 
 			AddConstraints (new[] {
+				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Left, NSLayoutRelation.GreaterThanOrEqual, this, NSLayoutAttribute.Left, 1, 0f),
 				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, Mac.Layout.GoldenRatioLeft, 0f),
 				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, 18),
 			});
@@ -85,7 +86,7 @@ namespace Xamarin.PropertyEditing.Mac
 		private readonly UnfocusableTextField label = new UnfocusableTextField {
 			Alignment = NSTextAlignment.Right,
 			Cell = {
-				LineBreakMode = NSLineBreakMode.TruncatingHead,
+				LineBreakMode = NSLineBreakMode.TruncatingMiddle,
 			},
 			TranslatesAutoresizingMaskIntoConstraints = false,
 		};


### PR DESCRIPTION
Fixes https://github.com/xamarin/Xamarin.PropertyEditing/issues/486

No Jiggery Pokery required.

<img width="321" alt="Screen Shot 2019-07-29 at 10 56 07" src="https://user-images.githubusercontent.com/271363/62035228-aed4ea00-b1ef-11e9-8cdb-72e69ad08d45.png">
