### PR TITLE
Remove UpdateExpansions

### DIFF
--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -153,8 +153,6 @@ namespace Xamarin.PropertyEditing.Mac
 		private void OnPropertiesChanged (object sender, EventArgs e)
 		{
 			this.propertyTable.ReloadData ();
-
-			((PropertyTableDelegate)this.propertyTable.Delegate).UpdateExpansions (this.propertyTable);
 		}
 
 		private void UpdateResourceProvider ()


### PR DESCRIPTION
Remove the call to UpdateExpansions after ReloadData in response to
OnPropertiesChanged (e.g. called when selection changes). This
doesn't seem necessary, as when views are recreated their
expansion status is set correctly originally and AppKit
remembers expansion state after.

Further, this fixes [AB#1521131](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1521131), where the Name and Type rows are
sometimes blank - apparently expanding manually, and doing it
synchronously like that, causes the NSOutlineView
to get confused and not show the top row sometimes.