### PR TITLE
Support PropertyPresenter being unloaded & reloaded

### DIFF
--- a/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
@@ -168,7 +168,6 @@ namespace Xamarin.PropertyEditing.Windows
 		private void OnUnloaded (object sender, RoutedEventArgs e)
 		{
 			IsSubProperty = false;
-			DataContext = null;
 		}
 
 		private void OnDataContextChanged (object sender, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
When the property panel is hidden via the auto-hide button,
controls are unloaded (the Unload event is generated). Then when
it's reshown it's loaded again (Load event). This may be the only
case where controls are loaded after being unloaded. Previously,
the code didn't seem to assume reloads would happen, clearing
out the DataContext on unload. But that seems wrong, as DataContext
isn't reset on the load, which caused controls not to work (all be
blank) in the panel hide/show scenario.

Updated to no longer null out the DataContext on unload. That fixed
this bug and doesn't seem to have any other ill effects.

Fixes [AB#1315193](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1315193)