### PR TITLE
Reimplementation UpdateKeyViews() based in ProxyRowResponder

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
@@ -49,7 +49,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			this.textNextResponderDelegate = new BasePathEditordDelegate (this)
 			{
-				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 			this.currentTextField.Delegate = this.textNextResponderDelegate;
 			AddSubview (this.currentTextField);

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
@@ -23,11 +23,35 @@ namespace Xamarin.PropertyEditing.Mac
 		private readonly NSObject[] objects;
 		public override NSObject[] AccessibilityChildren { get => this.objects; }
 
+		private readonly TextNextResponderDelegate textNextResponderDelegate;
+
+		class BasePathEditordDelegate : TextNextResponderDelegate
+		{
+			WeakReference<BasePathEditorControl<T>> weakView;
+
+			public BasePathEditordDelegate (BasePathEditorControl<T> basePathEditorControl)
+			{
+				weakView = new WeakReference<BasePathEditorControl<T>>(basePathEditorControl);
+			}
+
+			public override void Changed (NSNotification notification)
+			{
+				if (this.weakView.TryGetTarget(out BasePathEditorControl<T> t)) {
+					t.StoreCurrentValue ();
+				}
+			}
+		}
+
 		protected BasePathEditorControl (IHostResourceProvider hostResource)
 			: base (hostResource)
 		{
 			this.currentTextField = new TextFieldSmallButtonContainer ();
-			this.currentTextField.Changed += CurrentTextField_Changed;
+
+			this.textNextResponderDelegate = new BasePathEditordDelegate (this)
+			{
+				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+			};
+			this.currentTextField.Delegate = this.textNextResponderDelegate;
 			AddSubview (this.currentTextField);
 
 			#region Reveal handler

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
@@ -25,11 +25,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private readonly TextNextResponderDelegate textNextResponderDelegate;
 
-		class BasePathEditordDelegate : TextNextResponderDelegate
+		class BasePathEditorDelegate : TextNextResponderDelegate
 		{
 			WeakReference<BasePathEditorControl<T>> weakView;
 
-			public BasePathEditordDelegate (BasePathEditorControl<T> basePathEditorControl)
+			public BasePathEditorDelegate (BasePathEditorControl<T> basePathEditorControl)
 			{
 				weakView = new WeakReference<BasePathEditorControl<T>>(basePathEditorControl);
 			}
@@ -47,7 +47,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			this.currentTextField = new TextFieldSmallButtonContainer ();
 
-			this.textNextResponderDelegate = new BasePathEditordDelegate (this)
+			this.textNextResponderDelegate = new BasePathEditorDelegate (this)
 			{
 				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePathEditorControl.cs
@@ -23,9 +23,9 @@ namespace Xamarin.PropertyEditing.Mac
 		private readonly NSObject[] objects;
 		public override NSObject[] AccessibilityChildren { get => this.objects; }
 
-		private readonly TextNextResponderDelegate textNextResponderDelegate;
+		private readonly DelegatedRowTextFieldDelegate textNextResponderDelegate;
 
-		class BasePathEditorDelegate : TextNextResponderDelegate
+		class BasePathEditorDelegate : DelegatedRowTextFieldDelegate
 		{
 			WeakReference<BasePathEditorControl<T>> weakView;
 
@@ -49,7 +49,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			this.textNextResponderDelegate = new BasePathEditorDelegate (this)
 			{
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 			this.currentTextField.Delegate = this.textNextResponderDelegate;
 			AddSubview (this.currentTextField);

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -28,7 +28,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			XEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
+			XEditor.ProxyResponder = new ProxyResponder (this, ProxyRowType.FirstView);
 			XEditor.ValueChanged += OnInputUpdated;
 
 			YLabel = new UnfocusableTextField {
@@ -40,7 +40,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			YEditor.ProxyResponder = new RowProxyResponder  (this, ProxyRowType.LastView);
+			YEditor.ProxyResponder = new ProxyResponder (this, ProxyRowType.LastView);
 			YEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -28,6 +28,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
+			XEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.FirstView);
 			XEditor.ValueChanged += OnInputUpdated;
 
 			YLabel = new UnfocusableTextField {
@@ -39,6 +40,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
+			YEditor.ResponderProxy = new ProxyRowResponder (this, ProxyRowType.LastView);
 			YEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);

--- a/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BasePointEditorControl.cs
@@ -28,7 +28,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			XEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.FirstView);
+			XEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
 			XEditor.ValueChanged += OnInputUpdated;
 
 			YLabel = new UnfocusableTextField {
@@ -40,7 +40,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			YEditor.ResponderProxy = new ProxyRowResponder (this, ProxyRowType.LastView);
+			YEditor.ProxyResponder = new RowProxyResponder  (this, ProxyRowType.LastView);
 			YEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -33,6 +33,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
+			XEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.FirstView);
 			XEditor.ValueChanged += OnInputUpdated;
 
 			YLabel =  new UnfocusableTextField {
@@ -63,6 +64,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
+			HeightEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.LastView);
 			HeightEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -33,7 +33,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			XEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
+			XEditor.ProxyResponder = new ProxyResponder (this, ProxyRowType.FirstView);
 			XEditor.ValueChanged += OnInputUpdated;
 
 			YLabel =  new UnfocusableTextField {
@@ -64,7 +64,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			HeightEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.LastView);
+			HeightEditor.ProxyResponder = new ProxyResponder (this, ProxyRowType.LastView);
 			HeightEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);

--- a/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BaseRectangleEditorControl.cs
@@ -33,7 +33,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			XEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.FirstView);
+			XEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
 			XEditor.ValueChanged += OnInputUpdated;
 
 			YLabel =  new UnfocusableTextField {
@@ -64,7 +64,7 @@ namespace Xamarin.PropertyEditing.Mac
 				BackgroundColor = NSColor.Clear,
 				Value = 0.0f
 			};
-			HeightEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.LastView);
+			HeightEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.LastView);
 			HeightEditor.ValueChanged += OnInputUpdated;
 
 			AddSubview (XLabel);

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -11,7 +11,10 @@ namespace Xamarin.PropertyEditing.Mac
 		public BooleanEditorControl (IHostResourceProvider hostResource)
 			: base (hostResource)
 		{
-			BooleanEditor = new FocusableBooleanButton ();
+			BooleanEditor = new FocusableBooleanButton ()
+			{
+				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+			};
 			BooleanEditor.Title = string.Empty;
 
 			// update the value on 'enter'

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -13,7 +13,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			BooleanEditor = new FocusableBooleanButton ()
 			{
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 			BooleanEditor.Title = string.Empty;
 

--- a/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BooleanEditorControl.cs
@@ -13,7 +13,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			BooleanEditor = new FocusableBooleanButton ()
 			{
-				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 			BooleanEditor.Title = string.Empty;
 

--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -56,7 +56,7 @@ namespace Xamarin.PropertyEditing.Mac
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
-				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 
 			this.popupButtonList = new NSMenu ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -56,6 +56,7 @@ namespace Xamarin.PropertyEditing.Mac
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
+				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
 			};
 
 			this.popupButtonList = new NSMenu ();

--- a/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/BrushEditorControl.cs
@@ -56,7 +56,7 @@ namespace Xamarin.PropertyEditing.Mac
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 
 			this.popupButtonList = new NSMenu ();

--- a/Xamarin.PropertyEditing.Mac/Controls/CharEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CharEditorControl.cs
@@ -15,7 +15,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			var charDelegate = new CharDelegate (viewModel)
 			{
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 			return charDelegate;
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/CharEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CharEditorControl.cs
@@ -15,7 +15,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			var charDelegate = new CharDelegate (viewModel)
 			{
-				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 			return charDelegate;
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/CharEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CharEditorControl.cs
@@ -13,7 +13,11 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override EntryPropertyEditorDelegate<char> CreateDelegate (PropertyViewModel<char> viewModel)
 		{
-			return new CharDelegate (viewModel);
+			var charDelegate = new CharDelegate (viewModel)
+			{
+				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView)
+			};
+			return charDelegate;
 		}
 
 		protected override void UpdateAccessibilityValues ()

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -24,7 +24,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Title = Properties.Resources.CollectionEditButton,
 				BezelStyle = NSBezelStyle.Rounded,
 				AccessibilityEnabled = true,
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView),
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView),
 				AccessibilityHelp = Properties.Resources.AccessibilityCollectionHelp
 			};
 

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -24,6 +24,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Title = Properties.Resources.CollectionEditButton,
 				BezelStyle = NSBezelStyle.Rounded,
 				AccessibilityEnabled = true,
+				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView),
 				AccessibilityHelp = Properties.Resources.AccessibilityCollectionHelp
 			};
 

