### PR TITLE
Show proper expanded icon by default

### DIFF
--- a/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
+++ b/Xamarin.PropertyEditing.Mac/Controls/EditorContainer.cs
@@ -27,34 +27,6 @@ namespace Xamarin.PropertyEditing.Mac
 			}
 		}
 
-		public NSView LeftEdgeView
-		{
-			get { return this.leftEdgeView; }
-			set
-			{
-				if (this.leftEdgeView != null) {
-					this.leftEdgeView.RemoveFromSuperview ();
-					RemoveConstraints (new[] { this.leftEdgeLeftConstraint, this.leftEdgeVCenterConstraint });
-					this.leftEdgeLeftConstraint.Dispose ();
-					this.leftEdgeLeftConstraint = null;
-					this.leftEdgeVCenterConstraint.Dispose ();
-					this.leftEdgeVCenterConstraint = null;
-				}
-
-				this.leftEdgeView = value;
-
-				if (value != null) {
-					AddSubview (value);
-
-					value.TranslatesAutoresizingMaskIntoConstraints = false;
-					this.leftEdgeLeftConstraint = NSLayoutConstraint.Create (this.leftEdgeView, NSLayoutAttribute.Left, NSLayoutRelation.Equal, this, NSLayoutAttribute.Left, 1, 4);
-					this.leftEdgeVCenterConstraint = NSLayoutConstraint.Create (this.leftEdgeView, NSLayoutAttribute.CenterY, NSLayoutRelation.Equal, this, NSLayoutAttribute.CenterY, 1, 0);
-
-					AddConstraints (new[] { this.leftEdgeLeftConstraint, this.leftEdgeVCenterConstraint });
-				}
-			}
-		}
-
 #if DEBUG // Currently only used to highlight which controls haven't been implemented
 		public NSColor LabelTextColor {
 			set { LabelControl.TextColor = value; }

--- a/Xamarin.PropertyEditing.Mac/PropertyList.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyList.cs
@@ -154,6 +154,7 @@ namespace Xamarin.PropertyEditing.Mac
 		private void OnPropertiesChanged (object sender, EventArgs e)
 		{
 			this.propertyTable.ReloadData ();
+			UpdateExpansions ();
 		}
 
 		private void UpdateResourceProvider ()

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -146,7 +146,8 @@ namespace Xamarin.PropertyEditing.Mac
 				// Also update the expander state. This is needed when the property editor first
 				// displays and category groups default to expanded, to show the right icon
 				NSView view = outline.GetView (0, row, makeIfNecessary: false);
-				if (view?.Subviews != null && view.Subviews.Length > 0 && view.Subviews[0] is NSButton expander)
+				NSView[] subviews = view?.Subviews;
+				if (subviews != null && subviews.Length > 0 && subviews[0] is NSButton expander)
 					expander.State = NSCellStateValue.On;
 			} else if (facade.Target is ObjectPropertyViewModel ovm) {
 				NSView view = outline.GetView (0, row, makeIfNecessary: false);

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -140,9 +140,15 @@ namespace Xamarin.PropertyEditing.Mac
 				return;
 			}
 
-			if (facade.Target is PanelGroupViewModel group)
+			if (facade.Target is PanelGroupViewModel group) {
 				this.dataSource.DataContext.SetIsExpanded (group.Category, isExpanded: true);
-			else if (facade.Target is ObjectPropertyViewModel ovm) {
+
+				// Also update the expander state. This is needed when the property editor first
+				// displays and category groups default to expanded, to show the right icon
+				NSView view = outline.GetView (0, row, makeIfNecessary: false);
+				if (view != null && view.Subviews[0] is NSButton expander)
+					expander.State = NSCellStateValue.On;
+			} else if (facade.Target is ObjectPropertyViewModel ovm) {
 				NSView view = outline.GetView (0, row, makeIfNecessary: false);
 				SetRowValueBackground (view, valueBackground: true);
 			}

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -146,7 +146,7 @@ namespace Xamarin.PropertyEditing.Mac
 				// Also update the expander state. This is needed when the property editor first
 				// displays and category groups default to expanded, to show the right icon
 				NSView view = outline.GetView (0, row, makeIfNecessary: false);
-				if (view != null && view.Subviews[0] is NSButton expander)
+				if (view?.Subviews != null && view.Subviews.Length > 0 && view.Subviews[0] is NSButton expander)
 					expander.State = NSCellStateValue.On;
 			} else if (facade.Target is ObjectPropertyViewModel ovm) {
 				NSView view = outline.GetView (0, row, makeIfNecessary: false);

--- a/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
+++ b/Xamarin.PropertyEditing.Mac/PropertyTableDelegate.cs
@@ -60,12 +60,6 @@ namespace Xamarin.PropertyEditing.Mac
 
 				((UnfocusableTextField)categoryContainer.Subviews[1]).StringValue = group.Category;
 
-				if (this.dataSource.DataContext.GetIsExpanded (group.Category)) {
-					SynchronizationContext.Current.Post (s => {
-						outlineView.ExpandItem (item);
-					}, null);
-				}
-
 				return categoryContainer;
 			}
 
