### PR TITLE
Update macos workload provisioning

### DIFF
--- a/bot-provisioning/dependencies.csx
+++ b/bot-provisioning/dependencies.csx
@@ -4,11 +4,16 @@ using static Xamarin.Provisioning.ProvisioningScript;
 
 if (IsMac) {
 	DotNetCoreSdk ("../global.json", installDirectory: Env("DOTNET_ROOT"))
-		.Workload(
-			"microsoft.net.sdk.macos",
-			"12.1.301-preview.13.7",
-			"https://aka.ms/dotnet6/nuget/index.json",
-			"https://api.nuget.org/v3/index.json");
+		.WithWorkload(
+			workload: new DotNetWorkload("microsoft.net.sdk.macos", "12.1.301-preview.13.10"),
+			dependencies: new [] {
+				new DotNetWorkload("microsoft.net.workload.mono.toolchain", "6.0.2-mauipre.1.22102.15"),
+			},
+			// nugetConfigFilePath: "../NuGet.Config"); // TODO: Make this work and remove `sources` below
+			sources: new [] {
+				"https://aka.ms/dotnet6/nuget/index.json",
+				"https://api.nuget.org/v3/index.json",
+			});
 
 	Xcode ("13.2.1").XcodeSelect ();
 }


### PR DESCRIPTION
Fixes this error that some people are seeing:

> Workload installation failed: microsoft.net.runtime.monoaotcompiler.task::6.0.4 is not found in NuGet feeds https://aka.ms/dotnet6/nuget/index.json;https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/VSMac/nuget/v3/index.json".

See xamarin/provisionator#455