### PR TITLE
Adds a new mechanism to open Modal dialogs over VS4Mac context

### DIFF
--- a/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
+++ b/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
@@ -41,7 +41,7 @@ namespace Xamarin.PropertyEditing.Mac
 			var result = (NSModalResponse)(int)NSApplication.SharedApplication.RunModalForWindow (window);
 
 			//after run modal our FocusedWindow is null, we set the parent again
-			parentWindow.MakeKeyAndOrderFront (parentWindow);
+			parentWindow?.MakeKeyAndOrderFront (parentWindow);
 
 			System.Threading.Tasks.Task.Delay (defaultDelayTime).ContinueWith (t => {
 				responseHandler?.Invoke (result);

--- a/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
+++ b/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
@@ -1,0 +1,51 @@
+//
+// CocoaHelpers.cs
+//
+// Author:
+//       jmedrano <josmed@microsoft.com>
+//
+// Copyright (c) 2020 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using AppKit;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	public static class CocoaHelpers
+	{
+		public static void RunModalForWindow (NSWindow window, NSWindow parentWindow = null, Action<NSModalResponse> responseHandler = null, int defaultDelayTime = 100)
+		{
+			//HACK: Because VS4Mac is a GTK application try force set to NSApplication.SharedApplication.RunModalForWindow 
+			//breaks the current focused window. Try only focus the ID is not enought, because our IDE on get focus (gtk) will override the current
+			//focused element, then launch a task to allow the IDE to get the focus and wait for synchcontext to focus the correct view.
+			if (parentWindow == null)
+				parentWindow = NSApplication.SharedApplication.KeyWindow;
+
+			var result = (NSModalResponse)(int)NSApplication.SharedApplication.RunModalForWindow (window);
+
+			//after run modal our FocusedWindow is null, we set the parent again
+			parentWindow.MakeKeyAndOrderFront (parentWindow);
+
+			System.Threading.Tasks.Task.Delay (defaultDelayTime).ContinueWith (t => {
+				responseHandler?.Invoke (result);
+			}, System.Threading.Tasks.TaskScheduler.FromCurrentSynchronizationContext ());
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
+++ b/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
@@ -30,13 +30,12 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	public static class CocoaHelpers
 	{
-		public static void RunModalForWindow (NSWindow window, NSWindow parentWindow = null, Action<NSModalResponse> responseHandler = null, int defaultDelayTime = 100)
+		public static void RunModalForWindow (NSWindow window, NSView controlToFocusWhenWindowClosed, Action<NSModalResponse> responseHandler = null, int defaultDelayTime = 100)
 		{
 			//HACK: Because VS4Mac is a GTK application try force set to NSApplication.SharedApplication.RunModalForWindow 
 			//breaks the current focused window. Try only focus the ID is not enought, because our IDE on get focus (gtk) will override the current
 			//focused element, then launch a task to allow the IDE to get the focus and wait for synchcontext to focus the correct view.
-			if (parentWindow == null)
-				parentWindow = NSApplication.SharedApplication.KeyWindow;
+			var	parentWindow = NSApplication.SharedApplication.KeyWindow;
 
 			var result = (NSModalResponse)(int)NSApplication.SharedApplication.RunModalForWindow (window);
 
@@ -45,6 +44,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			System.Threading.Tasks.Task.Delay (defaultDelayTime).ContinueWith (t => {
 				responseHandler?.Invoke (result);
+				parentWindow?.MakeFirstResponder (controlToFocusWhenWindowClosed);
 			}, System.Threading.Tasks.TaskScheduler.FromCurrentSynchronizationContext ());
 		}
 	}

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionEditorWindow.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionEditorWindow.cs
@@ -94,20 +94,5 @@ namespace Xamarin.PropertyEditing.Mac
 			this.collectionEditor.ViewModel = null;
 			Close ();
 		}
-
-		public static void EditCollection (NSAppearance appearance, IHostResourceProvider hostResources, CollectionPropertyViewModel collectionVm)
-		{
-			var w = new CollectionEditorWindow (hostResources, collectionVm) {
-				Appearance = appearance
-			};
-
-			var result = (NSModalResponse)(int)NSApplication.SharedApplication.RunModalForWindow (w);
-			if (result != NSModalResponse.OK) {
-				collectionVm.CancelCommand.Execute (null);
-				return;
-			}
-
-			collectionVm.CommitCommand.Execute (null);
-		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -36,7 +36,7 @@ namespace Xamarin.PropertyEditing.Mac
 						ViewModel.CancelCommand.Execute (null);
 					else
 						ViewModel.CommitCommand.Execute (null);
-					parentWindow.MakeFirstResponder (this.openCollection);
+					parentWindow?.MakeFirstResponder (this.openCollection);
 				});
 			};
 

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -25,18 +25,15 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 
 			this.openCollection.Activated += (o, e) => {
-				NSWindow parentWindow = NSApplication.SharedApplication.KeyWindow;
-
 				var w = new CollectionEditorWindow (hostResources, ViewModel) {
 					Appearance = EffectiveAppearance
 				};
 
-				CocoaHelpers.RunModalForWindow (w, parentWindow, responseHandler: result => {
+				CocoaHelpers.RunModalForWindow (w, this.openCollection, responseHandler: result => {
 					if (result != NSModalResponse.OK)
 						ViewModel.CancelCommand.Execute (null);
 					else
 						ViewModel.CommitCommand.Execute (null);
-					parentWindow?.MakeFirstResponder (this.openCollection);
 				});
 			};
 

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -25,8 +25,19 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 
 			this.openCollection.Activated += (o, e) => {
-				CollectionEditorWindow.EditCollection (EffectiveAppearance, HostResources, ViewModel);
-				Window.MakeFirstResponder (this.openCollection);
+				NSWindow parentWindow = NSApplication.SharedApplication.KeyWindow;
+
+				var w = new CollectionEditorWindow (hostResources, ViewModel) {
+					Appearance = EffectiveAppearance
+				};
+
+				CocoaHelpers.RunModalForWindow (w, parentWindow, responseHandler: result => {
+					if (result != NSModalResponse.OK)
+						ViewModel.CancelCommand.Execute (null);
+					else
+						ViewModel.CommitCommand.Execute (null);
+					parentWindow.MakeFirstResponder (this.openCollection);
+				});
 			};
 
 			AddSubview (this.openCollection);


### PR DESCRIPTION
This issue was hitting some problems. Use NSApplication.SharedApplication.RunModalForWindow (window) over a GTK application has very odd behaviours with our hacks. In this case, it sets null the current NSApplication.SharedApplciation.MainWindow, and that's the reason because the focused ring is not visible and not receiving the keyevents.

Additional to this, the IDE has a default behaviour of focus the Document selected when it gets the focus, and this behaviour it was executed after the Proppy call. That's because now we wait until SynchronizationContext to execute our proppy focus call.


![v6G5ysrIob](https://user-images.githubusercontent.com/1587480/85452352-1845b000-b59b-11ea-8a04-94472476677c.gif)

The fix doesn't breaks the Standalone

![yh08ZMuOVJ](https://user-images.githubusercontent.com/1587480/85458287-3b735e00-b5a1-11ea-9718-286ea810925c.gif)


Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1002094

