### PR TITLE
[mac] Don't autosize the editor panel

### DIFF
--- a/Xamarin.PropertyEditing.Mac.Standalone/Main.storyboard
+++ b/Xamarin.PropertyEditing.Mac.Standalone/Main.storyboard
@@ -679,7 +679,7 @@
                         <subviews>
                             <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Iru-Rx-5Kw" customClass="PropertyEditorPanel">
                                 <rect key="frame" x="0.0" y="0.0" width="314" height="451"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </customView>
                             <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p4n-Th-xBf">
                                 <rect key="frame" x="4" y="457" width="302" height="24"/>

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -142,8 +142,6 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private void Initialize ()
 		{
-			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
-
 			this.header = new DynamicBox (HostResourceProvider, NamedResources.PanelTabBackground) {
 				ContentViewMargins = new CGSize (0, 0),
 				ContentView = new NSView ()


### PR DESCRIPTION
The view adding the panel as a subview should control how it's sized,
not the panel itself.