### PR TITLE
[Mac] Tweaks for a more consistent UX

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -32,13 +32,14 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.openCollection);
 
 			AddConstraints (new[] {
-				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1, 0),
+				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1, 0),
 				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1, 0),
 				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1, 0),
-				NSLayoutConstraint.Create (this.openCollection, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this.label, NSLayoutAttribute.Trailing, 1, 12),
+				NSLayoutConstraint.Create (this.label, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.openCollection, NSLayoutAttribute.Left, 1, -4),
+
+				NSLayoutConstraint.Create (this.openCollection, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1f, 0),
 				NSLayoutConstraint.Create (this.openCollection, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1, 0),
-				NSLayoutConstraint.Create (this.openCollection, NSLayoutAttribute.Width, NSLayoutRelation.GreaterThanOrEqual, 1, 70),
-				NSLayoutConstraint.Create (this.openCollection, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1, -6)
+				NSLayoutConstraint.Create (this.openCollection, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1, DefaultButtonWidth),
 			});
 
 			AppearanceChanged ();

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
@@ -8,6 +8,11 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }
 
+		public FocusablePopUpButton ()
+		{
+			Cell.LineBreakMode = NSLineBreakMode.TruncatingMiddle;
+		}
+
 		public override bool BecomeFirstResponder ()
 		{
 			var willBecomeFirstResponder = base.BecomeFirstResponder ();

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/PropertyTextField.cs
@@ -8,7 +8,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public PropertyTextField ()
 		{
 			AllowsExpansionToolTips = true;
-			Cell.LineBreakMode = NSLineBreakMode.TruncatingTail;
+			Cell.LineBreakMode = NSLineBreakMode.TruncatingMiddle;
 			Cell.UsesSingleLineMode = true;
 		}
 
@@ -26,7 +26,7 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public PropertyTextFieldCell ()
 		{
-			LineBreakMode = NSLineBreakMode.TruncatingTail;
+			LineBreakMode = NSLineBreakMode.TruncatingMiddle;
 			UsesSingleLineMode = true;
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -136,12 +136,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 					AddSubview (this.inputModePopup);
 					this.editorInputModeConstraint = NSLayoutConstraint.Create (NumericEditor, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.inputModePopup, NSLayoutAttribute.Left, 1, -4);
-					this.AddConstraints (new[] {
+					AddConstraints (new[] {
 						this.editorInputModeConstraint,
 						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this,  NSLayoutAttribute.CenterY, 1f, 0f),
 						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Right, 1f, 0f),
-						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 80f),
-						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Height, NSLayoutRelation.Equal, NumericEditor, NSLayoutAttribute.Height, 1f, 0),
+						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, DefaultButtonWidth),
 					});
 				}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ObjectEditorControl.cs
@@ -26,16 +26,17 @@ namespace Xamarin.PropertyEditing.Mac
 			this.createObject.Activated += OnNewPressed;
 			AddSubview (this.createObject);
 
-			this.buttonConstraint = NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Trailing, 1f, 12);
+			//this.buttonConstraint = NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Trailing, 1f, 12);
 
 			AddConstraints (new[] {
-				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1f, 0f),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 0f),
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1, 0),
-				this.buttonConstraint,
-				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1, 0).WithPriority (NSLayoutPriority.DefaultLow),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.createObject, NSLayoutAttribute.Left, 1, -4),
+
+				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1f, 0),
 				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
-				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Width, NSLayoutRelation.GreaterThanOrEqual, 1f, 70f),
+				NSLayoutConstraint.Create (this.createObject, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, DefaultButtonWidth),
 			});
 		}
 
@@ -93,7 +94,6 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private readonly UnfocusableTextField typeLabel;
 		private readonly NSButton createObject;
-		private readonly NSLayoutConstraint buttonConstraint;
 
 		private void OnCreateInstanceExecutableChanged (object sender, EventArgs e)
 		{
@@ -108,11 +108,9 @@ namespace Xamarin.PropertyEditing.Mac
 		private void UpdateTypeLabel ()
 		{
 			if (ViewModel.ValueType == null) {
-				this.typeLabel.StringValue = String.Empty;
-				this.buttonConstraint.Active = false;
+				this.typeLabel.StringValue = $"({Properties.Resources.ObjectTypeLabelNone})";
 			} else {
 				this.typeLabel.StringValue = $"({ViewModel.ValueType.Name})";
-				this.buttonConstraint.Active = true;
 			}
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -33,6 +33,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public const int DefaultPropertyLabelFontSize = 11;
 		public const int DefaultDescriptionLabelFontSize = 9;
 		public const string DefaultFontName = ".AppleSystemUIFont";
+		public const float DefaultButtonWidth = 70f;
 		public virtual bool IsDynamicallySized => false;
 
 		PropertyViewModel viewModel;

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -59,7 +59,7 @@ namespace Xamarin.PropertyEditing.Mac
 						this.editorInputModeConstraint,
 						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this,  NSLayoutAttribute.CenterY, 1f, 0f),
 						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this,  NSLayoutAttribute.Right, 1f, 0),