@@ -90,14 +84,8 @@ namespace Xamarin.PropertyEditing.Mac
 
 			if (editor != null) {
 				var ovm = evm as ObjectPropertyViewModel;
-				if (ovm != null && editorOrContainer is EditorContainer container) {
-					if (container.LeftEdgeView == null) {
-						if (ovm.CanDelve)
-							container.LeftEdgeView = outlineView.MakeView ("NSOutlineViewDisclosureButtonKey", outlineView);
-					} else if (!ovm.CanDelve) {
-						container.LeftEdgeView = null;
-					}
-				} else if (!(editorOrContainer is EditorContainer)) {
+
+				if (!(editorOrContainer is EditorContainer)) {
 					editor.ViewModel = evm;
 				}
 
@@ -128,28 +116,17 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override void ItemDidExpand (NSNotification notification)
 		{
+			if (this.isUpdatingExpansions)
+				return;
+
 			NSObjectFacade facade = notification.UserInfo.Values[0] as NSObjectFacade;
 			var outline = (NSOutlineView)notification.Object;
 			nint row = outline.RowForItem (facade);
 
-			if (this.isUpdatingExpansions) {
-				NSView view = outline.GetView (0, row, makeIfNecessary: true);
-				if (view.Subviews[0] is NSButton expander)
-					expander.State = NSCellStateValue.On;
-
-				return;
-			}
-
 			if (facade.Target is PanelGroupViewModel group) {
 				this.dataSource.DataContext.SetIsExpanded (group.Category, isExpanded: true);
-
-				// Also update the expander state. This is needed when the property editor first
-				// displays and category groups default to expanded, to show the right icon
-				NSView view = outline.GetView (0, row, makeIfNecessary: false);
-				NSView[] subviews = view?.Subviews;
-				if (subviews != null && subviews.Length > 0 && subviews[0] is NSButton expander)
-					expander.State = NSCellStateValue.On;
-			} else if (facade.Target is ObjectPropertyViewModel ovm) {
+			}
+			else if (facade.Target is ObjectPropertyViewModel ovm) {
 				NSView view = outline.GetView (0, row, makeIfNecessary: false);
 				SetRowValueBackground (view, valueBackground: true);
 			}
@@ -157,17 +134,12 @@ namespace Xamarin.PropertyEditing.Mac
 
 		public override void ItemDidCollapse (NSNotification notification)
 		{
+			if (this.isUpdatingExpansions)
+				return;
+
 			NSObjectFacade facade = notification.UserInfo.Values[0] as NSObjectFacade;
 			var outline = (NSOutlineView)notification.Object;
 			nint row = outline.RowForItem (facade);
-
-			if (this.isUpdatingExpansions) {
-				NSView view = outline.GetView (0, row, makeIfNecessary: true);
-				if (view.Subviews[0] is NSButton expander)
-					expander.State = NSCellStateValue.Off;
-
-				return;
-			}
 
 			if (facade.Target is PanelGroupViewModel group)
 				this.dataSource.DataContext.SetIsExpanded (group.Category, isExpanded: false);


### PR DESCRIPTION
Fix so that when a category is expanded by default the UI shows the proper icon (the expanded icon, not collapsed).

There are two main changes here:
1. Remove the code added in https://github.com/xamarin/Xamarin.PropertyEditing/commit/96561f19bf1c81e24c852e0a88ef46bd72e05e38 to support custom disclosures for Catalina. That's no longer required in newer versions of macOS. Now we just let AppKit handle setting the right disclosure icon.
2. Add call to UpdateExpansions in OnPropertiesChanged, so that the default expansion state is correct when the property editor context changes, ensuring that categories are autoexpanded when they are supposed to be.

Fixes AB#1559942