### PR TITLE
Add simple resource selector

### DIFF
--- a/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockResourceProvider.cs
@@ -55,7 +55,7 @@ namespace Xamarin.PropertyEditing.Tests
 		public Task<IReadOnlyList<Resource>> GetResourcesAsync (object target, IPropertyInfo property, CancellationToken cancelToken)
 		{
 			return Task.FromResult<IReadOnlyList<Resource>> (this.resources.SelectMany (g => g)
-				.Where (r => property.Type.IsAssignableFrom (r.GetType().GetGenericArguments()[0]) && (!(r.Source is ObjectResourceSource ors) || ReferenceEquals (target, ors.Target)))
+				.Where (r => (property.Type == typeof(Resource) || property.Type.IsAssignableFrom (r.GetType().GetGenericArguments()[0])) && (!(r.Source is ObjectResourceSource ors) || ReferenceEquals (target, ors.Target)))
 				.ToList());
 		}
 
@@ -145,7 +145,9 @@ namespace Xamarin.PropertyEditing.Tests
 				new Resource<CommonSolidBrush> (SystemResourcesSource, "CHighlightBrush", new CommonSolidBrush (51, 153, 255)),
 				new Resource<CommonSolidBrush> (SystemResourcesSource, "CTransparentBrush", new CommonSolidBrush (0, 0, 0, 0)),
 				new Resource<CommonColor> (SystemResourcesSource, "ControlTextColor", new CommonColor (0, 0, 0)),
-				new Resource<CommonColor> (SystemResourcesSource, "HighlightColor", new CommonColor (51, 153, 255))
+				new Resource<CommonColor> (SystemResourcesSource, "HighlightColor", new CommonColor (51, 153, 255)),
+
+				new Resource<string> (SystemResourcesSource, "StringResource", "StringResourceValue")
 			},
 
 			new ObservableGrouping<ResourceSource, Resource> (ApplicationResourcesSource) {

--- a/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
@@ -41,6 +41,7 @@ namespace Xamarin.PropertyEditing.Tests.MockControls
 			AddProperty<CommonRectangle> ("Rectangle", ReadWrite);
 			AddProperty<CommonRatio> ("Ratio", ReadWrite);
 			AddProperty<CommonThickness> ("Thickness", ReadWrite);
+			AddProperty<Resource> ("Resource", ReadWrite, valueSources: ValueSources.Default | ValueSources.Resource);
 			AddProperty<object> ("Object", ReadWrite);
 			AddProperty<IList> ("Collection", ReadWrite);
 			AddProperty<ITypeInfo> ("Type", ReadWrite, realType: typeof(Type).ToTypeInfo());

--- a/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
+++ b/Xamarin.PropertyEditing.Windows/EditorPropertySelector.cs
@@ -113,6 +113,8 @@ namespace Xamarin.PropertyEditing.Windows
 			{ typeof(TypePropertyViewModel), typeof(TypeEditorControl) },
 			{ typeof(CollectionPropertyViewModel), typeof(CollectionEditor) },
 			{ typeof(RatioViewModel), typeof(RatioEditorControl) },
+			{ typeof(ResourcePropertyViewModel), typeof(SimpleResourceEditorControl) },
+
 		};
 	}
 }

--- a/Xamarin.PropertyEditing.Windows/SimpleResourceEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/SimpleResourceEditorControl.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Xamarin.PropertyEditing.Windows
+{
+	internal class SimpleResourceEditorControl
+		: PropertyEditorControl
+	{
+	}
+}

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -75,6 +75,16 @@
 		</Setter>
 	</Style>
 
+	<Style TargetType="{x:Type local:SimpleResourceEditorControl}">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type local:SimpleResourceEditorControl}">
+					<local:ComboBoxEx x:Name="ComboBox" ItemsSource="{Binding Selector.Resources}" DisplayMemberPath="Name" SelectedValue="{Binding Resource,Mode=TwoWay}" VerticalContentAlignment="Center" AutomationProperties.Name="{Binding Name,Mode=OneTime}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
 	<Style TargetType="{x:Type local:Spinner}">
 		<Setter Property="Template">
 			<Setter.Value>

--- a/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
+++ b/Xamarin.PropertyEditing.Windows/Xamarin.PropertyEditing.Windows.csproj
@@ -112,6 +112,7 @@
     <Compile Include="ResourceSelectorWindow.xaml.cs">
       <DependentUpon>ResourceSelectorWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="SimpleResourceEditorControl.cs" />
     <Compile Include="Spinner.cs" />
     <Compile Include="TextBoxEx.cs" />
     <Compile Include="ToggleButtonEx.cs" />

--- a/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PropertiesViewModel.cs
@@ -650,11 +650,11 @@ namespace Xamarin.PropertyEditing.ViewModels
 			{ typeof(CommonThickness), (tp,p,e,v) => new ThicknessPropertyViewModel (tp, p, e, v) },
 			{ typeof(IList), (tp,p,e,v) => new CollectionPropertyViewModel (tp, p ,e, v) },
 			{ typeof(BindingSource), (tp,p,e,v) => new PropertyViewModel<BindingSource> (tp, p, e, v) },
-			{ typeof(Resource), (tp,p,e,v) => new PropertyViewModel<Resource> (tp, p, e, v) },
 			{ typeof(FilePath), (tp,p,e,v) => new PropertyViewModel<FilePath> (tp, p, e, v) },
 			{ typeof(object), (tp,p,e,v) => new ObjectPropertyViewModel (tp, p, e, v) },
 			{ typeof(ITypeInfo), (tp,p,e,v) => new TypePropertyViewModel (tp, p, e, v) },
 			{ typeof(CommonRatio), (tp, p, e, v) => new RatioViewModel (tp, p, e, v) },
+			{ typeof(Resource), (tp, p, e, v) => new ResourcePropertyViewModel (tp, p, e, v) }
 		};
 	}
 }

--- a/Xamarin.PropertyEditing/ViewModels/ResourcePropertyViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/ResourcePropertyViewModel.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Xamarin.PropertyEditing.ViewModels
+{
+	internal class ResourcePropertyViewModel
+		: PropertyViewModel<Resource>
+	{
+		public ResourcePropertyViewModel (TargetPlatform platform, IPropertyInfo property, IEnumerable<IObjectEditor> editors, PropertyVariation variation = null)
+			: base (platform, property, editors, variation)
+		{
+			UpdateResourceSelector();
+		}
+
+		public ResourceSelectorViewModel Selector
+		{
+			get { return this.selector; }
+			private set
+			{
+				if (this.selector == value)
+					return;
+
+				this.selector = value;
+				OnPropertyChanged();
+			}
+		}
+
+		protected override void OnEditorsChanged (object sender, NotifyCollectionChangedEventArgs e)
+		{
+			base.OnEditorsChanged (sender, e);
+			UpdateResourceSelector();
+		}
+
+		private ResourceSelectorViewModel selector;
+
+		private void UpdateResourceSelector ()
+		{
+			if (Property == null)
+				return;
+
+			Selector = new ResourceSelectorViewModel (TargetPlatform.ResourceProvider, Editors.Select (oe => oe.Target), Property);
+		}
+	}
+}


### PR DESCRIPTION
![2019-10-07_15-29-03](https://user-images.githubusercontent.com/156582/66342478-82d49400-e917-11e9-83a4-9b7249875ba8.gif)

This adds a simple drop down selector for properties that are reported as `Resource` types. Setting the value here will pass resource as the value source as it would if you selected it from the resource selector. The `IResourceProvider` will still need to handle returning the proper resources for properties of this type.