### PR TITLE
Use PreviewKeyDown for Ctrl+Space to show menu

### DIFF
--- a/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
@@ -117,6 +117,7 @@ namespace Xamarin.PropertyEditing.Windows
 			this.propertyButton = (PropertyButton) GetTemplateChild ("propertyButton");
 
 			this.propertyContainer = (Border) GetTemplateChild ("propertyContainer");
+			// Since the template never changes, the handler only gets added once and there's no need to unsubscribe
 			this.propertyContainer.AddHandler (Border.PreviewKeyDownEvent, new KeyEventHandler (PropertyContainer_PreviewKeyDown));
 		}
 

--- a/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
+++ b/Xamarin.PropertyEditing.Windows/PropertyPresenter.cs
@@ -6,6 +6,7 @@ using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 using System.Windows.Media;
 using Xamarin.PropertyEditing.ViewModels;
 
@@ -112,6 +113,11 @@ namespace Xamarin.PropertyEditing.Windows
 
 			this.variationRow = (RowDefinition) GetTemplateChild ("variationRow");
 			this.variationsList = GetTemplateChild ("variationsList") as ItemsControl;
+
+			this.propertyButton = (PropertyButton) GetTemplateChild ("propertyButton");
+
+			this.propertyContainer = (Border) GetTemplateChild ("propertyContainer");
+			this.propertyContainer.AddHandler (Border.PreviewKeyDownEvent, new KeyEventHandler (PropertyContainer_PreviewKeyDown));
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer ()
@@ -155,10 +161,22 @@ namespace Xamarin.PropertyEditing.Windows
 			}
 		}
 
+		private void PropertyContainer_PreviewKeyDown (object sender, KeyEventArgs e)
+		{
+			var isModifierControl = Keyboard.Modifiers == ModifierKeys.Control;
+
+			if (e.Key == Key.Space && isModifierControl) {
+				propertyButton.ShowMenu ();
+				e.Handled = true;
+			}
+		}
+
 		private PropertyViewModel pvm;
 		private ButtonBase addButton, removeButton;
 		private RowDefinition variationRow;
 		private ItemsControl variationsList;
+		private Border propertyContainer;
+		private PropertyButton propertyButton;
 
 		private void OnLoaded (object sender, RoutedEventArgs e)
 		{

--- a/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
+++ b/Xamarin.PropertyEditing.Windows/Themes/Resources.xaml
@@ -1708,10 +1708,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="local:PropertyPresenter">
-					<Border Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
-						<Border.InputBindings>
-							<KeyBinding Gesture="CTRL+Space" Command="{StaticResource InvokePropertyButtonCommand}" CommandParameter="{Binding ElementName=propertyButton,Mode=OneTime}" />
-						</Border.InputBindings>
+					<Border x:Name="propertyContainer" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
 						<Grid>
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Name="delveColumn" Width="Auto" />


### PR DESCRIPTION
Ctrl+Space is the keyboard short that can
be used to show the property editor menu
for a property (with options like Reset,
Convert to Local Value, etc.). Previously, that
was detected via a KeyBinding in XAML, which
worked for text boxes but not controls like
checkbox and button, which handle the
key down event themselves. Now we
use PreviewKeyDown instead, handling that
in C# code, to work for all control
types.

Fixes [AB#1491229](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1491229)