### PR TITLE
[d17-0-vsmac] Protect against CurrentAppearance NRE

### DIFF
--- a/Xamarin.PropertyEditing.Mac/HostResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Mac/HostResourceProvider.cs
@@ -39,7 +39,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public virtual NSImage GetNamedImage (string name)
 		{
-			if ((CurrentAppearance ?? NSAppearance.CurrentAppearance).Name.ToLower ().Contains ("dark")) {
+			NSAppearance currentAppearance = CurrentAppearance ?? NSAppearance.CurrentAppearance;
+			if (currentAppearance != null && currentAppearance.Name.ToLower ().Contains ("dark")) {
 				bool sel = name.EndsWith ("~sel");
 				if (sel)
 					name = name.Substring (0, name.Length - 4);


### PR DESCRIPTION
Fix [AB#1468252](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1468252)

Apparently there are scenarios where CurrentAppearance is not
set by the client on HostResourceProvider (UITools sets it but
vsmac doesn't currently) nor is NSAppearance.CurrentAppearance
set on the current thread (perhaps the thread is newly
created and AppKit didn't get a chance to set it), causing
bug 1468252.

To protect against that, we check if both are null and in that
case just assume it's light theme rather than generate an NRE.


Backport of #789