--- a/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CollectionInlineEditorControl.cs
@@ -24,7 +24,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Title = Properties.Resources.CollectionEditButton,
 				BezelStyle = NSBezelStyle.Rounded,
 				AccessibilityEnabled = true,
-				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView),
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView),
 				AccessibilityHelp = Properties.Resources.AccessibilityCollectionHelp
 			};
 

--- a/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
@@ -92,10 +92,10 @@ namespace Xamarin.PropertyEditing.Mac
 			if (combinableList.Count > 0)
 			{
 				if (firstButton == lastButton) {
-					firstButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
+					firstButton.ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView);
 				} else {
-					firstButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
-					lastButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.LastView);
+					firstButton.ProxyResponder = new ProxyResponder (this, ProxyRowType.FirstView);
+					lastButton.ProxyResponder = new ProxyResponder (this, ProxyRowType.LastView);
 				}
 			}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/CombinablePropertyEditor.cs
@@ -83,8 +83,21 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 
 			// Set our tabable order
-			this.firstKeyView = this.combinableList.KeyAt (0);
-			this.lastKeyView = this.combinableList.KeyAt (this.combinableList.Count - 1);
+			var firstButton = (FocusableBooleanButton) this.combinableList.KeyAt (0);
+			this.firstKeyView = firstButton;
+			
+			var lastButton = (FocusableBooleanButton)this.combinableList.KeyAt (this.combinableList.Count - 1);
+			this.lastKeyView = lastButton;
+
+			if (combinableList.Count > 0)
+			{
+				if (firstButton == lastButton) {
+					firstButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
+				} else {
+					firstButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
+					lastButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.LastView);
+				}
+			}
 
 			SetEnabled ();
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
@@ -5,17 +5,17 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal class ProxyResponderButton : NSButton
 	{
-		public ProxyRowResponder ResponderProxy { get; set; }
+		public RowProxyResponder ProxyResponder { get; set; }
 
 		public override void KeyDown (NSEvent theEvent)
 		{
 			switch (theEvent.KeyCode) {
 			case (int)NSKey.Tab:
-				if (ResponderProxy != null) {
+				if (ProxyResponder != null) {
 					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
-						ResponderProxy.PreviousResponder ();
+						ProxyResponder.PreviousResponder ();
 					} else {
-						ResponderProxy.NextResponder ();
+						ProxyResponder.NextResponder ();
 					}
 				}
 				return;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
@@ -17,8 +17,9 @@ namespace Xamarin.PropertyEditing.Mac
 					} else {
 						ProxyResponder.NextResponder ();
 					}
+					return;
 				}
-				return;
+				break;
 			}
 			base.KeyDown (theEvent);
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
@@ -3,28 +3,6 @@ using AppKit;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	internal class ProxyResponderButton : NSButton
-	{
-		public RowProxyResponder ProxyResponder { get; set; }
-
-		public override void KeyDown (NSEvent theEvent)
-		{
-			switch (theEvent.KeyCode) {
-			case (int)NSKey.Tab:
-				if (ProxyResponder != null) {
-					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
-						ProxyResponder.PreviousResponder ();
-					} else {
-						ProxyResponder.NextResponder ();
-					}
-					return;
-				}
-				break;
-			}
-			base.KeyDown (theEvent);
-		}
-	}
-
 	internal class FocusableBooleanButton : ProxyResponderButton
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableBooleanButton.cs
@@ -3,7 +3,28 @@ using AppKit;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	internal class FocusableBooleanButton : NSButton
+	internal class ProxyResponderButton : NSButton
+	{
+		public ProxyRowResponder ResponderProxy { get; set; }
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			switch (theEvent.KeyCode) {
+			case (int)NSKey.Tab:
+				if (ResponderProxy != null) {
+					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
+						ResponderProxy.PreviousResponder ();
+					} else {
+						ResponderProxy.NextResponder ();
+					}
+				}
+				return;
+			}
+			base.KeyDown (theEvent);
+		}
+	}
+
+	internal class FocusableBooleanButton : ProxyResponderButton
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableButton.cs
@@ -3,7 +3,7 @@ using AppKit;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	internal class FocusableButton : NSButton
+	internal class FocusableButton : ProxyResponderButton
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
@@ -5,17 +5,17 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal class FocusableComboBox : NSComboBox
 	{
-		public ProxyRowResponder ResponderProxy { get; set; }
+		public RowProxyResponder ProxyResponder { get; set; }
 
 		public override void KeyDown (NSEvent theEvent)
 		{
 			switch (theEvent.KeyCode) {
 			case (int)NSKey.Tab:
-				if (ResponderProxy != null) {
+				if (ProxyResponder != null) {
 					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
-						ResponderProxy.PreviousResponder ();
+						ProxyResponder.PreviousResponder ();
 					} else {
-						ResponderProxy.NextResponder ();
+						ProxyResponder.NextResponder ();
 					}
 				}
 				return;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
@@ -5,7 +5,7 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal class FocusableComboBox : NSComboBox
 	{
-		public RowProxyResponder ProxyResponder { get; set; }
+		public ProxyResponder ProxyResponder { get; set; }
 
 		public override void KeyDown (NSEvent theEvent)
 		{

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
@@ -17,8 +17,9 @@ namespace Xamarin.PropertyEditing.Mac
 					} else {
 						ProxyResponder.NextResponder ();
 					}
+					return;
 				}
-				return;
+				break;
 			}
 			base.KeyDown (theEvent);
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusableComboBox.cs
@@ -5,6 +5,24 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal class FocusableComboBox : NSComboBox
 	{
+		public ProxyRowResponder ResponderProxy { get; set; }
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			switch (theEvent.KeyCode) {
+			case (int)NSKey.Tab:
+				if (ResponderProxy != null) {
+					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
+						ResponderProxy.PreviousResponder ();
+					} else {
+						ResponderProxy.NextResponder ();
+					}
+				}
+				return;
+			}
+			base.KeyDown (theEvent);
+		}
+
 		public override bool BecomeFirstResponder ()
 		{
 			var willBecomeFirstResponder = base.BecomeFirstResponder ();

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
@@ -8,7 +8,7 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }
 
-		public ProxyRowResponder ResponderProxy { get; set; }
+		public RowProxyResponder ProxyResponder { get; set; }
 
 		public FocusablePopUpButton ()
 		{
@@ -19,11 +19,11 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			switch (theEvent.KeyCode) {
 			case (int)NSKey.Tab:
-				if (ResponderProxy != null) {
+				if (ProxyResponder != null) {
 					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
-						ResponderProxy.PreviousResponder ();
+						ProxyResponder.PreviousResponder ();
 					} else {
-						ResponderProxy.NextResponder ();
+						ProxyResponder.NextResponder ();
 					}
 				}
 				return;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
@@ -8,9 +8,27 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }
 
+		public ProxyRowResponder ResponderProxy { get; set; }
+
 		public FocusablePopUpButton ()
 		{
 			Cell.LineBreakMode = NSLineBreakMode.TruncatingMiddle;
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			switch (theEvent.KeyCode) {
+			case (int)NSKey.Tab:
+				if (ResponderProxy != null) {
+					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
+						ResponderProxy.PreviousResponder ();
+					} else {
+						ResponderProxy.NextResponder ();
+					}
+				}
+				return;
+			}
+			base.KeyDown (theEvent);
 		}
 
 		public override bool BecomeFirstResponder ()

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
@@ -8,7 +8,7 @@ namespace Xamarin.PropertyEditing.Mac
 	{
 		public override bool CanBecomeKeyView { get { return Enabled; } }
 
-		public RowProxyResponder ProxyResponder { get; set; }
+		public ProxyResponder ProxyResponder { get; set; }
 
 		public FocusablePopUpButton ()
 		{

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/FocusablePopupButton.cs
@@ -25,8 +25,9 @@ namespace Xamarin.PropertyEditing.Mac
 					} else {
 						ProxyResponder.NextResponder ();
 					}
+					return;
 				}
-				return;
+				break;
 			}
 			base.KeyDown (theEvent);
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
@@ -172,10 +172,10 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.numericEditor.AccessibilityTitle = value; }
 		}
 
