### PR TITLE
GITHUB_TOKEN read-only change: Include permissions block

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@gitbot backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
-    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:

--- a/.github/workflows/localization-pr.yml
+++ b/.github/workflows/localization-pr.yml
@@ -2,13 +2,20 @@ name: Localization-CI
 
 on:
   push:
-    branches: 
+    branches:
       - loc
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/localization-pr.yml
+++ b/.github/workflows/localization-pr.yml
@@ -9,7 +9,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:

--- a/.github/workflows/rebase-trigger.yml
+++ b/.github/workflows/rebase-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   launchBackportBuild:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@gitbot rebase')
 
     steps:

--- a/.github/workflows/rebase-trigger.yml
+++ b/.github/workflows/rebase-trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   launchBackportBuild:
     runs-on: ubuntu-latest
-    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:


### PR DESCRIPTION
Provide permission block to allow GITHUB_TOKEN access to continue working after 2024-02-01
Guidance: https://docs.opensource.microsoft.com/github/apps/permission-changes/