### PR TITLE
Removes current hack to focus caller view on calling a RunModalForWindow

### DIFF
--- a/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
+++ b/Xamarin.PropertyEditing.Mac/CocoaHelpers.cs
@@ -30,22 +30,11 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	public static class CocoaHelpers
 	{
-		public static void RunModalForWindow (NSWindow window, NSView controlToFocusWhenWindowClosed, Action<NSModalResponse> responseHandler = null, int defaultDelayTime = 100)
+		public static NSModalResponse RunModalForWindow (NSWindow window, NSWindow parent)
 		{
-			//HACK: Because VS4Mac is a GTK application try force set to NSApplication.SharedApplication.RunModalForWindow 
-			//breaks the current focused window. Try only focus the ID is not enought, because our IDE on get focus (gtk) will override the current
-			//focused element, then launch a task to allow the IDE to get the focus and wait for synchcontext to focus the correct view.
-			var	parentWindow = NSApplication.SharedApplication.KeyWindow;
-
 			var result = (NSModalResponse)(int)NSApplication.SharedApplication.RunModalForWindow (window);
-
-			//after run modal our FocusedWindow is null, we set the parent again
-			parentWindow?.MakeKeyAndOrderFront (parentWindow);
-
-			System.Threading.Tasks.Task.Delay (defaultDelayTime).ContinueWith (t => {
-				responseHandler?.Invoke (result);
-				parentWindow?.MakeFirstResponder (controlToFocusWhenWindowClosed);
-			}, System.Threading.Tasks.TaskScheduler.FromCurrentSynchronizationContext ());
+			parent?.MakeKeyAndOrderFront (parent);
+			return result;
 		}
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -29,12 +29,13 @@ namespace Xamarin.PropertyEditing.Mac
 					Appearance = EffectiveAppearance
 				};
 
-				CocoaHelpers.RunModalForWindow (w, this.openCollection, responseHandler: result => {
-					if (result != NSModalResponse.OK)
-						ViewModel.CancelCommand.Execute (null);
-					else
-						ViewModel.CommitCommand.Execute (null);
-				});
+				var parentWindow = Window;
+
+				var result = CocoaHelpers.RunModalForWindow (w, parentWindow);
+				if (result != NSModalResponse.OK)
+					ViewModel.CancelCommand.Execute (null);
+				else
+					ViewModel.CommitCommand.Execute (null);
 			};
 
 			AddSubview (this.openCollection);


### PR DESCRIPTION
This is a test fixing the real problem from VS4Mac