### PR TITLE
Fix incorrect expansion after reuse

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDataSource.cs
@@ -108,9 +108,9 @@ namespace Xamarin.PropertyEditing.Mac
 			return f.Target is PanelGroupViewModel;
 		}
 
-		public NSObject GetFacade (object element)
+		public NSObjectFacade GetFacade (object element)
 		{
-			NSObject facade;
+			NSObjectFacade facade;
 			if (element is PanelGroupViewModel) {
 				if (!this.groupFacades.TryGetValue (element, out facade)) {
 					this.groupFacades[element] = facade = new NSObjectFacade (element);
@@ -121,12 +121,12 @@ namespace Xamarin.PropertyEditing.Mac
 			return facade;
 		}
 
-		public bool TryGetFacade (object element, out NSObject facade)
+		public bool TryGetFacade (object element, out NSObjectFacade facade)
 		{
 			return this.groupFacades.TryGetValue (element, out facade);
 		}
 
 		private readonly PanelViewModel vm;
-		private readonly Dictionary<object, NSObject> groupFacades = new Dictionary<object, NSObject> ();
+		private readonly Dictionary<object, NSObjectFacade> groupFacades = new Dictionary<object, NSObjectFacade> ();
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -31,7 +31,7 @@ namespace Xamarin.PropertyEditing.Mac
 				outlineView.ExpandItem (null, true);
 			} else {
 				foreach (PanelGroupViewModel g in this.dataSource.DataContext.ArrangedEditors) {
-					NSObject item;
+					NSObjectFacade item;
 					if (!this.dataSource.TryGetFacade (g, out item))
 						continue;
 


### PR DESCRIPTION
Fixes an issue where reused open/collapse buttons would sometimes have the wrong visual state. Fixes #610