### PR TITLE
Generate token for use by the OneLocBuild task

### DIFF
--- a/.build/automation/stages/localization-handback.yml
+++ b/.build/automation/stages/localization-handback.yml
@@ -3,8 +3,7 @@ stages:
   - stage: localization_handback
     displayName: Localization Handback
     dependsOn: []
-    # UNDONE: TEST:
-    # condition: and(succeeded(), eq(variables.isLocBranch, true))
+    condition: and(succeeded(), eq(variables.isLocBranch, true))
 
     jobs:
       - job : generate_resx
@@ -27,7 +26,7 @@ stages:
           # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/configuration-guides/pat-burndown-guidance#authentication-from-pipelines
           # Requires Azure client 2.x
           - task: AzureCLI@2
-            displayName: 'AzDO.OneLocBuildToken based on service connection'
+            displayName: 'Set AzDO.OneLocBuildToken'
             enabled: true
             inputs:
               azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DevOps service connection

--- a/.build/automation/stages/localization-handback.yml
+++ b/.build/automation/stages/localization-handback.yml
@@ -3,7 +3,8 @@ stages:
   - stage: localization_handback
     displayName: Localization Handback
     dependsOn: []
-    condition: and(succeeded(), eq(variables.isLocBranch, true))
+    # UNDONE: TEST:
+    # condition: and(succeeded(), eq(variables.isLocBranch, true))
 
     jobs:
       - job : generate_resx
@@ -45,7 +46,7 @@ stages:
           - task: cesve.one-loc-build.one-loc-build.OneLocBuild@2
             displayName: 'Localization Build'
             env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken) 
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:
               locProj: '.config/LocProject.json'
               outDir: '$(Build.ArtifactStagingDirectory)'
@@ -93,7 +94,7 @@ stages:
               $response = Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri "https://api.github.com/repos/Xamarin/Xamarin.PropertyEditing/pulls" -Body ($payload | ConvertTo-json)
               $newPr =  $response.Content | ConvertFrom-Json
 
-              Write-Host "Response is $newPr"      
+              Write-Host "Response is $newPr"
             displayName: Open Pull Request
 
           - task: PublishBuildArtifacts@1

--- a/.build/automation/stages/localization-handback.yml
+++ b/.build/automation/stages/localization-handback.yml
@@ -23,6 +23,25 @@ stages:
               Invoke-Git merge origin/loc --no-commit
             displayName: 'Merge loc Branch'
 
+          # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/configuration-guides/pat-burndown-guidance#authentication-from-pipelines
+          # Requires Azure client 2.x
+          - task: AzureCLI@2
+            displayName: 'AzDO.OneLocBuildToken based on service connection'
+            enabled: true
+            inputs:
+              azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DeDevOps service connection
+              scriptType: 'pscore'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                # if this fails, check out this bash script that includes diagnostics:
+                # https://gist.github.com/johnterickson/19f80a3e969e39f1000d118739176e62
+
+                # Note that the resource is specified to limit the token to Azure DevOps
+                $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+
+                Write-Host "Setting AzDO.OneLocBuildToken: ${token}"
+                Write-Host "##vso[task.setvariable variable=AzDO.OneLocBuildToken]${token}"
+
           - task: cesve.one-loc-build.one-loc-build.OneLocBuild@2
             displayName: 'Localization Build'
             env:
@@ -31,7 +50,7 @@ stages:
               locProj: '.config/LocProject.json'
               outDir: '$(Build.ArtifactStagingDirectory)'
               packageSourceAuth: patAuth
-              patVariable: "$(OneLocBuild--PAT)"
+              patVariable: "$(AzDO.OneLocBuildToken)"
               isCreatePrSelected: false
               repoType: gitHub
               prSourceBranchPrefix: $(LocBranchPrefix)

--- a/.build/automation/stages/localization-handback.yml
+++ b/.build/automation/stages/localization-handback.yml
@@ -29,7 +29,7 @@ stages:
             displayName: 'AzDO.OneLocBuildToken based on service connection'
             enabled: true
             inputs:
