### PR TITLE
Fix edit box focus border contrast

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -2237,8 +2237,14 @@
 						<Trigger Property="Text" Value="{x:Null}">
 							<Setter TargetName="hintContent" Property="Visibility" Value="Visible" />
 						</Trigger>
+						<Trigger Property="IsMouseOver" Value="True">
+							<Setter Property="BorderBrush" Value="{DynamicResource InputMouseOverBorderBrush}" />
+							<Setter Property="Foreground" Value="{DynamicResource InputMouseOverBrush}" />
+						</Trigger>
 						<Trigger Property="IsFocused" Value="True">
 							<Setter TargetName="hintContent" Property="Visibility" Value="Collapsed" />
+							<Setter Property="BorderBrush" Value="{DynamicResource InputMouseOverBorderBrush}" />
+							<Setter Property="Foreground" Value="{DynamicResource InputMouseOverBrush}" />
 						</Trigger>
 					</ControlTemplate.Triggers>
 				</ControlTemplate>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Dark.xaml
@@ -80,9 +80,11 @@
 	<SolidColorBrush x:Key="SearchControlButtonPressedBorderBrush">#FF007ACC</SolidColorBrush>
 	<SolidColorBrush x:Key="SearchControlWatermarkBrush">#FF999999</SolidColorBrush>
 
-	<SolidColorBrush x:Key="InputBackgroundBrush">#333337</SolidColorBrush>
-	<SolidColorBrush x:Key="InputBorderBrush">#434346</SolidColorBrush>
-	<SolidColorBrush x:Key="InputForegroundBrush">#F1F1F1</SolidColorBrush>
+	<SolidColorBrush x:Key="InputBackgroundBrush">#FF333333</SolidColorBrush>
+	<SolidColorBrush x:Key="InputBorderBrush">#FF4D4D4D</SolidColorBrush>
+	<SolidColorBrush x:Key="InputForegroundBrush">#FFFFFFFF</SolidColorBrush>
+	<SolidColorBrush x:Key="InputMouseOverBrush">#FFFFFFFF</SolidColorBrush>
+	<SolidColorBrush x:Key="InputMouseOverBorderBrush">#FF4D4D4D</SolidColorBrush>
 
 	<SolidColorBrush x:Key="PopupBackgroundBrush">#FF1B1B1C</SolidColorBrush>
 	<SolidColorBrush x:Key="PopupForegroundBrush">#FFF1F1F1</SolidColorBrush>

--- a/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/VS.Light.xaml
@@ -79,6 +79,8 @@
 	<SolidColorBrush x:Key="InputBackgroundBrush">#FFFFFFFF</SolidColorBrush>
 	<SolidColorBrush x:Key="InputBorderBrush">#FFCCCEDB</SolidColorBrush>
 	<SolidColorBrush x:Key="InputForegroundBrush">#FF1E1E1E</SolidColorBrush>
+	<SolidColorBrush x:Key="InputMouseOverBrush">#FF1E1E1E</SolidColorBrush>
+	<SolidColorBrush x:Key="InputMouseOverBorderBrush">#FF007ACC</SolidColorBrush>
 
 	<SolidColorBrush x:Key="PopupBackgroundBrush">#FFF6F6F6</SolidColorBrush>
 	<SolidColorBrush x:Key="PopupForegroundBrush">#FF1E1E1E</SolidColorBrush>


### PR DESCRIPTION
Fix [AB#1251444](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1251444). The rule is that the border for edit boxes (and all controls) when focused must have at least a 3:1 contrast difference with the border when unfocused - there must enough contrast difference to make obvious to all that the visual state changed. That wasn't the case for our edit boxes before but is now. Updated to use the same themed border & text colors as the as the Cider colors, used by the WPF designer, which we've kept consistent with in the past.

Checkboxes and buttons already show a dashed outline for a focus rect. That's not the current standard for VS UI controls, but it's what it's always done and is fine from an a11y point of view, since there's even more obvious contrast, so that didn't change here. It was only text boxes that had an a11y problem.