### PR TITLE
Adds manual focus chain to views instead expect automatic behaviour from window

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/DynamicBox.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/DynamicBox.cs
@@ -6,6 +6,8 @@ namespace Xamarin.PropertyEditing.Mac
 	internal class DynamicBox
 		: NSBox
 	{
+		public override bool AcceptsFirstResponder () => false;
+
 		public DynamicBox (IHostResourceProvider hostResources, string fillName = null, string borderName = null)
 		{
 			if (hostResources == null)

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableScrollView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableScrollView.cs
@@ -1,0 +1,9 @@
+﻿using AppKit;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	class UnfocusableScrollView : NSScrollView
+	{
+		public override bool AcceptsFirstResponder () => false;
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableStackView.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/UnfocusableStackView.cs
@@ -1,0 +1,9 @@
+﻿using AppKit;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	class UnfocusableStackView : NSStackView
+	{
+		public override bool AcceptsFirstResponder () => false;
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -105,6 +105,7 @@ namespace Xamarin.PropertyEditing.Mac
 				if (this.viewModel != null) {
 					this.viewModel.PropertyChanged += OnVmPropertyChanged;
 
+					TabButton lastArrangeMode = null;
 					for (int i = 0; i < this.viewModel.ArrangeModes.Count; i++) {
 						var item = this.viewModel.ArrangeModes[i];
 						string imageName = GetIconName (item.ArrangeMode);
@@ -121,6 +122,14 @@ namespace Xamarin.PropertyEditing.Mac
 						arrangeMode.AccessibilityTitle = string.Format (Properties.Resources.ArrangeByButtonName, item.ArrangeMode.ToString());
 
 						this.tabStack.AddView (arrangeMode, NSStackViewGravity.Top);
+
+						if (i == this.viewModel.ArrangeModes.Count - 1) {
+							arrangeMode.NextKeyView = propertyFilter;
+						}
+						if (lastArrangeMode != null) {
+							lastArrangeMode.NextKeyView = arrangeMode;
+						}
+						lastArrangeMode = arrangeMode;
 					}
 				}
 			}
@@ -182,6 +191,7 @@ namespace Xamarin.PropertyEditing.Mac
 				TranslatesAutoresizingMaskIntoConstraints = false
 			};
 			AddSubview (this.propertyList);
+			propertyFilter.NextKeyView = propertyList;
 
 			this.AddConstraints (new[] {
 				NSLayoutConstraint.Create (this.header, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 0),

--- a/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyEditorPanel.cs
@@ -13,6 +13,8 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	public partial class PropertyEditorPanel : NSView
 	{
+		public override bool AcceptsFirstResponder () => false;
+
 		public PropertyEditorPanel ()
 		{
 			this.hostResources = new HostResourceProvider ();
@@ -167,7 +169,7 @@ namespace Xamarin.PropertyEditing.Mac
 			this.propertyFilter.AccessibilityEnabled = true;
 			this.propertyFilter.AccessibilityTitle = Properties.Resources.AccessibilityPropertyFilter;
 
-			this.tabStack = new NSStackView {
+			this.tabStack = new UnfocusableStackView {
 				Orientation = NSUserInterfaceLayoutOrientation.Horizontal,
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				EdgeInsets = new NSEdgeInsets (0, 0, 0, 0)

--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -13,6 +13,9 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		internal const string PropertyEditorColId = "PropertyEditors";
 
+		public override bool AcceptsFirstResponder () => true;
+		public override bool BecomeFirstResponder () => Window.MakeFirstResponder (propertyTable);
+
 		public PropertyList ()
 		{
 			this.propertyTable = new FirstResponderOutlineView {

--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -122,6 +122,16 @@ namespace Xamarin.PropertyEditing.Mac
 				return true;
 			}
 
+			private const string disclosureKey = "NSOutlineViewDisclosureButtonKey";
+			public override NSView MakeView (string identifier, NSObject owner)
+			{
+				NSView view = base.MakeView (identifier, owner);
+				if (identifier == disclosureKey && view is NSButton btn) {
+					btn.RefusesFirstResponder = true;
+				}
+				return view;
+			}
+
 			public override bool BecomeFirstResponder ()
 			{
 				var willBecomeFirstResponder = base.BecomeFirstResponder ();

--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -27,7 +27,7 @@ namespace Xamarin.PropertyEditing.Mac
 			var propertyEditors = new NSTableColumn (PropertyEditorColId);
 			this.propertyTable.AddColumn (propertyEditors);
 
-			this.scrollView = new NSScrollView {
+			this.scrollView = new UnfocusableScrollView {
 				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable,
 				HasHorizontalScroller = false,
 				HasVerticalScroller = true,


### PR DESCRIPTION
In VS4Mac the autocalculation of the keyviewloop chain is not well done by the gtkquarz window, and because this we need to ensure NextKeyView are correctly set in the views.

![9DUbofnfVY](https://user-images.githubusercontent.com/1587480/67560563-6dcf7180-f71b-11e9-9f92-cf2267983bca.gif)
