### PR TITLE
Fixes double disclosure triangle in Property panel

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -119,6 +119,8 @@ namespace Xamarin.PropertyEditing.Mac
 				return true;
 			}
 
+			public override CGRect FrameOfOutlineCellAtRow (nint row) => CGRect.Empty;
+
 			public override bool BecomeFirstResponder ()
 			{
 				var willBecomeFirstResponder = base.BecomeFirstResponder ();


### PR DESCRIPTION
Fixes VSTS #1340425: Property pane has double chevrons

old

![image](https://user-images.githubusercontent.com/1587480/127638273-1a29d48a-1d65-40bb-b20f-9122a31aea33.png)

new

<img width="453" alt="CleanShot 2021-07-30 at 12 11 04@2x" src="https://user-images.githubusercontent.com/1587480/127638230-dc32d69f-3e13-487f-b167-ec08dfa7b316.png">
