### PR TITLE
Bump provisioned dependencies

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
+++ b/Xamarin.PropertyEditing.Mac/Xamarin.PropertyEditing.Mac.csproj
@@ -10,7 +10,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Xamarin.Mac">
-      <HintPath>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll</HintPath>
+      <HintPath>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/64bits/full/Xamarin.Mac.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/bot-provisioning/dependencies.csx
+++ b/bot-provisioning/dependencies.csx
@@ -2,6 +2,7 @@
 
 using static Xamarin.Provisioning.ProvisioningScript;
 
-Item ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/77/e9d3af508e46454389cb29836d19616eae1615c0/MonoFramework-MDK-6.12.0.74.macos10.xamarin.universal.pkg");
-Item ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-6/088c73638ed0f29f310d362789e7d622cd97dc89/28/package/notarized/xamarin.mac-6.18.0.23.pkg");
-Item (XreItem.Xcode_11_5_0).XcodeSelect();
+Item ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2020-02/144/b4a385816ed4f1398d0184c38f19f560e868fd80/MonoFramework-MDK-6.12.0.137.macos10.xamarin.universal.pkg");
+Item ("https://bosstoragemirror.blob.core.windows.net/wrench/main/c8b6bc6c85a0067387ee298ef5e7d55992be5f0a/4590608/package/notarized/xamarin.mac-7.11.0.247.pkg");
+
+Xcode ("12.4.0").XcodeSelect();

--- a/provision.sh
+++ b/provision.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 DEFAULT_CSX=
 
 if ! echo "$@" | grep -q 'csx'


### PR DESCRIPTION
Bump provisioned dependencies to match what's currently used
for Designer, getting the latest Xamarin.Mac.

This is needed because the Xamarin.Mac.dll path changed and we
need to update the csproj reference to it accordingly, also done here.