### PR TITLE
[Core] Don't assume default is default(TValue)

### DIFF
--- a/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
@@ -16,13 +16,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 				throw new ArgumentException (nameof(property) + " did not have predefined values", nameof(property));
 
 			var list = new List<string> (this.predefinedValues.PredefinedValues.Keys);
-			// If we're constrained but can't use the default, we need a blank to represent default
-			if (this.predefinedValues.IsConstrainedToPredefined) {
-				if (!property.ValueSources.HasFlag (ValueSources.Default) || !TryGetValueName (default(TValue), out string defaultName)) {
-					if (!list.Contains (String.Empty)) {
-						this.supportUnset = true;
-						list.Insert (0, String.Empty);
-					}
+			// If we're constrained but can't use the default, we need a blank to represent unset
+			if (IsConstrainedToPredefined && !property.ValueSources.HasFlag (ValueSources.Default)) {
+				if (!list.Contains (String.Empty)) {
+					this.supportUnset = true;
+					list.Insert (0, String.Empty);
 				}
 			}
 


### PR DESCRIPTION
This removes a seeming requirement that the default value of a
predefiend values constrained property be the default of the type.

A object editor that properly supports default will return a default
value that is in the list of predefined values. Resetting the value does
not attempt to use the default value and instead simply passes Unset, so
there's no need for the default value to need to be known.