-						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, 80f),
+						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1, DefaultButtonWidth),
 						NSLayoutConstraint.Create (this.inputModePopup, NSLayoutAttribute.Height, NSLayoutRelation.Equal, Entry, NSLayoutAttribute.Height, 1, 0),
 					});
 

--- a/Xamarin.PropertyEditing.Mac/Controls/TypeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TypeEditorControl.cs
@@ -20,22 +20,21 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.typeLabel);
 
 			this.selectType = new FocusableButton {
+				BezelStyle = NSBezelStyle.Rounded,
 				Title = Properties.Resources.Select,
-				BezelStyle = NSBezelStyle.Rounded
 			};
 			this.selectType.Activated += OnSelectPressed;
 			AddSubview (this.selectType);
 
-			this.buttonConstraint = NSLayoutConstraint.Create (this.selectType, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this.typeLabel, NSLayoutAttribute.Trailing, 1f, 12);
-
 			AddConstraints (new[] {
-				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1f, 0f),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1f, 0f),
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, this, NSLayoutAttribute.Height, 1, 0),
-				this.buttonConstraint,
-				NSLayoutConstraint.Create (this.selectType, NSLayoutAttribute.Leading, NSLayoutRelation.Equal, this, NSLayoutAttribute.Leading, 1, 0).WithPriority (NSLayoutPriority.DefaultLow),
+				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.selectType, NSLayoutAttribute.Left, 1, -4),
+
+				NSLayoutConstraint.Create (this.selectType, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1f, 0),
 				NSLayoutConstraint.Create (this.selectType, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1f, 0f),
-				NSLayoutConstraint.Create (this.selectType, NSLayoutAttribute.Width, NSLayoutRelation.GreaterThanOrEqual, 1f, 70f),
+				NSLayoutConstraint.Create (this.selectType, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1f, DefaultButtonWidth),
 			});
 		}
 
@@ -91,7 +90,6 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private readonly UnfocusableTextField typeLabel;
 		private readonly NSButton selectType;
-		private readonly NSLayoutConstraint buttonConstraint;
 
 		private void OnTypeRequested (object sender, TypeRequestedEventArgs e)
 		{
@@ -101,11 +99,9 @@ namespace Xamarin.PropertyEditing.Mac
 		private void UpdateTypeLabel ()
 		{
 			if (ViewModel.Value == null) {
-				this.typeLabel.StringValue = String.Empty;
-				this.buttonConstraint.Active = false;
+				this.typeLabel.StringValue = $"({Properties.Resources.ObjectTypeLabelNone})";
 			} else {
 				this.typeLabel.StringValue = $"({ViewModel.Value.Name})";
-				this.buttonConstraint.Active = true;
 			}
 		}
 

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -191,7 +191,7 @@ namespace Xamarin.PropertyEditing.Mac
 				NSLayoutConstraint.Create (this.tabStack, NSLayoutAttribute.Bottom, NSLayoutRelation.Equal, this.header, NSLayoutAttribute.Bottom, 1, 0),
 				NSLayoutConstraint.Create (this.tabStack, NSLayoutAttribute.Right, NSLayoutRelation.LessThanOrEqual, this.propertyFilter, NSLayoutAttribute.Left, 1, 0),
 
-				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.header, NSLayoutAttribute.Right, 1, -15),
+				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this.header, NSLayoutAttribute.Right, 1, -19),
 				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1, 150),
 				NSLayoutConstraint.Create (this.propertyFilter, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this.header, NSLayoutAttribute.CenterY, 1, 0),
 

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -1468,5 +1468,11 @@ namespace Xamarin.PropertyEditing.Properties {
                 return ResourceManager.GetString("AccessibilityBindingAddValueConverterCancel", resourceCulture);
             }
         }
+        
+        public static string ObjectTypeLabelNone {
+            get {
+                return ResourceManager.GetString("ObjectTypeLabelNone", resourceCulture);
+            }
+        }
     }
 }

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -1036,5 +1036,8 @@
   <data name="AccessibilityBindingAddValueConverterCancel" xml:space="preserve">
     <value>This button will cancel the changes you have made in the Add Value Converter Editor.</value>
     <comment>Text to inform the user that this button will cancel the changes you have made in the Add Value Converter Editor</comment>
+  </data>  
+  <data name="ObjectTypeLabelNone" xml:space="preserve">
+    <value>None</value>
   </data>
 </root>


### PR DESCRIPTION
Before:
<img width="235" alt="Screen Shot 2019-10-24 at 20 06 48" src="https://user-images.githubusercontent.com/271363/67517282-2e147580-f69a-11e9-9cb1-bc20ba0abff3.png">


Fixes - https://github.com/xamarin/Xamarin.PropertyEditing/issues/667
Fixes - https://github.com/xamarin/Xamarin.PropertyEditing/issues/625

After:
<img width="237" alt="Screen Shot 2019-10-16 at 16 24 28" src="https://user-images.githubusercontent.com/271363/66934192-0a19ba00-f032-11e9-863c-e1a8b1e41b92.png">
