### PR TITLE
Update AzDO NuGet feed, as required for compliance

### DIFF
--- a/.build/automation/stages/validate.yml
+++ b/.build/automation/stages/validate.yml
@@ -50,6 +50,8 @@ stages:
       - job: 'MacOS'
         pool:
           vmImage: 'macos-12'
+        # Disable building on Mac as the main branch is now only used on Windows
+        condition: false
 
         steps:
           - checkout: self

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<config>
-		<add key="repositorypath" value="packages" />
-	</config>
-	<packageSources>
-		<!-- Don't use any sources set by the system-->
-		<clear />
-		<!-- https://devdiv.visualstudio.com/DevDiv/_artifacts/feed/Xamarin.UITooling -->
-		<add key="Xamarin.UITooling" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/Xamarin.UITooling/nuget/v3/index.json" />
-	</packageSources>
+  <packageSources>
+    <clear />
+    <!-- ensure only the sources defined below are used -->
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <disabledPackageSources />
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+	<config>
+		<add key="repositorypath" value="packages" />
+	</config>
 	<packageSources>
-		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+		<!-- Don't use any sources set by the system-->
+		<clear />
+		<!-- https://devdiv.visualstudio.com/DevDiv/_artifacts/feed/Xamarin.UITooling -->
+		<add key="Xamarin.UITooling" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/Xamarin.UITooling/nuget/v3/index.json" />
 	</packageSources>
 </configuration>


### PR DESCRIPTION
For compliance we can't use the default public NuGet feed.
Instead, use the same feeds (some of them) that are used for xamarin-android (https://github.com/xamarin/xamarin-android/blob/main/NuGet.config), another public repo.

Also disable building for Mac, since it's no longer needed.