### PR TITLE
[Windows ] fix controls for DateTime and TimeSpan types

### DIFF
--- a/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
+++ b/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
@@ -97,6 +97,8 @@ namespace Xamarin.PropertyEditing.Windows
 		}
 
 		private static readonly Dictionary<Type, Type> TypeMap = new Dictionary<Type, Type> {
+			{ typeof(PropertyViewModel<DateTime>), typeof(StringEditorControl) },
+			{ typeof(PropertyViewModel<TimeSpan>), typeof(StringEditorControl) },
 			{ typeof(StringPropertyViewModel), typeof(StringEditorControl) },
 			{ typeof(PropertyViewModel<bool?>), typeof(BoolEditorControl) },
 			{ typeof(NumericPropertyViewModel<>), typeof(NumericEditorControl) },


### PR DESCRIPTION
This PR fixes `DateTime` editor for windows.
Regression from https://github.com/xamarin/Xamarin.PropertyEditing/pull/480

**Before**
![Actual](https://user-images.githubusercontent.com/27482193/63274762-08897b00-c2a9-11e9-8ce3-de982d893fbd.PNG)

**After**
![Expected](https://user-images.githubusercontent.com/27482193/63274763-09221180-c2a9-11e9-85cc-2b279a8aea76.png)

