### PR TITLE
Hide Name UI unless object is nameable

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
@@ -57,7 +57,7 @@ namespace Xamarin.PropertyEditing.Mac
 			AddSubview (this.propertyIcon);
 
 			typeTopConstraintWhenNameVisible = NSLayoutConstraint.Create(this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.propertyObjectName, NSLayoutAttribute.Bottom, 1, 5);
-			typeTopConstraintWhenNameHidden = NSLayoutConstraint.Create(this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 5);
+			typeTopConstraintWhenNameHidden = NSLayoutConstraint.Create(this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 1);
 			typeTopConstraintWhenNameHidden.Active = false;
 
 			this.AddConstraints (new[] {

--- a/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/PanelHeaderEditorControl.cs
@@ -56,6 +56,10 @@ namespace Xamarin.PropertyEditing.Mac
 			};
 			AddSubview (this.propertyIcon);
 
+			typeTopConstraintWhenNameVisible = NSLayoutConstraint.Create(this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.propertyObjectName, NSLayoutAttribute.Bottom, 1, 5);
+			typeTopConstraintWhenNameHidden = NSLayoutConstraint.Create(this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this, NSLayoutAttribute.Top, 1, 5);
+			typeTopConstraintWhenNameHidden.Active = false;
+
 			this.AddConstraints (new[] {
 				NSLayoutConstraint.Create (this.propertyIcon, NSLayoutAttribute.Width, NSLayoutRelation.Equal, 1, 32),
 				NSLayoutConstraint.Create (this.propertyIcon, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1, 32),
@@ -70,7 +74,8 @@ namespace Xamarin.PropertyEditing.Mac
 				NSLayoutConstraint.Create (this.propertyObjectName, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this.objectNameLabel, NSLayoutAttribute.Right, 1, EditorContainer.LabelToControlSpacing),
 				NSLayoutConstraint.Create (this.propertyObjectName, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, 1, -(EditorContainer.PropertyTotalWidth)),
 
-				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Top, NSLayoutRelation.Equal, this.propertyObjectName, NSLayoutAttribute.Bottom, 1, 5),
+				typeTopConstraintWhenNameVisible,
+				typeTopConstraintWhenNameHidden,
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Right, NSLayoutRelation.Equal, this, NSLayoutAttribute.Right, Mac.Layout.GoldenRatioLeft, 0),
 				NSLayoutConstraint.Create (this.typeLabel, NSLayoutAttribute.Height, NSLayoutRelation.Equal, 1f, 20),
 
@@ -97,9 +102,8 @@ namespace Xamarin.PropertyEditing.Mac
 					this.viewModel.PropertyChanged += OnViewModelPropertyChanged;
 
 				this.typeDisplay.StringValue = value?.TypeName ?? String.Empty;
-				UpdateValue ();
+				UpdateObjectName ();
 				UpdateIcon ();
-				this.propertyObjectName.Enabled = !this.viewModel.IsObjectNameReadOnly;
 			}
 		}
 
@@ -112,6 +116,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 		private NSImageView propertyIcon;
 		private NSTextField propertyObjectName;
+		private NSLayoutConstraint typeTopConstraintWhenNameVisible;
+		private NSLayoutConstraint typeTopConstraintWhenNameHidden;
 		private UnfocusableTextField typeLabel, typeDisplay, objectNameLabel;
 
 		private PanelViewModel viewModel;
@@ -119,20 +125,26 @@ namespace Xamarin.PropertyEditing.Mac
 		private void OnViewModelPropertyChanged (object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof (PanelViewModel.ObjectName)) {
-				UpdateValue ();
+				UpdateObjectName ();
 			} else if (e.PropertyName == nameof (PanelViewModel.TypeName)) {
 				UpdateIcon ();
 			} else if (String.IsNullOrEmpty (e.PropertyName)) {
-				UpdateValue ();
+				UpdateObjectName ();
 				UpdateIcon ();
 			}
 		}
 
-		private void UpdateValue ()
+		private void UpdateObjectName ()
 		{
 			this.propertyObjectName.StringValue = this.viewModel.ObjectName ?? string.Empty;
 			this.propertyObjectName.AccessibilityTitle = string.Format (Properties.Resources.AccessibilityObjectName, nameof (viewModel.ObjectName));
 			this.propertyObjectName.Enabled = !this.viewModel.IsObjectNameReadOnly;
+
+			bool objectNameVisible = this.viewModel.IsObjectNameable;
+			this.objectNameLabel.Hidden = !objectNameVisible;
+			this.propertyObjectName.Hidden = !objectNameVisible;
+			this.typeTopConstraintWhenNameVisible.Active = objectNameVisible;
+			this.typeTopConstraintWhenNameHidden.Active = !objectNameVisible;
 		}
 
 		private void OnObjectNameEdited (object sender, EventArgs e)

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -192,7 +192,7 @@ namespace Xamarin.PropertyEditing.Mac
 
 				if (cellIdentifier == nameof (PanelHeaderEditorControl)) {
 					if (this.dataSource?.DataContext is PanelViewModel panelView && !panelView.IsObjectNameable) {
-						registration.RowSize = 27;
+						registration.RowSize = 26;
 					}
 					else {
 						registration.RowSize = 54;

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -191,7 +191,12 @@ namespace Xamarin.PropertyEditing.Mac
 				registration = new EditorRegistration ();
 
 				if (cellIdentifier == nameof (PanelHeaderEditorControl)) {
-					registration.RowSize = 54;
+					if (this.dataSource?.DataContext is PanelViewModel panelView && !panelView.IsObjectNameable) {
+						registration.RowSize = 27;
+					}
+					else {
+						registration.RowSize = 54;
+					}
 				} else {
 					NSView editorOrContainer = GetEditor (cellIdentifier, vm, outlineView);
 					IEditorView view = ((editorOrContainer as EditorContainer)?.EditorView) ?? editorOrContainer as IEditorView;


### PR DESCRIPTION
The Name field should only show in the property UI if the object is nameable - which it normally isn’t. The Name UI is properly hidden on VS Windows - it
just wasn’t on Mac. That’s fixed now.

Fixes AB#1615257

UI with fix:
![image](https://user-images.githubusercontent.com/245892/207206767-f464918e-9355-4802-8437-f2c9c241a151.png)

Original UI:
![image](https://user-images.githubusercontent.com/245892/207203705-fa8a70b8-234c-4edc-abc8-e7f26828666b.png)
