### PR TITLE
Adds a mechanism in PredefinedValues to allow handle separator string values

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -39,14 +39,22 @@ namespace Xamarin.PropertyEditing.Mac
 
 				this.popupButtonList.RemoveAllItems ();
 				foreach (var item in ViewModel.PossibleValues) {
-					this.popupButtonList.AddItem (new NSMenuItem (item));
+					if (!string.IsNullOrEmpty (ViewModel.SeparatorString) && ViewModel.SeparatorString == item) {
+						this.popupButtonList.AddItem (NSMenuItem.SeparatorItem);
+					} else {
+						this.popupButtonList.AddItem (new NSMenuItem (item));
+					}
 				}
 			} else {
 				RequireComboBox ();
 
 				this.comboBox.RemoveAll ();
 				foreach (var item in ViewModel.PossibleValues) {
-					this.comboBox.Add (new NSString (item));
+					if (!string.IsNullOrEmpty (ViewModel.SeparatorString) && ViewModel.SeparatorString == item) {
+						this.comboBox.Add (NSMenuItem.SeparatorItem);
+					} else {
+						this.comboBox.Add (new NSString (item));
+					}
 				}
 			}
 

--- a/Xamarin.PropertyEditing/IHavePredefinedValues.cs
+++ b/Xamarin.PropertyEditing/IHavePredefinedValues.cs
@@ -21,6 +21,8 @@ namespace Xamarin.PropertyEditing
 		/// </remarks>
 		bool IsValueCombinable { get; }
 
+		string SeparatorString { get; }
+
 		IReadOnlyDictionary<string, TValue> PredefinedValues { get; }
 	}
 }

--- a/Xamarin.PropertyEditing/Reflection/ReflectionEnumPropertyInfo.cs
+++ b/Xamarin.PropertyEditing/Reflection/ReflectionEnumPropertyInfo.cs
@@ -44,6 +44,8 @@ namespace Xamarin.PropertyEditing.Reflection
 			get;
 		}
 
+		public string SeparatorString { get; }
+
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 		public override async Task SetValueAsync<TValue> (object target, TValue value)
 		{

--- a/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
@@ -41,6 +41,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 			set { SetValueName (value); }
 		}
 
+		public string SeparatorString => this.predefinedValues.SeparatorString;
+
 		public bool IsConstrainedToPredefined => this.predefinedValues.IsConstrainedToPredefined;
 
 		protected override TValue CoerceValue (TValue validationValue)


### PR DESCRIPTION
In VS4Mac we have some PredefinedValues that include dividers to make more clear the selection of items for the user.

![image](https://user-images.githubusercontent.com/1587480/66136987-a7b9c600-e5fc-11e9-8182-b2475ecffd3e.png)

This is how it feels now.

![image](https://user-images.githubusercontent.com/1587480/66137720-c9677d00-e5fd-11e9-8b19-165fa651052e.png)

Fixes #644 
