### PR TITLE
[HistoryLayer] On viewmodel changes we ensure our viewmodel is not null and set default color

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/HistoryLayer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/HistoryLayer.cs
@@ -78,7 +78,11 @@ namespace Xamarin.PropertyEditing.Mac
 		{
 			LayoutIfNeeded ();
 			current.BackgroundColor = interaction.Color.ToCGColor ();
-			previous.BackgroundColor = interaction.ViewModel.InitialColor.ToCGColor ();
+			//there are some scenarios where viewmodel could be null
+			var initialColor = interaction.ViewModel?.InitialColor;
+			if (initialColor != null) {
+				previous.BackgroundColor = initialColor.ToCGColor ();
+			}
 			last.BackgroundColor = interaction.LastColor.ToCGColor ();
 		}
 

--- a/Xamarin.PropertyEditing.Mac/Controls/Custom/HistoryLayer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/Custom/HistoryLayer.cs
@@ -3,6 +3,7 @@ using AppKit;
 using CoreAnimation;
 using CoreGraphics;
 using ObjCRuntime;
+using Xamarin.PropertyEditing.Drawing;
 
 namespace Xamarin.PropertyEditing.Mac
 {
@@ -77,13 +78,20 @@ namespace Xamarin.PropertyEditing.Mac
 		public override void UpdateFromModel (EditorInteraction interaction)
 		{
 			LayoutIfNeeded ();
-			current.BackgroundColor = interaction.Color.ToCGColor ();
+			SetCALayerBackgroundColor (current, interaction.Color);
 			//there are some scenarios where viewmodel could be null
-			var initialColor = interaction.ViewModel?.InitialColor;
-			if (initialColor != null) {
-				previous.BackgroundColor = initialColor.ToCGColor ();
-			}
-			last.BackgroundColor = interaction.LastColor.ToCGColor ();
+			if (interaction.ViewModel != null)
+				SetCALayerBackgroundColor (previous, interaction.ViewModel.InitialColor);
+			SetCALayerBackgroundColor (last, interaction.LastColor);
+		}
+
+		static void SetCALayerBackgroundColor(CALayer layer, CommonColor color)
+		{
+			// We need to use GC.KeepAlive to ensure that the CGColor doesn't get garbage collected (and thus the
+			// native object Released) before the BackgroundColor assignment is complete
+			CGColor cgColor = color.ToCGColor ();
+			layer.BackgroundColor = cgColor;
+			GC.KeepAlive (cgColor);
 		}
 
 		public override void UpdateFromLocation (EditorInteraction interaction, CGPoint location)


### PR DESCRIPTION
Fix [AB#1569130](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1569130)

Due to the issue https://github.com/xamarin/xamarin-macios/issues/15600, when a CGColor is allocated and its native object about to be passed to PInvoke when setting CALayout.BackgroundColor, it's possible for it be GC'ed, which CFReleases the CGColor, before the PInvoke completes and BackgroundColor gets a chance to CFRetain it. In that case, the BackgroundColor can point to a deleted object. Until there's a real fix for that race condition with https://github.com/xamarin/xamarin-macios/issues/15600 fixed, we workaround it here by doing a GC.KeepAlive ensuring that the object lives until the PInvoke completes.

Also, in some scenarios looks like ViewModel is not yet set in OnViewModelChanged event, which could cause a NRE. We now protect against that too.

[<img width="628" alt="CleanShot 2022-07-21 at 17 38 24@2x" src="https://user-images.githubusercontent.com/1587480/180255034-431b16e9-f02e-4e70-93c6-46485e9f5cde.png">]

(https://github.com/xamarin/Xamarin.PropertyEditing/blob/dev/netonjm/fix-1569130/Xamarin.PropertyEditing.Mac/Controls/Custom/SolidColorBrushEditorViewController.cs#L33-L47)

