### PR TITLE
Add Name a11y property to expander

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -80,6 +80,7 @@
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="Background" Value="Transparent" />
 		<Setter Property="Foreground" Value="{DynamicResource ToggleItemForegroundBrush}" />
+		<Setter Property="AutomationProperties.Name" Value="{x:Static prop:Resources.UncommonPropertiesName}" />
 		<Setter Property="ToolTip" Value="{x:Static prop:Resources.UncommonPropertiesTooltip}" />
 		<Setter Property="Template">
 			<Setter.Value>


### PR DESCRIPTION
Set AutomationProperty.Name on the "advanced properties" expander
control (with value "Advanced Properties") for a11y.
Fixes [AB#1214551](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1214551)