### PR TITLE
Fix resource/no resource brush swapping

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/BrushTabViewController.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/BrushTabViewController.cs
@@ -59,7 +59,7 @@ namespace Xamarin.PropertyEditing.Mac
 			existing.IntersectWith (this.brushTypeTable.Keys);
 
 			var removed = new HashSet<CommonBrushType> (this.brushTypeTable.Keys);
-			removed.ExceptWith (existing);
+			removed.ExceptWith (ViewModel?.BrushTypes.Values ?? Array.Empty<CommonBrushType>());
 
 			foreach (var item in removed.Select (t => new { Type = t, Tab = TabView.Items[this.brushTypeTable[t]] }).ToArray ()) {
 				RemoveTabViewItem (item.Tab);
@@ -137,7 +137,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 			if (this.brushTypeTable.TryGetValue (ViewModel.SelectedBrushType, out int index)) {
 				SelectedTabViewItemIndex = index;
-			}
+				this.filterResource.Hidden = ViewModel.SelectedBrushType != CommonBrushType.Resource;
+			} else
+				this.filterResource.Hidden = true;
 
 			this.inhibitSelection = false;
 		}

--- a/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
@@ -70,6 +70,13 @@ namespace Xamarin.PropertyEditing.Tests.MockControls
 				colorSpaces: new[] { "RGB", "sRGB" });
 			AddProperty<CommonBrush> (this.brushPropertyInfo);
 
+			AddProperty<CommonBrush> (new MockBrushPropertyInfo (
+				name: "SolidBrushNoResource",
+				valueSources: ValueSources.Default | ValueSources.Local,
+				category: null,
+				canWrite: true
+			));
+
 			this.materialDesignBrushPropertyInfo = new MockBrushPropertyInfo (
 				name: "MaterialDesignBrush",
 				category: null,

--- a/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/BrushPropertyViewModel.cs
@@ -34,7 +34,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 
 			if (allowedBrushTypes.Contains (CommonBrushType.NoBrush)) types.Add (Resources.NoBrush, CommonBrushType.NoBrush);
 			if (allowedBrushTypes.Contains (CommonBrushType.Solid)) types.Add (Resources.SolidBrush, CommonBrushType.Solid);
-			if (allowedBrushTypes.Contains (CommonBrushType.Resource)) types.Add (Resources.ResourceBrush, CommonBrushType.Resource);
+			if (allowedBrushTypes.Contains (CommonBrushType.Resource) && property.ValueSources.HasFlag (ValueSources.Resource))
+				types.Add (Resources.ResourceBrush, CommonBrushType.Resource);
 
 			if (platform.SupportsMaterialDesign && allowedBrushTypes.Contains (CommonBrushType.MaterialDesign)) {
 				types.Insert (2, Resources.MaterialDesignColorBrush, CommonBrushType.MaterialDesign);


### PR DESCRIPTION
Fixes some issues around reusing the brush tabbed view between properties that do and don't support resources.