-		public ProxyRowResponder ResponderProxy
+		public RowProxyResponder ProxyResponder
 		{
-			get => this.numericEditor.ResponderProxy;
-			set => this.numericEditor.ResponderProxy = value;
+			get => this.numericEditor.ProxyResponder;
+			set => this.numericEditor.ProxyResponder = value;
 		}
 
 		public virtual void Reset ()

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
@@ -172,6 +172,12 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.numericEditor.AccessibilityTitle = value; }
 		}
 
+		public ProxyRowResponder ResponderProxy
+		{
+			get => this.numericEditor.ResponderProxy;
+			set => this.numericEditor.ResponderProxy = value;
+		}
+
 		public virtual void Reset ()
 		{
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericSpinEditor.cs
@@ -172,7 +172,7 @@ namespace Xamarin.PropertyEditing.Mac
 			set { this.numericEditor.AccessibilityTitle = value; }
 		}
 
-		public RowProxyResponder ProxyResponder
+		public ProxyResponder ProxyResponder
 		{
 			get => this.numericEditor.ProxyResponder;
 			set => this.numericEditor.ProxyResponder = value;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
@@ -51,7 +51,7 @@ namespace Xamarin.PropertyEditing.Mac
 			Delegate = keyUpDownDelegate;
 		}
 
