### PR TITLE
[VS] Show focus via focus rect, not color, for choice buttons

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -202,7 +202,7 @@
 		<Setter Property="BorderThickness" Value="1" />
 		<Setter Property="Padding" Value="4,2,4,2" />
 		<Setter Property="Margin" Value="1,0,0,0" />
-		<Setter Property="FocusVisualStyle" Value="{x:Null}" />
+		<Setter Property="FocusVisualStyle" Value="{DynamicResource GenericVisualFocusStyle}" />
 		<Setter Property="ToolTip" Value="{Binding Tooltip}" />
 		<Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
 		<Setter Property="AutomationProperties.HelpText" Value="{Binding Tooltip}" />
@@ -224,9 +224,6 @@
 			<Trigger Property="IsMouseOver" Value="True">
 				<Setter Property="Background" Value="{DynamicResource ToggleItemMouseOverBackgroundBrush}" />
 				<Setter Property="Foreground" Value="{DynamicResource ToggleItemMouseOverForegroundBrush}" />
-			</Trigger>
-			<Trigger Property="IsFocused" Value="True">
-				<Setter Property="Background" Value="{DynamicResource ToggleItemMouseOverBackgroundBrush}" />
 			</Trigger>
 			<Trigger Property="IsPressed" Value="True">
 				<Setter Property="BorderBrush" Value="{DynamicResource ToggleItemPressedBorderBrush}" />

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -225,6 +225,9 @@
 				<Setter Property="Background" Value="{DynamicResource ToggleItemMouseOverBackgroundBrush}" />
 				<Setter Property="Foreground" Value="{DynamicResource ToggleItemMouseOverForegroundBrush}" />
 			</Trigger>
+			<Trigger Property="IsFocused" Value="True">
+				<Setter Property="Background" Value="{DynamicResource ToggleItemMouseOverBackgroundBrush}" />
+			</Trigger>
 			<Trigger Property="IsPressed" Value="True">
 				<Setter Property="BorderBrush" Value="{DynamicResource ToggleItemPressedBorderBrush}" />
 				<Setter Property="Background" Value="{DynamicResource ToggleItemPressedBackgroundBrush}" />


### PR DESCRIPTION
This fixes AB#1003978
Previously the choice buttons (used for picking brush type) showed focus via a different background color. But that color difference wasn't sufficiently obvious, per a11y testing, especially in the blue theme. Our UI designer suggested that we should show a focus rect to fix this.

Old UI (blue theme; note that the 3rd button has the focus):
![image](https://user-images.githubusercontent.com/245892/72956414-ad831500-3d6d-11ea-8697-9df26c5f08f9.png)


Updated UI (blue theme):
![image](https://user-images.githubusercontent.com/245892/72956232-f4243f80-3d6c-11ea-8e1f-2fee1e381114.png)

Updated UI (dark theme):
![image](https://user-images.githubusercontent.com/245892/72956295-35b4ea80-3d6d-11ea-9237-688825743608.png)
