### PR TITLE
Set the Arrange By AutomationProperty Name correctly

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -213,7 +213,7 @@
 
 								<local:TextBoxEx x:Name="search" Grid.Row="0" Style="{DynamicResource PropertySearchTextBox}" AutomationProperties.Name="{x:Static prop:Resources.SearchProperties}" Text="{Binding FilterText,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" />
 
-								<local:MenuButton Grid.Row="1" x:Name="arrangeBy" Header="{x:Static prop:Resources.ArrangeByLabel}" Margin="0,0,18,0" Content="{Binding ArrangeMode,Converter={StaticResource ArrangeLocalizer}}" AutomationProperties.Name="{Binding ArrangeMode,StringFormat={x:Static prop:Resources.ArrangeByButtonName}}">
+								<local:MenuButton Grid.Row="1" x:Name="arrangeBy" Header="{x:Static prop:Resources.ArrangeByLabel}" Margin="0,0,18,0" Content="{Binding ArrangeMode,Converter={StaticResource ArrangeLocalizer}}" AutomationProperties.Name="{x:Static prop:Resources.ArrangeByButtonName}">
 									<local:MenuButton.Visibility>
 										<Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsArrangeEnabled">
 											<Binding.Converter>

--- a/Xamarin.PropertyEditing/Properties/Resources.resx
+++ b/Xamarin.PropertyEditing/Properties/Resources.resx
@@ -915,7 +915,7 @@
     <value>Advanced properties</value>
   </data>
   <data name="ArrangeByButtonName" xml:space="preserve">
-    <value>This button allows you to arrange the property list by {0}.</value>
+    <value>Arrange By</value>
   </data>
   <data name="PropertyButtonName" xml:space="preserve">
     <value>Advanced options</value>


### PR DESCRIPTION
The name here should generally match the button label -
it's a name, not a description.

Fixes [AB#1491218](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1491218)