### PR TITLE
[mac] Fix timing of appearance changes for popovers

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/AutoClosePopOver.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/AutoClosePopOver.cs
@@ -9,7 +9,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public bool CloseOnEnter { get; internal set; }
 
-		public AutoClosePopOver (IHostResourceProvider hostResources) : base ()
+		public AutoClosePopOver (IHostResourceProvider hostResources, NSAppearance effectiveAppearance)
 		{
 			if (hostResources == null)
 				throw new ArgumentNullException (nameof (hostResources));
@@ -19,7 +19,7 @@ namespace Xamarin.PropertyEditing.Mac
 			Behavior = NSPopoverBehavior.Semitransient;
 			CloseOnEnter = true;
 
-			this.SetAppearance (this.hostResources.GetVibrantAppearance (EffectiveAppearance));
+			this.SetAppearance (this.hostResources.GetVibrantAppearance (effectiveAppearance));
 		}
 
 		public override void KeyUp (NSEvent theEvent)

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/BasePopOverControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/BasePopOverControl.cs
@@ -51,9 +51,7 @@ namespace Xamarin.PropertyEditing.Mac
 				NSLayoutConstraint.Create (this.viewTitle, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, PropertyEditorControl.DefaultControlHeight),
 			});
 
-			this.SetAppearance (hostResources.GetVibrantAppearance (EffectiveAppearance));
-
-			ViewDidChangeEffectiveAppearance ();
+			AppearanceChanged ();
 		}
 
 		protected IHostResourceProvider HostResources
@@ -64,6 +62,13 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override void ViewDidChangeEffectiveAppearance ()
 		{
+			base.ViewDidChangeEffectiveAppearance ();
+			AppearanceChanged ();
+		}
+
+		protected void AppearanceChanged()
+		{
+			this.SetAppearance (HostResources.GetVibrantAppearance (EffectiveAppearance));
 			this.viewTitle.TextColor = HostResources.GetNamedColor (NamedResources.DescriptionLabelColor);
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyButton.cs
@@ -256,7 +256,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Appearance = EffectiveAppearance
 			};
 
-			var customExpressionPopOver = new AutoClosePopOver(this.hostResources) {
+			var customExpressionPopOver = new AutoClosePopOver (this.hostResources, EffectiveAppearance) {
 				CloseOnEnter = false,
 				ContentViewController = new NSViewController (null, null) { View = customExpressionView },
 			};
@@ -272,7 +272,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Appearance = EffectiveAppearance
 			};
 
-			var resourceSelectorPopOver = new AutoClosePopOver(this.hostResources) {
+			var resourceSelectorPopOver = new AutoClosePopOver (this.hostResources, EffectiveAppearance) {
 				ContentViewController = new NSViewController (null, null) { View = requestResourceView },
 			};
 


### PR DESCRIPTION
The popovers had their appearance set later, but weren't updating their
vibrant appearance so they were using the light appearance still.

Fixes #604