-              azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DeDevOps service connection
+              azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DevOps service connection
               scriptType: 'pscore'
               scriptLocation: 'inlineScript'
               inlineScript: |

--- a/.build/automation/stages/localization-handoff.yml
+++ b/.build/automation/stages/localization-handoff.yml
@@ -10,6 +10,24 @@ stages:
         displayName: 'Process outgoing strings'
         pool:  $(HostedWinVS2019)
         steps:
+          # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/configuration-guides/pat-burndown-guidance#authentication-from-pipelines
+          # Requires Azure client 2.x
+          - task: AzureCLI@2
+            displayName: 'AzDO.OneLocBuildToken based on service connection'
+            enabled: true
+            inputs:
+              azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DeDevOps service connection
+              scriptType: 'pscore'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                # if this fails, check out this bash script that includes diagnostics:
+                # https://gist.github.com/johnterickson/19f80a3e969e39f1000d118739176e62
+
+                # Note that the resource is specified to limit the token to Azure DevOps
+                $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+
+                Write-Host "Setting AzDO.OneLocBuildToken: ${token}"
+                Write-Host "##vso[task.setvariable variable=AzDO.OneLocBuildToken]${token}"
 
           - task: cesve.one-loc-build.one-loc-build.OneLocBuild@2
             displayName: 'Localization Build'
@@ -19,7 +37,7 @@ stages:
               locProj: '.config/LocProject.json'
               outDir: '$(Build.ArtifactStagingDirectory)'
               packageSourceAuth: patAuth
-              patVariable: "$(OneLocBuild--PAT)"
+              patVariable: "$(AzDO.OneLocBuildToken)"
 
           - task: PublishBuildArtifacts@1
             inputs:

--- a/.build/automation/stages/localization-handoff.yml
+++ b/.build/automation/stages/localization-handoff.yml
@@ -13,7 +13,7 @@ stages:
           # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/configuration-guides/pat-burndown-guidance#authentication-from-pipelines
           # Requires Azure client 2.x
           - task: AzureCLI@2
-            displayName: 'AzDO.OneLocBuildToken based on service connection'
+            displayName: 'Set AzDO.OneLocBuildToken'
             enabled: true
             inputs:
               azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DevOps service connection

--- a/.build/automation/stages/localization-handoff.yml
+++ b/.build/automation/stages/localization-handoff.yml
@@ -16,7 +16,7 @@ stages:
             displayName: 'AzDO.OneLocBuildToken based on service connection'
             enabled: true
             inputs:
-              azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DeDevOps service connection
+              azureSubscription: 'VSEng-AzureDevOps-ceapex-OneLocBuild'   # Azure DevOps service connection
               scriptType: 'pscore'
               scriptLocation: 'inlineScript'
               inlineScript: |

--- a/.build/automation/variables.yml
+++ b/.build/automation/variables.yml
@@ -6,7 +6,7 @@ variables:
   value: Release
 
 - name: GitHub.Token
-  value: $(github-pat)
+  value: $(github-pat)    # Defined in xamops-azdev-secrets
 - name: isMainBranch
   value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 - name: isLocBranch

--- a/.build/automation/variables.yml
+++ b/.build/automation/variables.yml
@@ -6,7 +6,7 @@ variables:
   value: Release
 
 - name: GitHub.Token
-  value: $(github-pat)    # Defined in xamops-azdev-secrets
+  value: $(github--pat--vs-mobiletools-engineering-service2)    # Defined in Xamarin-Secrets
 - name: isMainBranch
   value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 - name: isLocBranch

--- a/.build/automation/variables.yml
+++ b/.build/automation/variables.yml
@@ -5,6 +5,8 @@ variables:
 - name: DefaultBuildConfiguration
   value: Release
 
+- name: GitHub.Token
+  value: $(github-pat)
 - name: isMainBranch
   value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 - name: isLocBranch


### PR DESCRIPTION
Related work item: VS #[2053237](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2053237)

Obtain a OneLocBuild feed access token via the `VSEng-AzureDevOps-ceapex-OneLocBuild` service connection

Removes the dependency on the `OneLocBuild--PAT` static token

GitHub.Token did not seem to be defined and so added it to variables