### PR TITLE
[mac] Ignore change events if no resources

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/BrushTabViewController.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/BrushTabViewController.cs
@@ -29,11 +29,7 @@ namespace Xamarin.PropertyEditing.Mac
 				PlaceholderString = Properties.Resources.SearchResourcesTitle,
 			};
 
-			this.filterResource.Changed += (sender, e) => {
-				ViewModel.ResourceSelector.FilterText = this.filterResource.Cell.Title;
-				this.resource.ReloadData ();
-			};
-
+			this.filterResource.Changed += OnResourceFilterChanged;
 			this.filterResource.Hidden = true;
 
 			TabStack.AddView (this.filterResource, NSStackViewGravity.Leading);
@@ -194,5 +190,14 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private NSSearchField filterResource;
 		private ResourceBrushViewController resource;
+
+		private void OnResourceFilterChanged (object sender, EventArgs e)
+		{
+			if (ViewModel.ResourceSelector == null)
+				return;
+
+			ViewModel.ResourceSelector.FilterText = this.filterResource.Cell.Title;
+			this.resource.ReloadData ();
+		}
 	}
 }


### PR DESCRIPTION
Seems like we might be getting chang events even when not visible so let's ignore them
if we don't actually have a resource selector. The search box gets added regardless to
simplify putting it at the end.