### PR TITLE
Allow other NuGet feeds when building

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
-		<clear />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
 	</packageSources>
 </configuration>


### PR DESCRIPTION
When using the latest internal .NET SDK the build will fail since Xamarin.PropertyEditing cannot resolve the latest packages since all internal package sources are cleared. Resulting in a build failure:

    error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 6.0.14)