### PR TITLE
[Core] Support refreshing resources

### DIFF
--- a/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
@@ -11,6 +11,8 @@ namespace Xamarin.PropertyEditing.Tests
 	public class MockResourceProvider
 		: IResourceProvider
 	{
+		public event EventHandler<ResourcesChangedEventArgs> ResourcesChanged;
+
 		public bool CanCreateResources => true;
 
 		public Task<ResourceCreateError> CheckNameErrorsAsync (object target, ResourceSource source, string name)

--- a/Xamarin.PropertyEditing/IResourceProvider.cs
+++ b/Xamarin.PropertyEditing/IResourceProvider.cs
@@ -8,6 +8,8 @@ namespace Xamarin.PropertyEditing
 {
 	public interface IResourceProvider
 	{
+		event EventHandler<ResourcesChangedEventArgs> ResourcesChanged;
+
 		/// <summary>
 		/// Gets whether or not the resource provider can create resources.
 		/// </summary>
@@ -81,6 +83,27 @@ namespace Xamarin.PropertyEditing
 		/// Gets or sets whether the error message is just a warning, thereby not preventing creation
 		/// </summary>
 		public bool IsWarning
+		{
+			get;
+		}
+	}
+
+	public class ResourcesChangedEventArgs
+		: EventArgs
+	{
+		public ResourcesChangedEventArgs ()
+		{
+		}
+
+		public ResourcesChangedEventArgs (ResourceSource source)
+		{
+			if (source == null)
+				throw new ArgumentNullException (nameof(source));
+
+			Source = source;
+		}
+
+		public ResourceSource Source
 		{
 			get;
 		}

--- a/Xamarin.PropertyEditing/ViewModels/ResourceSelectorViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ResourceSelectorViewModel.cs
@@ -21,6 +21,8 @@ namespace Xamarin.PropertyEditing.ViewModels
 				throw new ArgumentNullException (nameof (property));
 
 			Provider = provider;
+			provider.ResourcesChanged += OnResourcesChanged;
+
 			this.targets = targets.ToArray();
 			Property = property;
 			UpdateResources();
@@ -168,6 +170,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 				return false;
 
 			return true;
+		}
+
+		private void OnResourcesChanged (object sender, EventArgs e)
+		{
+			UpdateResources ();
 		}
 
 		private async void UpdateResources ()


### PR DESCRIPTION
While most resource UIs have a popup or window that doesn't really
require a live refresh, the brush resource tab does have a persistent
list so it needs to be able to update. Since the view model is shared,
we get the former for free anyway.