### PR TITLE
[mac] fixes object editor crash

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/ObjectEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ObjectEditorControl.cs
@@ -44,6 +44,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override NSView LastKeyView => this.createObject;
 
+		public override NSWindow Window => base.Window ?? TableView?.Window;
+
 		protected override void UpdateValue ()
 		{
 		}


### PR DESCRIPTION
Context [AB#966531](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/966531)

**Testing**

- Xamarin.PropertyEditing.Mac.Standalone
- load `Mock1`
- in the filter write `obj`
- click on `New` button

**Before**

Crash http://recordit.co/BNq03qy7Vm

**After**
![image](https://user-images.githubusercontent.com/27482193/68212851-706b7a00-ffeb-11e9-9a39-722f254ff5c8.png)
https://recordit.co/szQoFrX0PI


