### PR TITLE
Localization Handoff: Use keyvault-backed nuget feed access PAT

### DIFF
--- a/.build/automation/stages/localization-handback.yml
+++ b/.build/automation/stages/localization-handback.yml
@@ -31,7 +31,7 @@ stages:
               locProj: '.config/LocProject.json'
               outDir: '$(Build.ArtifactStagingDirectory)'
               packageSourceAuth: patAuth
-              patVariable: "$(OneLocBuildPAT)"
+              patVariable: "$(OneLocBuild--PAT)"
               isCreatePrSelected: false
               repoType: gitHub
               prSourceBranchPrefix: $(LocBranchPrefix)

--- a/.build/automation/stages/localization-handoff.yml
+++ b/.build/automation/stages/localization-handoff.yml
@@ -19,7 +19,7 @@ stages:
               locProj: '.config/LocProject.json'
               outDir: '$(Build.ArtifactStagingDirectory)'
               packageSourceAuth: patAuth
-              patVariable: "$(OneLocBuildPAT)"
+              patVariable: "$(OneLocBuild--PAT)"
 
           - task: PublishBuildArtifacts@1
             inputs:

--- a/.build/automation/variables.yml
+++ b/.build/automation/variables.yml
@@ -1,5 +1,6 @@
 variables:
 - group: xamops-azdev-secrets
+- group: Xamarin-Secrets
 
 - name: DefaultBuildConfiguration
   value: Release


### PR DESCRIPTION
Use the `OneLocBuild--PAT` provided by the `Xamarin-Secrets` variable group instead of the `OneLocBuildPAT` variable defined on the build definition. This will make PAT rotations more reliable going forward