-		public RowProxyResponder ProxyResponder
+		public ProxyResponder ProxyResponder
 		{
 			get {
 				if (Delegate is KeyUpDownDelegate keydown) {
@@ -172,7 +172,7 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 	}
 
-	internal class KeyUpDownDelegate : TextNextResponderDelegate
+	internal class KeyUpDownDelegate : DelegatedRowTextFieldDelegate
 	{
 		public event EventHandler<bool> KeyArrowUp;
 		public event EventHandler<bool> KeyArrowDown;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
@@ -179,24 +179,28 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override bool DoCommandBySelector (NSControl control, NSTextView textView, Selector commandSelector)
 		{
-			if (!base.DoCommandBySelector(control, textView, commandSelector))
+			//if parent already handles command we break the event chain
+			var parentHandlesCommand = base.DoCommandBySelector (control, textView, commandSelector);
+			if (parentHandlesCommand)
 			{
-				switch (commandSelector.Name) {
-				case "moveUp:":
-					OnKeyArrowUp ();
-					break;
-				case "moveDown:":
-					OnKeyArrowDown ();
-					break;
-				case "moveUpAndModifySelection:":
-					OnKeyArrowUp (true);
-					break;
-				case "moveDownAndModifySelection:":
-					OnKeyArrowDown (true);
-					break;
-				default:
-					return false;
-				}
+				return false;
+			}
+
+			switch (commandSelector.Name) {
+			case "moveUp:":
+				OnKeyArrowUp ();
+				break;
+			case "moveDown:":
+				OnKeyArrowDown ();
+				break;
+			case "moveUpAndModifySelection:":
+				OnKeyArrowUp (true);
+				break;
+			case "moveDownAndModifySelection:":
+				OnKeyArrowDown (true);
+				break;
+			default:
+				return false;
 			}
 
 			return true;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
@@ -54,10 +54,7 @@ namespace Xamarin.PropertyEditing.Mac
 		public ProxyResponder ProxyResponder
 		{
 			get {
-				if (Delegate is KeyUpDownDelegate keydown) {
-					return keydown.ProxyResponder;
-				}
-				return null;
+				return Delegate is KeyUpDownDelegate viewDownDelegate ? viewDownDelegate.ProxyResponder : null;
 			}
 			set
 			{

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
@@ -51,6 +51,22 @@ namespace Xamarin.PropertyEditing.Mac
 			Delegate = keyUpDownDelegate;
 		}
 
+		public ProxyRowResponder ResponderProxy
+		{
+			get {
+				if (Delegate is KeyUpDownDelegate keydown) {
+					return keydown.ResponderProxy;
+				}
+				return null;
+			}
+			set
+			{
+				if (Delegate is KeyUpDownDelegate keydown) {
+					keydown.ResponderProxy = value;
+				}
+			}
+		}
+
 		public override CGSize IntrinsicContentSize => new CGSize(30, 20);
 
 		public override bool ShouldBeginEditing (NSText textObject)
@@ -156,14 +172,16 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 	}
 
-	internal class KeyUpDownDelegate : NSTextFieldDelegate
+	internal class KeyUpDownDelegate : TextNextResponderDelegate
 	{
 		public event EventHandler<bool> KeyArrowUp;
 		public event EventHandler<bool> KeyArrowDown;
 
 		public override bool DoCommandBySelector (NSControl control, NSTextView textView, Selector commandSelector)
 		{
-			switch (commandSelector.Name) {
+			if (!base.DoCommandBySelector(control, textView, commandSelector))
+			{
+				switch (commandSelector.Name) {
 				case "moveUp:":
 					OnKeyArrowUp ();
 					break;
@@ -178,6 +196,7 @@ namespace Xamarin.PropertyEditing.Mac
 					break;
 				default:
 					return false;
+				}
 			}
 
 			return true;

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/NumericTextField.cs
@@ -51,18 +51,18 @@ namespace Xamarin.PropertyEditing.Mac
 			Delegate = keyUpDownDelegate;
 		}
 
-		public ProxyRowResponder ResponderProxy
+		public RowProxyResponder ProxyResponder
 		{
 			get {
 				if (Delegate is KeyUpDownDelegate keydown) {
-					return keydown.ResponderProxy;
+					return keydown.ProxyResponder;
 				}
 				return null;
 			}
 			set
 			{
 				if (Delegate is KeyUpDownDelegate keydown) {
-					keydown.ResponderProxy = value;
+					keydown.ProxyResponder = value;
 				}
 			}
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/ProxyResponderButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/ProxyResponderButton.cs
@@ -4,7 +4,7 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	internal class ProxyResponderButton : NSButton
 	{
-		public RowProxyResponder ProxyResponder { get; set; }
+		public ProxyResponder ProxyResponder { get; set; }
 
 		public override void KeyDown (NSEvent theEvent)
 		{

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/ProxyResponderButton.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/ProxyResponderButton.cs
@@ -1,0 +1,26 @@
+﻿using AppKit;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal class ProxyResponderButton : NSButton
+	{
+		public RowProxyResponder ProxyResponder { get; set; }
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			switch (theEvent.KeyCode) {
+			case (int)NSKey.Tab:
+				if (ProxyResponder != null) {
+					if (theEvent.ModifierFlags.HasFlag(NSEventModifierMask.ShiftKeyMask)) {
+						ProxyResponder.PreviousResponder ();
+					} else {
+						ProxyResponder.NextResponder ();
+					}
+					return;
+				}
+				break;
+			}
+			base.KeyDown (theEvent);
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/TextFieldSmallButtonContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/TextFieldSmallButtonContainer.cs
@@ -6,7 +6,7 @@ using Foundation;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	internal class SmallButton : NSButton
+	internal class SmallButton : ProxyResponderButton
 	{
 		private NSView previousKeyView;
 		public override NSView PreviousKeyView => this.previousKeyView ?? base.PreviousKeyView;

--- a/Xamarin.PropertyEditing.Mac/Controls/EntryPropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EntryPropertyEditor.cs
@@ -44,6 +44,11 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 			AddSubview (Entry);
 
+			Entry.Delegate = new TextNextResponderDelegate ()
+			{
+				ProxyResponder = new RowProxyResponder(this, ProxyRowType.SingleView)
+			};
+
 			RightEdgeConstraint = NSLayoutConstraint.Create (Entry, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1f, 0);
 			AddConstraints (new[] {
 				NSLayoutConstraint.Create (Entry, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this,  NSLayoutAttribute.CenterY, 1f, 0),
@@ -88,7 +93,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			var propertyEditorDelegate = new EntryPropertyEditorDelegate<T> (viewModel)
 			{
-				ProxyResponder = new RowProxyResponder  (this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 			return propertyEditorDelegate;
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/EntryPropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EntryPropertyEditor.cs
@@ -6,26 +6,27 @@ using ObjCRuntime;
 
 namespace Xamarin.PropertyEditing.Mac
 {
-	class TextNextResponderDelegate : NSTextFieldDelegate
+	class DelegatedRowTextFieldDelegate : NSTextFieldDelegate
 	{
-		public RowProxyResponder ProxyResponder { get; set; }
+		public ProxyResponder ProxyResponder { get; set; }
 
 		public override bool DoCommandBySelector (NSControl control, NSTextView textView, Selector commandSelector)
 		{
-			switch (commandSelector.Name) {
-			case "insertTab:":
-				if (ProxyResponder?.NextResponder () ?? false)
-				{
-					return true;
+			if (ProxyResponder != null)
+			{
+				switch (commandSelector.Name) {
+				case "insertTab:":
+					if (ProxyResponder.NextResponder ()) {
+						return true;
+					}
+					break;
+				case "insertBacktab:":
+					if (ProxyResponder.PreviousResponder ()) {
+						return true;
+					}
+					break;
 				}
-				break;
-			case "insertBacktab:":
-				if (ProxyResponder?.PreviousResponder () ?? false)
-				{
-					return true;
-				}
-				break;
-			}
+			} 
 			return false;
 		}
 	}
@@ -44,9 +45,9 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 			AddSubview (Entry);
 
-			Entry.Delegate = new TextNextResponderDelegate ()
+			Entry.Delegate = new DelegatedRowTextFieldDelegate ()
 			{
-				ProxyResponder = new RowProxyResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder(this, ProxyRowType.SingleView)
 			};
 
 			RightEdgeConstraint = NSLayoutConstraint.Create (Entry, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1f, 0);
@@ -93,7 +94,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			var propertyEditorDelegate = new EntryPropertyEditorDelegate<T> (viewModel)
 			{
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 			return propertyEditorDelegate;
 		}
@@ -105,7 +106,7 @@ namespace Xamarin.PropertyEditing.Mac
 	}
 
 	internal class EntryPropertyEditorDelegate<T>
-		: TextNextResponderDelegate
+		: DelegatedRowTextFieldDelegate
 	{
 		public EntryPropertyEditorDelegate (PropertyViewModel<T> viewModel)
 		{

--- a/Xamarin.PropertyEditing.Mac/Controls/EntryPropertyEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EntryPropertyEditor.cs
@@ -8,19 +8,19 @@ namespace Xamarin.PropertyEditing.Mac
 {
 	class TextNextResponderDelegate : NSTextFieldDelegate
 	{
-		public ProxyRowResponder ResponderProxy { get; set; }
+		public RowProxyResponder ProxyResponder { get; set; }
 
 		public override bool DoCommandBySelector (NSControl control, NSTextView textView, Selector commandSelector)
 		{
 			switch (commandSelector.Name) {
 			case "insertTab:":
-				if (ResponderProxy?.NextResponder () ?? false)
+				if (ProxyResponder?.NextResponder () ?? false)
 				{
 					return true;
 				}
 				break;
 			case "insertBacktab:":
-				if (ResponderProxy?.PreviousResponder () ?? false)
+				if (ProxyResponder?.PreviousResponder () ?? false)
 				{
 					return true;
 				}
@@ -88,7 +88,7 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			var propertyEditorDelegate = new EntryPropertyEditorDelegate<T> (viewModel)
 			{
-				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder  (this, ProxyRowType.SingleView)
 			};
 			return propertyEditorDelegate;
 		}

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -132,6 +132,9 @@ namespace Xamarin.PropertyEditing.Mac
 						TranslatesAutoresizingMaskIntoConstraints = false,
 					};
 
+					this.NumericEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
+					this.inputModePopup.ProxyResponder = new RowProxyResponder (this, ProxyRowType.LastView);
+
 					this.inputModePopup.Activated += (o, e) => {
 						var popupButton = o as NSPopUpButton;
 						ViewModel.InputMode = this.viewModelInputModes.FirstOrDefault (im => im.Identifier == popupButton.Title);
@@ -166,7 +169,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private Type underlyingType;
 
-		internal NSPopUpButton inputModePopup;
+		internal FocusablePopUpButton inputModePopup;
 		private IReadOnlyList<InputMode> viewModelInputModes;
 
 		private readonly NSLayoutConstraint editorRightConstraint;

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -18,7 +18,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			NumericEditor = new NumericSpinEditor<T> (hostResources)
 			{
-				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 			NumericEditor.ValueChanged += OnValueChanged;
 

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -16,7 +16,10 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
-			NumericEditor = new NumericSpinEditor<T> (hostResources);
+			NumericEditor = new NumericSpinEditor<T> (hostResources)
+			{
+				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView)
+			};
 			NumericEditor.ValueChanged += OnValueChanged;
 
 			var t = typeof (T);

--- a/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/NumericEditorControl.cs
@@ -18,7 +18,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 			NumericEditor = new NumericSpinEditor<T> (hostResources)
 			{
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 			NumericEditor.ValueChanged += OnValueChanged;
 
@@ -132,8 +132,8 @@ namespace Xamarin.PropertyEditing.Mac
 						TranslatesAutoresizingMaskIntoConstraints = false,
 					};
 
-					this.NumericEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.FirstView);
-					this.inputModePopup.ProxyResponder = new RowProxyResponder (this, ProxyRowType.LastView);
+					this.NumericEditor.ProxyResponder = new ProxyResponder (this, ProxyRowType.FirstView);
+					this.inputModePopup.ProxyResponder = new ProxyResponder (this, ProxyRowType.LastView);
 
 					this.inputModePopup.Activated += (o, e) => {
 						var popupButton = o as NSPopUpButton;

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -74,8 +74,8 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 		}
 
-		private NSComboBox comboBox;
-		private NSPopUpButton popupButton;
+		private FocusableComboBox comboBox;
+		private FocusablePopUpButton popupButton;
 		private NSMenu popupButtonList;
 
 		private NSView firstKeyView;
@@ -115,7 +115,7 @@ namespace Xamarin.PropertyEditing.Mac
 				StringValue = String.Empty,
 				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
-
+			this.popupButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
 			this.popupButtonList = new NSMenu ();
 			this.popupButton.Menu = this.popupButtonList;
 			this.popupButton.Activated += PopupButton_Activated; 
@@ -162,7 +162,7 @@ namespace Xamarin.PropertyEditing.Mac
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				StringValue = String.Empty,
 			};
-
+			this.comboBox.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
 			this.comboBox.SelectionChanged += ComboBox_SelectionChanged;
 
 			AddSubview (this.comboBox);

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -113,7 +113,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				StringValue = String.Empty,
-				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 
 			this.popupButtonList = new NSMenu ();
@@ -156,7 +156,7 @@ namespace Xamarin.PropertyEditing.Mac
 					LineBreakMode = NSLineBreakMode.TruncatingTail,
 					UsesSingleLineMode = true,
 				},
-				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView),
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView),
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -113,9 +113,9 @@ namespace Xamarin.PropertyEditing.Mac
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				StringValue = String.Empty,
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
-			this.popupButton.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
+			this.popupButton.ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView);
 			this.popupButtonList = new NSMenu ();
 			this.popupButton.Menu = this.popupButtonList;
 			this.popupButton.Activated += PopupButton_Activated; 
@@ -156,13 +156,13 @@ namespace Xamarin.PropertyEditing.Mac
 					LineBreakMode = NSLineBreakMode.TruncatingTail,
 					UsesSingleLineMode = true,
 				},
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView),
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView),
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				StringValue = String.Empty,
 			};
-			this.comboBox.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
+			this.comboBox.ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView);
 			this.comboBox.SelectionChanged += ComboBox_SelectionChanged;
 
 			AddSubview (this.comboBox);

--- a/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PredefinedValuesEditor.cs
@@ -113,6 +113,7 @@ namespace Xamarin.PropertyEditing.Mac
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,
 				StringValue = String.Empty,
+				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
 			};
 
 			this.popupButtonList = new NSMenu ();
@@ -155,6 +156,7 @@ namespace Xamarin.PropertyEditing.Mac
 					LineBreakMode = NSLineBreakMode.TruncatingTail,
 					UsesSingleLineMode = true,
 				},
+				ResponderProxy = new ProxyRowResponder (this, ProxyRowType.SingleView),
 				ControlSize = NSControlSize.Small,
 				Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 				TranslatesAutoresizingMaskIntoConstraints = false,

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -64,43 +64,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 		NSView INativeContainer.NativeView => this;
 
-		[Export ("_primitiveSetDefaultNextKeyView:")]
-		public void SetDefaultNextKeyView (NSView child)
-		{
-			if (child == FirstKeyView || child == LastKeyView) {
-				UpdateKeyViews ();
-			}
-		}
 
 		public virtual bool NeedsPropertyButton => true;
 
-		public void UpdateKeyViews ()
-		{
-			if (TableView != null) {
-				nint row = TableView.RowForView (this);
-				if (row <= 0)
-					return;
-
-				NSView view;
-				PropertyEditorControl ctrl = null;
-				do {
-					row--;
-					view = TableView.GetView (0, row, makeIfNecessary: false);
-					if (view is PropertyEditorControl pec) { // This is to include the CategoryContainer
-						ctrl = pec;
-					} else {
-						ctrl = (view as EditorContainer)?.EditorView?.NativeView as PropertyEditorControl;
-					}
-				} while (row > 0 && ctrl == null);
-
-				if (ctrl != null) {
-					ctrl.LastKeyView.NextKeyView = FirstKeyView;
-					ctrl.UpdateKeyViews ();
-				} else if (row == 0 && view is PanelHeaderEditorControl header) {
-					header.SetNextKeyView (FirstKeyView);
-				}
-			}
-		}
 
 		/// <remarks>You should treat the implementation of this as static.</remarks>
 		public virtual nint GetHeight (EditorViewModel vm)
@@ -145,6 +111,66 @@ namespace Xamarin.PropertyEditing.Mac
 			base.ViewDidChangeEffectiveAppearance ();
 
 			AppearanceChanged ();
+		}
+
+		public void OnNextResponderRequested ()
+		{
+			if (TableView != null) {
+				nint row = TableView.RowForView (this) + 1;
+
+				NSView view;
+				PropertyEditorControl ctrl = null;
+
+				for (; row < TableView.RowCount; row++) {
+					view = TableView.GetView (0, row, makeIfNecessary: false);
+					if (view is PropertyEditorControl pec) { // This is to include the CategoryContainer
+						ctrl = pec;
+					} else {
+						ctrl = (view as EditorContainer)?.EditorView?.NativeView as PropertyEditorControl;
+					}
+
+					if (ctrl != null && !ctrl.viewModel.IsInputEnabled) {
+						ctrl = null;
+					}
+
+					if (ctrl != null) {
+						Window?.MakeFirstResponder (ctrl.FirstKeyView);
+						return;
+					}
+				}
+			}
+		}
+
+		public void OnPreviousResponderRequested ()
+		{
+			if (TableView != null) {
+				nint row = TableView.RowForView (this) - 1;
+
+				NSView view;
+				PropertyEditorControl ctrl = null;
+
+				for (; row > 0; row--)
+				{
+					view = TableView.GetView (0, row, makeIfNecessary: false);
+					if (view is PropertyEditorControl pec) { // This is to include the CategoryContainer
+						ctrl = pec;
+					} else {
+						ctrl = (view as EditorContainer)?.EditorView?.NativeView as PropertyEditorControl;
+					}
+
+					if (ctrl != null && !ctrl.viewModel.IsInputEnabled) {
+						ctrl = null;
+					}
+
+					if (ctrl != null) {
+						Window?.MakeFirstResponder (ctrl.LastKeyView);
+						return;
+					} else if (row == 0 && view is PanelHeaderEditorControl header) {
+						Window?.MakeFirstResponder(header);
+						return;
+					}
+				}
+			}
 		}
 	}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -113,15 +113,18 @@ namespace Xamarin.PropertyEditing.Mac
 			AppearanceChanged ();
 		}
 
-		public void OnNextResponderRequested ()
+		public void OnNextResponderRequested (bool reverse)
 		{
 			if (TableView != null) {
-				nint row = TableView.RowForView (this) + 1;
+				var modifier = reverse ? -1 : 1;
+
+				nint row = TableView.RowForView (this) + modifier;
 
 				NSView view;
 				PropertyEditorControl ctrl = null;
 
-				for (; row < TableView.RowCount; row++) {
+				for (; reverse ? row > 0 : row < TableView.RowCount; row += modifier) {
+
 					view = TableView.GetView (0, row, makeIfNecessary: false);
 					if (view is PropertyEditorControl pec) { // This is to include the CategoryContainer
 						ctrl = pec;
@@ -134,39 +137,11 @@ namespace Xamarin.PropertyEditing.Mac
 					}
 
 					if (ctrl != null) {
-						Window?.MakeFirstResponder (ctrl.FirstKeyView);
-						return;
-					}
-				}
-			}
-		}
-
-		public void OnPreviousResponderRequested ()
-		{
-			if (TableView != null) {
-				nint row = TableView.RowForView (this) - 1;
-
-				NSView view;
-				PropertyEditorControl ctrl = null;
-
-				for (; row > 0; row--)
-				{
-					view = TableView.GetView (0, row, makeIfNecessary: false);
-					if (view is PropertyEditorControl pec) { // This is to include the CategoryContainer
-						ctrl = pec;
-					} else {
-						ctrl = (view as EditorContainer)?.EditorView?.NativeView as PropertyEditorControl;
-					}
-
-					if (ctrl?.viewModel != null && !ctrl.viewModel.IsInputEnabled) {
-						ctrl = null;
-					}
-
-					if (ctrl != null) {
-						Window?.MakeFirstResponder (ctrl.LastKeyView);
+						var targetView = reverse ? ctrl.LastKeyView : ctrl.FirstKeyView;
+						Window?.MakeFirstResponder (targetView);
 						return;
 					} else if (row == 0 && view is PanelHeaderEditorControl header) {
-						Window?.MakeFirstResponder(header);
+						Window?.MakeFirstResponder (header);
 						return;
 					}
 				}

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -129,7 +129,7 @@ namespace Xamarin.PropertyEditing.Mac
 						ctrl = (view as EditorContainer)?.EditorView?.NativeView as PropertyEditorControl;
 					}
 
-					if (ctrl != null && !ctrl.viewModel.IsInputEnabled) {
+					if (ctrl?.viewModel != null && !ctrl.viewModel.IsInputEnabled) {
 						ctrl = null;
 					}
 
@@ -158,7 +158,7 @@ namespace Xamarin.PropertyEditing.Mac
 						ctrl = (view as EditorContainer)?.EditorView?.NativeView as PropertyEditorControl;
 					}
 
-					if (ctrl != null && !ctrl.viewModel.IsInputEnabled) {
+					if (ctrl?.viewModel != null && !ctrl.viewModel.IsInputEnabled) {
 						ctrl = null;
 					}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PropertyEditorControl.cs
@@ -123,7 +123,8 @@ namespace Xamarin.PropertyEditing.Mac
 				NSView view;
 				PropertyEditorControl ctrl = null;
 
-				for (; reverse ? row > 0 : row < TableView.RowCount; row += modifier) {
+				var rowCount = TableView.RowCount;
+				for (; reverse ? row > 0 : row < rowCount; row += modifier) {
 
 					view = TableView.GetView (0, row, makeIfNecessary: false);
 					if (view is PropertyEditorControl pec) { // This is to include the CategoryContainer

--- a/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
@@ -9,13 +9,13 @@ namespace Xamarin.PropertyEditing.Mac
 		LastView
 	}
 
-	internal class RowProxyResponder 
+	internal class ProxyResponder 
 	{
 		protected WeakReference<PropertyEditorControl> editorControl;
 
 		readonly ProxyRowType rowType;
 
-		public RowProxyResponder (PropertyEditorControl editorControl, ProxyRowType rowType)
+		public ProxyResponder (PropertyEditorControl editorControl, ProxyRowType rowType)
 		{
 			this.rowType = rowType;
 			this.editorControl = new WeakReference<PropertyEditorControl> (editorControl);

--- a/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
@@ -9,13 +9,13 @@ namespace Xamarin.PropertyEditing.Mac
 		LastView
 	}
 
-	internal class ProxyRowResponder
+	internal class RowProxyResponder 
 	{
 		protected WeakReference<PropertyEditorControl> editorControl;
 
 		readonly ProxyRowType rowType;
 
-		public ProxyRowResponder (PropertyEditorControl editorControl, ProxyRowType rowType)
+		public RowProxyResponder (PropertyEditorControl editorControl, ProxyRowType rowType)
 		{
 			this.rowType = rowType;
 			this.editorControl = new WeakReference<PropertyEditorControl> (editorControl);

--- a/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
@@ -26,7 +26,7 @@ namespace Xamarin.PropertyEditing.Mac
 			if (this.editorControl.TryGetTarget (out var editor))
 			{
 				if (this.rowType == ProxyRowType.LastView || this.rowType == ProxyRowType.SingleView) {
-					editor.OnNextResponderRequested ();
+					editor.OnNextResponderRequested (false);
 					return true;
 				}
 			}
@@ -38,7 +38,7 @@ namespace Xamarin.PropertyEditing.Mac
 			if (this.editorControl.TryGetTarget (out var editor))
 			{
 				if (this.rowType == ProxyRowType.FirstView || this.rowType == ProxyRowType.SingleView) {
-					editor.OnPreviousResponderRequested ();
+					editor.OnNextResponderRequested (true);
 					return true;
 				}
 			}

--- a/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/ProxyRowResponder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace Xamarin.PropertyEditing.Mac
+{
+	internal enum ProxyRowType
+	{
+		SingleView,
+		FirstView,
+		LastView
+	}
+
+	internal class ProxyRowResponder
+	{
+		protected WeakReference<PropertyEditorControl> editorControl;
+
+		readonly ProxyRowType rowType;
+
+		public ProxyRowResponder (PropertyEditorControl editorControl, ProxyRowType rowType)
+		{
+			this.rowType = rowType;
+			this.editorControl = new WeakReference<PropertyEditorControl> (editorControl);
+		}
+
+		public bool NextResponder()
+		{
+			if (this.editorControl.TryGetTarget (out var editor))
+			{
+				if (this.rowType == ProxyRowType.LastView || this.rowType == ProxyRowType.SingleView) {
+					editor.OnNextResponderRequested ();
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public bool PreviousResponder ()
+		{
+			if (this.editorControl.TryGetTarget (out var editor))
+			{
+				if (this.rowType == ProxyRowType.FirstView || this.rowType == ProxyRowType.SingleView) {
+					editor.OnPreviousResponderRequested ();
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -16,6 +16,7 @@ namespace Xamarin.PropertyEditing.Mac
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
 			this.ratioEditor = new RatioEditor<T> (hostResources);
+			this.ratioEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView);
 			this.ratioEditor.SetFormatter (null);
 
 			// update the value on keypress

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -16,7 +16,7 @@ namespace Xamarin.PropertyEditing.Mac
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
 			this.ratioEditor = new RatioEditor<T> (hostResources);
-			this.ratioEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
+			this.ratioEditor.ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView);
 			this.ratioEditor.SetFormatter (null);
 
 			// update the value on keypress

--- a/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/RatioEditorControl.cs
@@ -16,7 +16,7 @@ namespace Xamarin.PropertyEditing.Mac
 			base.TranslatesAutoresizingMaskIntoConstraints = false;
 
 			this.ratioEditor = new RatioEditor<T> (hostResources);
-			this.ratioEditor.ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView);
+			this.ratioEditor.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
 			this.ratioEditor.SetFormatter (null);
 
 			// update the value on keypress

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -45,7 +45,7 @@ namespace Xamarin.PropertyEditing.Mac
 						Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 						TranslatesAutoresizingMaskIntoConstraints = false
 					};
-
+					this.inputModePopup.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
 					this.inputModePopup.Activated += (o, e) => {
 						var popupButton = o as NSPopUpButton;
 						ViewModel.InputMode = this.viewModelInputModes.FirstOrDefault (im => im.Identifier == popupButton.Title);
@@ -104,7 +104,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private NSView lastKeyView;
 		private NSLayoutConstraint editorInputModeConstraint;
-		private NSPopUpButton inputModePopup;
+		private FocusablePopUpButton inputModePopup;
 		private IReadOnlyList<InputMode> viewModelInputModes;
 	}
 }

--- a/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/StringEditorControl.cs
@@ -45,7 +45,7 @@ namespace Xamarin.PropertyEditing.Mac
 						Font = NSFont.SystemFontOfSize (NSFont.SystemFontSizeForControlSize (NSControlSize.Small)),
 						TranslatesAutoresizingMaskIntoConstraints = false
 					};
-					this.inputModePopup.ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView);
+					this.inputModePopup.ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView);
 					this.inputModePopup.Activated += (o, e) => {
 						var popupButton = o as NSPopUpButton;
 						ViewModel.InputMode = this.viewModelInputModes.FirstOrDefault (im => im.Identifier == popupButton.Title);

--- a/Xamarin.PropertyEditing.Mac/Controls/TimeSpanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TimeSpanEditorControl.cs
@@ -13,7 +13,9 @@ namespace Xamarin.PropertyEditing.Mac
 
 		protected override EntryPropertyEditorDelegate<TimeSpan> CreateDelegate (PropertyViewModel<TimeSpan> viewModel)
 		{
-			return new TimeSpanDelegate (viewModel);
+			return new TimeSpanDelegate (viewModel) {
+				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+			};
 		}
 
 		protected override void UpdateAccessibilityValues ()

--- a/Xamarin.PropertyEditing.Mac/Controls/TimeSpanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TimeSpanEditorControl.cs
@@ -14,7 +14,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override EntryPropertyEditorDelegate<TimeSpan> CreateDelegate (PropertyViewModel<TimeSpan> viewModel)
 		{
 			return new TimeSpanDelegate (viewModel) {
-				ResponderProxy = new ProxyRowResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
 			};
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/TimeSpanEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TimeSpanEditorControl.cs
@@ -14,7 +14,7 @@ namespace Xamarin.PropertyEditing.Mac
 		protected override EntryPropertyEditorDelegate<TimeSpan> CreateDelegate (PropertyViewModel<TimeSpan> viewModel)
 		{
 			return new TimeSpanDelegate (viewModel) {
-				ProxyResponder = new RowProxyResponder (this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder (this, ProxyRowType.SingleView)
 			};
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/TypeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TypeEditorControl.cs
@@ -22,7 +22,9 @@ namespace Xamarin.PropertyEditing.Mac
 			this.selectType = new FocusableButton {
 				BezelStyle = NSBezelStyle.Rounded,
 				Title = Properties.Resources.Select,
+				ProxyResponder = new RowProxyResponder(this, ProxyRowType.SingleView)
 			};
+
 			this.selectType.Activated += OnSelectPressed;
 			AddSubview (this.selectType);
 
@@ -89,7 +91,7 @@ namespace Xamarin.PropertyEditing.Mac
 		}
 
 		private readonly UnfocusableTextField typeLabel;
-		private readonly NSButton selectType;
+		private readonly FocusableButton selectType;
 
 		private void OnTypeRequested (object sender, TypeRequestedEventArgs e)
 		{

--- a/Xamarin.PropertyEditing.Mac/Controls/TypeEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/TypeEditorControl.cs
@@ -22,7 +22,7 @@ namespace Xamarin.PropertyEditing.Mac
 			this.selectType = new FocusableButton {
 				BezelStyle = NSBezelStyle.Rounded,
 				Title = Properties.Resources.Select,
-				ProxyResponder = new RowProxyResponder(this, ProxyRowType.SingleView)
+				ProxyResponder = new ProxyResponder(this, ProxyRowType.SingleView)
 			};
 
 			this.selectType.Activated += OnSelectPressed;

--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -129,7 +129,9 @@ namespace Xamarin.PropertyEditing.Mac
 						SelectRow (0, false);
 						this.tabbedIn = true;
 						var row = GetRowView ((nint)SelectedRows.FirstIndex, false);
-						return Window.MakeFirstResponder (row.NextValidKeyView);
+						if (row != null) {
+							return Window.MakeFirstResponder (row.NextValidKeyView);
+						}
 					}
 				}
 				this.tabbedIn = false;


### PR DESCRIPTION
- [x] Fixes NRE trying BecomeFirstResponder when GetRow gets a null object (probably a race condition reloading)
- [x] Reimplements hack to set first responder based in _primitiveSetDefaultNextKeyView 

The old approach was doing a recusive iteration on every editor multiple times re-configuring next responder in any focus change, which was complicated to maintain/understand and dowhile{} was giving us unexpected results (Infinite loops).

To try improve how focus is handled over this views, now we only calculate the next/previous responder "on demand", when tab or shift+tab is pressed in a specific view implementing a ProxyRowResponder which knows if is first/end view and moves to the next available editor.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1472832