### PR TITLE
Fix a11y bug 999307

### DIFF
--- a/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
+++ b/Xamarin.PropertyEditing.Tests/MockControls/MockSampleControl.cs
@@ -37,6 +37,7 @@ namespace Xamarin.PropertyEditing.Tests.MockControls
 				});
 			AddProperty<FlagsNoValues> ("FlagsNoValues", ReadWrite, canWrite: true, flag: true);
 			AddProperty<FlagsWithValues> ("FlagsWithValues", ReadWrite, canWrite: true, flag: true);
+			AddProperty<FlagsWithValues> ("prefix:FlagsWithColonInLabel", ReadWrite, canWrite: true, flag: true);
 			AddProperty<CommonPoint> ("Point", ReadWrite, isUncommon: true);
 			AddProperty<CommonSize> ("Size", ReadWrite, isUncommon: true);
 			AddProperty<CommonRectangle> ("Rectangle", ReadWrite);

--- a/Xamarin.PropertyEditing.Windows/CombinablePredefinedValuesEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/CombinablePredefinedValuesEditorControl.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Automation;
+using Xamarin.PropertyEditing.ViewModels;
 
 namespace Xamarin.PropertyEditing.Windows
 {
@@ -14,6 +16,25 @@ namespace Xamarin.PropertyEditing.Windows
 		{
 			DefaultStyleKeyProperty.OverrideMetadata (typeof (CombinablePredefinedValuesEditor), new FrameworkPropertyMetadata (typeof (CombinablePredefinedValuesEditor)));
 			FocusableProperty.OverrideMetadata (typeof(CombinablePredefinedValuesEditor), new FrameworkPropertyMetadata (false));
+		}
+
+		public override void OnApplyTemplate ()
+		{
+			base.OnApplyTemplate ();
+
+			// Windows has the surprising behavior that when an automation group (like a group of combinable checkboxes)
+			// has a colon in the name, the group label is not read by the narrator. This causes a problem for the Android
+			// designer, which has property names like "app:layout_anchorGravity". We work around this by replacing the
+			// colon with a space in the group's automation name.
+			var propertyPresenter = this.FindParent<PropertyPresenter> ();
+			if (propertyPresenter != null) {
+				var name = (propertyPresenter.DataContext as PropertyViewModel)?.Name;
+
+				if (name != null && name.Contains (":", StringComparison.Ordinal)) {
+					var automationName = name.Replace (':', ' ');
+					AutomationProperties.SetName (propertyPresenter, automationName);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Windows has the surprising behavior that when an automation group (like a group of combinable checkboxes) has a colon in the name, the group label is not read by the narrator. This causes a problem for the Android designer, which has property names like "app:layout_anchorGravity". We work around this by replacing the colon with a space in the group's automation name.