### PR TITLE
[mac] Use more reliable row removed notice

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -55,14 +55,6 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 		}
 
-		public override void ViewWillMoveToSuperview (NSView newSuperview)
-		{
-			if (newSuperview == null)
-				ViewModel = null;
-
-			base.ViewWillMoveToSuperview (newSuperview);
-		}
-
 #if DEBUG // Currently only used to highlight which controls haven't been implemented
 		public NSColor LabelTextColor {
 			set { LabelControl.TextColor = value; }

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -184,6 +184,13 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 		}
 
+		public override void DidRemoveRowView (NSOutlineView outlineView, NSTableRowView rowView, nint row)
+		{
+			if (rowView.Subviews[0] is EditorContainer ec) {
+				ec.ViewModel = null;
+			}
+		}
+
 		public override nfloat GetRowHeight (NSOutlineView outlineView, NSObject item)
 		{
 			EditorViewModel vm;


### PR DESCRIPTION
This method seems far more reliable for noticing when rows are removed so we can use it instead of changing to null superview (which sometimes it doesn't do). This fixes 966531.