### PR TITLE
Don't allow property editor panel to get the focus

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -159,6 +159,7 @@
 	<Style TargetType="local:PropertyEditorPanel">
 		<Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />
 		<Setter Property="Foreground" Value="{DynamicResource PanelForegroundBrush}" />
+		<Setter Property="Focusable" Value="False" />
 		<Setter Property="UseLayoutRounding" Value="True" />
 		<Setter Property="SnapsToDevicePixels" Value="True" />
 		<Setter Property="Template">


### PR DESCRIPTION
Hitting tab should never set focus to the property editor panel itself. Fixed [AB#1251446](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1251446)