### PR TITLE
Allow ESC key to close brush editor popup

### DIFF
--- a/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
+++ b/Xamarin.PropertyEditing.Windows/BrushEditorControl.cs
@@ -36,9 +36,10 @@ namespace Xamarin.PropertyEditing.Windows
 			this.brushBoxPopup.Closed += (s, e) => {
 				this.brushBoxButton.Focus ();
 			};
-			this.brushBoxPopup.KeyUp += (s, e) => {
+			this.brushBoxPopup.PreviewKeyDown += (s, e) => {
 				if (e.Key == Key.Escape) {
 					this.brushBoxPopup.IsOpen = false;
+					e.Handled = true;
 				}
 			};
 		}


### PR DESCRIPTION
Fixes:
[Bug 1491842](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1491842): A11y_The brush icons popups which is present for options like background brush is not getting closed when pressing esc key_XamarinDevelopment_AddUI_Keyboard

When focus is in the brush editor popup, hitting the ESC key would set focus back to the active document tab, and leave the popup open.

<img width="232" alt="image" src="https://user-images.githubusercontent.com/2523431/159092902-0e51d965-0cc9-4899-a53b-5232eeeee7d3.png">

This change adds the proper ESC key handler and blocks VS from uses the accelerator for ESC (which focuses the active document) 