### PR TITLE
Fallback PropertyEditingResource in app bundle resources directory

### DIFF
--- a/Xamarin.PropertyEditing.Mac/HostResourceProvider.cs
+++ b/Xamarin.PropertyEditing.Mac/HostResourceProvider.cs
@@ -17,8 +17,14 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public HostResourceProvider ()
 		{
-			var containingDir = Path.GetDirectoryName (typeof (HostResourceProvider).Assembly.Location);
-			var bundlePath = Path.Combine (containingDir, "PropertyEditingResource.bundle");
+			var bundlePath = NSBundle.MainBundle.PathForResource ("PropertyEditingResource", "bundle");
+			if (!Directory.Exists (bundlePath))
+			{
+				//if the bundle resource directory is not in place we fallback into the assembly location
+				var containingDir = Path.GetDirectoryName (typeof (HostResourceProvider).Assembly.Location);
+				bundlePath = Path.Combine (containingDir, "PropertyEditingResource.bundle");
+			}
+			
 			this.resourceBundle = new NSBundle (bundlePath);
 		}
 


### PR DESCRIPTION
HostResourceProvider expects the PropertyEditingResource bundle directory in the same directory than the assembly, but in VSMac we have this bundle duplicated in 2 locations. After some refactoring in the PropertyPad integration this will be only in : bundlePath = /Resources/PropertyEditingResource
So added some code to don't break and check new paths