### PR TITLE
[win] fixes collection editor window

### DIFF
--- a/Xamarin.PropertyEditing.Windows/CollectionEditorWindow.xaml.cs
+++ b/Xamarin.PropertyEditing.Windows/CollectionEditorWindow.xaml.cs
@@ -12,8 +12,8 @@ namespace Xamarin.PropertyEditing.Windows
 	{
 		public CollectionEditorWindow (IEnumerable<ResourceDictionary> mergedResources)
 		{
-			Resources.MergedDictionaries.AddItems (mergedResources);
 			InitializeComponent ();
+			Resources.MergedDictionaries.AddItems (mergedResources);
 			DataContextChanged += OnDataContextChanged;
 		}
 


### PR DESCRIPTION
Context [AB#1009752](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1009752)

Component initialization call before adding `MergedDictionaries`. Because `InitializeComponent` sets resources from the xaml file.
https://recordit.co/vQ846hHnp2

| Before| After |
|:----------:|:-------------:|
| ![Screenshot_2](https://user-images.githubusercontent.com/27482193/70074186-4073be80-160b-11ea-99bb-cabe7125830a.png) |  ![Screenshot_1](https://user-images.githubusercontent.com/27482193/70074184-4073be80-160b-11ea-9b9d-4411d516784e.png) | 
