### PR TITLE
[Mac] CustomExpressionView always set editorControl

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/CustomExpressionView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CustomExpressionView.cs
@@ -33,12 +33,12 @@ namespace Xamarin.PropertyEditing.Mac
 			NSControl editorControl = null;
 			PropertyInfo customAutocompleteItemsPropertyInfo = vmType.GetProperty (AutocompleteItemsString);
 			if (customAutocompleteItemsPropertyInfo.GetValue (viewModel) is ObservableCollectionEx<string> values) {
-				if (values != null && values.Count > 0) {
+				if (values != null && values.Count > 0)
 					editorControl = new AutocompleteComboBox (hostResources, viewModel, values, previewCustomExpressionPropertyInfo);
-				} else {
-					editorControl = new NSTextField ();
-				}
 			}
+
+			if (editorControl == null)
+				editorControl = new NSTextField ();
 
 			editorControl.TranslatesAutoresizingMaskIntoConstraints = false;
 			editorControl.StringValue = (string)value ?? string.Empty;


### PR DESCRIPTION
This prevents editorControl from ever being null