### PR TITLE
Add cast to fix bug with numeric conversion

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/CommonBrushLayer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/CommonBrushLayer.cs
@@ -84,8 +84,11 @@ namespace Xamarin.PropertyEditing.Mac
 		public NSImage RenderPreview ()
 		{
 			var scale = this.ContentsScale;
-			nint h = (nint)(this.Bounds.Height * scale);
-			nint w = (nint)(this.Bounds.Width * scale);
+			// The double cast below is needed for now, while Width/Height/scale are of type ObjCRuntime.nfloat
+			// in order for the floating point to integral conversion to work properly. Later when ObjCRuntime.nfloat
+			// is replaced with System.Runtime.InteropServices.NFloat that won't be needed (but can't hurt).
+			nint h = (nint)(double)(this.Bounds.Height * scale);
+			nint w = (nint)(double)(this.Bounds.Width * scale);
 			nint bytesPerRow = w * 4;
 
 			if (h <= 0 || w <= 0)

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -212,7 +212,11 @@ namespace Xamarin.PropertyEditing.Mac
 				this.registrations[cellIdentifier] = registration;
 			}
 
-			return (nfloat) registration.GetHeight (vm);
+			// The double cast below is needed for now, while the return value is type ObjCRuntime.nfloat
+			// in order for the integral to floating point conversion to work properly. Later when ObjCRuntime.nfloat
+			// is replaced with System.Runtime.InteropServices.NFloat that won't be needed (but can't hurt).
+			nfloat rowHeight = (nfloat)(double)registration.GetHeight (vm);
+			return rowHeight;
 		}
 
 		private class EditorRegistration


### PR DESCRIPTION
With the macos P13 API type changes, an issue was introduced since
casting an ObjCRuntime.nfloat to an nint (aka IntPtr) doesn't work
properly - (nint)(ObjCRuntime.nfloat)23 for instance will evaluate
to 0x4037000000000000, the floating point bits are just reinterpreted
as an int rather than actually being converted.

That in turn caused huge sizes for width and height causing
new CGBitmapContext to throw an exception.

Adding the double cast here fixes this, for now.

Soon ObjCRuntime.nfloat will go away, replaced by
System.Runtime.InteropServices.NFloat, but for now
this workaround makes us work.

Fixes:
[AB#1487089](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487089)
[AB#1487070](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487070)
[AB#1487089](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487089)