### PR TITLE
Set a11y name for editable combo TextEdit

### DIFF
--- a/Xamarin.PropertyEditing.Windows/ComboBoxEx.cs
+++ b/Xamarin.PropertyEditing.Windows/ComboBoxEx.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -25,6 +26,18 @@ namespace Xamarin.PropertyEditing.Windows
 		protected override AutomationPeer OnCreateAutomationPeer ()
 		{
 			return new ComboBoxExAutomationPeer (this);
+		}
+
+		public override void OnApplyTemplate ()
+		{
+			base.OnApplyTemplate ();
+
+			var textBox = Template.FindName ("PART_EditableTextBox", this) as TextBox;
+			if (textBox != null) {
+				string accessibilityName = AutomationProperties.GetName (this);
+
+				AutomationProperties.SetName (textBox, accessibilityName);
+			}
 		}
 
 		protected override void OnSelectionChanged (SelectionChangedEventArgs e)


### PR DESCRIPTION
Set the Automation.Name property for the TextEdit control in
an editable combo to be the same as that for the entire combo
box.

Fixes [AB#1501925](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1501925)