### PR TITLE
Fix setting custom values for non-constrained enums

### DIFF
--- a/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
+++ b/Xamarin.PropertyEditing/ViewModels/PredefinedValuesViewModel.cs
@@ -116,6 +116,13 @@ namespace Xamarin.PropertyEditing.ViewModels
 				this.valueName = newValueName;
 				OnPropertyChanged (nameof(ValueName));
 			}
+			// If the value doesn't match a predefined value (checked with TryGetValueName above) then treat it the same as if the
+			// ValueDescriptor contains the custom value name so that the custom value is displayed. The original intention of the code
+			// isn't quite clear, but the Forms XAML code just sets the value, not ValueDescriptor, in this scenario, so support either
+			else if (!IsConstrainedToPredefined && CurrentValue != null && CurrentValue.Value is string customValue && ! string.IsNullOrEmpty(customValue)) {
+				this.valueName = customValue;
+				OnPropertyChanged (nameof (ValueName));
+			}
 		}
 	}
 }


### PR DESCRIPTION
If a predefined property value is set that doesn't match one of the standard options, then set it as the valueName, same as if it was passed in the ValueDescriptor. This fixes showing the custom value in the property editor UI. Fixes AB#1600201.

Proppy's intention may have been that custom values like this should be set in the ValueDescriptor instead of Value - I'm not sure about that. However the Forms XAML code doesn't do that. Given that, and the fact that there's no harm is allowing custom values to be specified in the Value instead of just ValueDescriptor, we now support both.