### PR TITLE
[Mac] Add missing placeholder resource for type filtering.

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/TypeSelectorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TypeSelectorControl.cs
@@ -62,7 +62,7 @@ namespace Xamarin.PropertyEditing.Mac
 			this.filter = new NSSearchField {
 				AccessibilityEnabled = true,
 				AccessibilityTitle = Properties.Resources.AccessibilityTypeSelectorSearch,
-				PlaceholderString = "Filter",
+				PlaceholderString = Properties.Resources.FilterTypePlaceholder,
 				TranslatesAutoresizingMaskIntoConstraints = false,
 			};
 			this.filter.Changed += OnFilterChanged;

--- a/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
+++ b/Xamarin.PropertyEditing/Properties/Resources.Designer.cs
@@ -1474,5 +1474,11 @@ namespace Xamarin.PropertyEditing.Properties {
                 return ResourceManager.GetString("ObjectTypeLabelNone", resourceCulture);
             }
         }
+        
+        public static string FilterTypePlaceholder {
+            get {
+                return ResourceManager.GetString("FilterTypePlaceholder", resourceCulture);
+            }
+        }
     }
 }

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -1040,4 +1040,8 @@
   <data name="ObjectTypeLabelNone" xml:space="preserve">
     <value>None</value>
   </data>
+  <data name="FilterTypePlaceholder" xml:space="preserve">
+    <value>Filter Types</value>
+    <comment>Placeholder for filter type control</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #688 

And https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1032219

As well as this field, we also need the localisation team to also localise the `PropertyFilterLabel` resource as that seems to have been missed across all, if not most languages.