### PR TITLE
Port MicroBuild Signing to d17 1

### DIFF
--- a/.build/automation/stages/validate.yml
+++ b/.build/automation/stages/validate.yml
@@ -33,7 +33,12 @@ stages:
               testResultsFiles: '**/TestResult.xml'
             condition: succeededOrFailed()
 
+      ###
+      # The MacOS job is disabled for the d17-1 branch because the branch is only used to ship VS Windows builds.
+      # Mac validation is superfluous.
+      ###
       - job: 'MacOS'
+        condition: false # Disable job
         pool:
           vmImage: 'macOS-latest'
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Deliberately empty so we don't inherit files from whoever submodules this repository -->
+  <!-- Enable MicroBuild signing on all projects, if the build is running in a pipeline where MicroBuild has been setup.  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core">
+      <Version>1.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll"> 
+      <Authenticode>Microsoft400</Authenticode> 
+    </FilesToSign>
+  </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,4 +3,28 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Xamarin.PropertyEditing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      Disable MicroBuild signing by default, then only enable it after compilation.
+      This way, if compilation is skipped because it the project has already been built, signing
+      will remain turned off and we will not redundantly submit already-signed files to sign.
+
+      This property group must remain in Directory.Build.targets file (as opposed to *.props) because
+      the initial MicroBuild_SigningEnabled value is not set until after Directory.Build.props has been processed.
+    -->
+    <MicroBuild_SigningEnabled_Old>$(MicroBuild_SigningEnabled)</MicroBuild_SigningEnabled_Old>
+    <MicroBuild_SigningEnabled>false</MicroBuild_SigningEnabled>
+
+    <TargetsTriggeredByCompilation>
+        $(TargetsTriggeredByCompilation);
+        EnableMicroBuildSigningPostCompile
+    </TargetsTriggeredByCompilation>
+  </PropertyGroup>
+
+  <Target Name="EnableMicroBuildSigningPostCompile">
+    <PropertyGroup>
+      <MicroBuild_SigningEnabled>$(MicroBuild_SigningEnabled_Old)</MicroBuild_SigningEnabled>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
+++ b/Xamarin.PropertyEditing/Xamarin.PropertyEditing.csproj
@@ -20,4 +20,12 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <Target Name="GetFilesToSign" BeforeTargets="SignFiles">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\**\$(AssemblyName).resources.dll">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
With the move away from the "sign-from-github-esrp" ("Groovy") pipeline, we need to shift our assembly signing to happen alongside the build itself, which is more secure. Without these changes, we will not be able to push new, signed assemblies from this branch.

**Important Note:** This change also disables Mac build & validation. These stages are currently broken with or without the signing changes, but since d17-1 should only be used to ship windows builds, they're superfluous anyway and I believe they can just be turned off (we did the same in d17-0)...