### PR TITLE
localization-handoff: Avoid showing token

### DIFF
--- a/.build/automation/stages/localization-handback.yml
+++ b/.build/automation/stages/localization-handback.yml
@@ -39,6 +39,7 @@ stages:
                 # Note that the resource is specified to limit the token to Azure DevOps
                 $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
 
+                Write-Host "Setting AzDO.OneLocBuildToken"
                 Write-Host "##vso[task.setvariable variable=AzDO.OneLocBuildToken;issecret=true]${token}"
 
           - task: cesve.one-loc-build.one-loc-build.OneLocBuild@2

--- a/.build/automation/stages/localization-handoff.yml
+++ b/.build/automation/stages/localization-handoff.yml
@@ -26,8 +26,8 @@ stages:
                 # Note that the resource is specified to limit the token to Azure DevOps
                 $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
 
-                Write-Host "Setting AzDO.OneLocBuildToken: ${token}"
-                Write-Host "##vso[task.setvariable variable=AzDO.OneLocBuildToken]${token}"
+                Write-Host "Setting AzDO.OneLocBuildToken"
+                Write-Host "##vso[task.setvariable variable=AzDO.OneLocBuildToken;issecret=true]${token}"
 
           - task: cesve.one-loc-build.one-loc-build.OneLocBuild@2
             displayName: 'Localization Build'


### PR DESCRIPTION
Follow up to the same fix that was applied to the `localization-handback` stage: https://github.com/xamarin/Xamarin.PropertyEditing/pull/841

Avoid showing the managed identity derived bearer token in the log output