### PR TITLE
Make tab order cycle for proppy controls

### DIFF
--- a/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/PropertyEditorPanelStyle.xaml
@@ -204,7 +204,7 @@
 								</Grid>
 							</Border>
 
-							<Grid Name="propertiesPane" Grid.Row="1">
+							<Grid Name="propertiesPane" Grid.Row="1" KeyboardNavigation.TabNavigation="Cycle">
 								<Grid.RowDefinitions>
 									<RowDefinition Height="Auto" />
 									<RowDefinition Height="Auto" />


### PR DESCRIPTION
Now hitting the Tab key in the last control in the property
editor changes focus to the search control at the top,
cycling around. And Shift-Tab in search moves to the
last control.

Fixes [AB#1491221](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1491221)