### PR TITLE
Reduce Redundant MicroBuild Signing

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <!--
-      Diable MicroBuild signing by default, then only enable it after compilation.
+      Disable MicroBuild signing by default, then only enable it after compilation.
       This way, if compilation is skipped because it the project has already been built, signing
       will remain turned off and we will not redundantly submit already-signed files to sign.
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,4 +3,28 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Xamarin.PropertyEditing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      Diable MicroBuild signing by default, then only enable it after compilation.
+      This way, if compilation is skipped because it the project has already been built, signing
+      will remain turned off and we will not redundantly submit already-signed files to sign.
+
+      This property group must remain in Directory.Build.targets file (as opposed to *.props) because
+      the initial MicroBuild_SigningEnabled value is not set until after Directory.Build.props has been processed.
+    -->
+    <MicroBuild_SigningEnabled_Old>$(MicroBuild_SigningEnabled)</MicroBuild_SigningEnabled_Old>
+    <MicroBuild_SigningEnabled>false</MicroBuild_SigningEnabled>
+
+    <TargetsTriggeredByCompilation>
+        $(TargetsTriggeredByCompilation);
+        EnableMicroBuildSigningPostCompile
+    </TargetsTriggeredByCompilation>
+  </PropertyGroup>
+
+  <Target Name="EnableMicroBuildSigningPostCompile">
+    <PropertyGroup>
+      <MicroBuild_SigningEnabled>$(MicroBuild_SigningEnabled_Old)</MicroBuild_SigningEnabled>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
When MicroBuild signing is enabled, the SignFiles task will run every time a project is built, even if it's already been compiled once before. In this scenario, the dlls have already been created and signed once (in the initial build), so MSBuild will skip the compilation step, but SignFiles will run again and unnecessarily submit the already-signed dlls for signing again. Since signing can be quite expensive, this redundant signing adds a significant amount of time to builds.

To prevent it from happening, we can *disable* signing at the start of the build, then only re-enable it if Compile runs. If Compile is skipped, signing will remain disabled, and we will not sign anything unnecessarily.

I've validated this works through builds in the UITools pipeline, i.e. https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5892501&view=results 